### PR TITLE
Changed the hardcoded 'nl' value as default for radiobuttons to the working language.

### DIFF
--- a/default_www/backend/modules/mailmotor/actions/add.php
+++ b/default_www/backend/modules/mailmotor/actions/add.php
@@ -73,7 +73,7 @@ class BackendMailmotorAdd extends BackendBaseActionAdd
 		$this->frm->addMultiCheckbox('groups', $groups, ((count($groups) == 1 && isset($groups[0])) ? $groups[0]['value'] : false));
 
 		// languages
-		$this->frm->addRadiobutton('languages', $languages, 'nl');
+		$this->frm->addRadiobutton('languages', $languages, BL::getWorkingLanguage());
 	}
 
 


### PR DESCRIPTION
An error occured when you added a mailing in a project without the language 'nl' as an active language. This is fixed by this commit.
