### PR TITLE
Altered |getnavigation

### DIFF
--- a/default_www/frontend/core/engine/navigation.php
+++ b/default_www/frontend/core/engine/navigation.php
@@ -258,9 +258,10 @@ class FrontendNavigation extends FrontendBaseObject
 	 * @param	int[optional] $parentId			The parentID to start of.
 	 * @param	int[optional] $depth			The maximum depth to parse.
 	 * @param	array[optional] $excludeIds		PageIDs to be excluded.
+	 * @param	bool[optional] $expandAll		Expand all navigation children.
 	 * @param	int[optional] $depthCounter		A counter that will hold the current depth.
 	 */
-	public static function getNavigationHTML($type = 'page', $parentId = 0, $depth = null, $excludeIds = array(), $depthCounter = 1)
+	public static function getNavigationHTML($type = 'page', $parentId = 0, $depth = null, $excludeIds = array(), $expandAll = false, $depthCounter = 1)
 	{
 		// get navigation
 		$navigation = self::getNavigation();
@@ -320,6 +321,10 @@ class FrontendNavigation extends FrontendBaseObject
 
 				// has children and is selected and is desired?
 				if(isset($navigation[$type][$page['page_id']]) && $navigation[$type][$parentId][$id]['selected'] == true && ($depth == null || $depthCounter + 1 <= $depth)) $navigation[$type][$parentId][$id]['children'] = self::getNavigationHTML($type, $page['page_id'], $depth, $excludeIds, $depthCounter + 1);
+				else $navigation[$type][$parentId][$id]['children'] = false;
+
+				// has children is not selected but forces expanding all
+				if(isset($navigation[$type][$page['page_id']]) && $expandAll == true && ($depth == null || $depthCounter + 1 <= $depth)) $navigation[$type][$parentId][$id]['children'] = self::getNavigationHTML($type, $page['page_id'], $depth, $excludeIds, $depthCounter + 1);
 				else $navigation[$type][$parentId][$id]['children'] = false;
 
 				// add parent id

--- a/default_www/frontend/core/engine/template.php
+++ b/default_www/frontend/core/engine/template.php
@@ -467,22 +467,23 @@ class FrontendTemplateModifiers
 
 	/**
 	 * Get the navigation html
-	 * 	syntax: {$var|getnavigation[:<type>][:<parentId>][:<depth>][:<excludeIds-splitted-by-dash>]}
+	 * 	syntax: {$var|getnavigation[:<type>][:<parentId>][:<depth>][:<excludeIds-splitted-by-dash>][:<expandAll>]}
 	 *
 	 * @return	string
 	 * @param	string[optional] $var			The variable.
 	 * @param	string[optional] $type			The type of navigation, possible values are: page, footer.
 	 * @param	int[optional] $parentId			The parent wherefore the navigation should be build.
 	 * @param	int[optional] $depth			The maximum depth that has to be build.
+	 * @param	bool[optional] $expandAll		Expand all navigation children.
 	 * @param	string[optional] $excludeIds	Which pageIds should be excluded (split them by -).
 	 */
-	public static function getNavigation($var = null, $type = 'page', $parentId = 0, $depth = null, $excludeIds = null)
+	public static function getNavigation($var = null, $type = 'page', $parentId = 0, $depth = null, $expandAll = false, $excludeIds = null)
 	{
 		// build excludeIds
 		if($excludeIds !== null) $excludeIds = (array) explode('-', $excludeIds);
 
 		// get HTML
-		$return = (string) FrontendNavigation::getNavigationHtml($type, $parentId, $depth, $excludeIds);
+		$return = (string) FrontendNavigation::getNavigationHtml($type, $parentId, $depth, $excludeIds, $expandAll);
 
 		// return the var
 		if($return != '') return $return;


### PR DESCRIPTION
Now able to force expanding all children

{$var|getnavigation:type:parentId:depth:excludeIds-splitted-by-dash:expandAll}

$expandAll expects bool, standard value is false
