### PR TITLE
remove tiny fields added to the body by naughty tinyMCE

### DIFF
--- a/default_www/backend/modules/mailmotor/js/mailmotor.js
+++ b/default_www/backend/modules/mailmotor/js/mailmotor.js
@@ -293,6 +293,9 @@ jsBackend.mailmotor.step3 =
 				var subject = $('#subject').val();
 				var plainText = ($('#contentPlain').length > 0) ? $('#contentPlain').val() : '';
 
+				// remove tiny fields added to the body by naughty tinyMCE
+				body.find('div.mceListBoxMenu').remove();
+				
 				// set iframe variables
 				var textareaValue = encodeURIComponent(iframe[0].contentWindow.getTinyMCEContent());
 				var bodyHTML = encodeURIComponent(body.html());


### PR DESCRIPTION
When using layout in step 3 some tiny stuff is added to the template. This results in invalid HTML so the mailing can't be sent via CM. Very strange, but managed to fix it by removing the added tiny stuff.
