### PR TITLE
Support carriage returns in install.sql files

### DIFF
--- a/default_www/backend/core/installer/install.php
+++ b/default_www/backend/core/installer/install.php
@@ -198,7 +198,7 @@ class ModuleInstaller
 			 * We know this isn't the best solution, but we couldn't find a beter way.
 			 * @later: find a beter way to handle multiple-line queries
 			 */
-			$queries = explode(";\n", $content);
+			$queries = preg_split("/;(\r)?\n/", $content);
 
 			// loop queries and execute them
 			foreach($queries as $query) $this->getDB()->execute($query);


### PR DESCRIPTION
Added support for ;\r\n in install.sql files. Without this fix the installer executes a multiquery and PDO will throw exceptions.

Note: this is only needed when the install file is saved with a windows line delimiter.
