### PR TITLE
Remove unnecessary anonymous functions

### DIFF
--- a/default_www/backend/core/js/backend.js
+++ b/default_www/backend/core/js/backend.js
@@ -1529,4 +1529,4 @@ jsBackend.tableSequenceByDragAndDrop =
 }
 
 
-$(document).ready(function() { jsBackend.init(); });
+$(document).ready(jsBackend.init);

--- a/default_www/backend/modules/analytics/js/analytics.js
+++ b/default_www/backend/modules/analytics/js/analytics.js
@@ -489,4 +489,4 @@ jsBackend.analytics.resize =
 }
 
 
-$(document).ready(function() { jsBackend.analytics.init(); });
+$(document).ready(jsBackend.analytics.init);

--- a/default_www/backend/modules/analytics/js/dashboard.js
+++ b/default_www/backend/modules/analytics/js/dashboard.js
@@ -58,4 +58,4 @@ jsBackend.analyticsDashboard =
 }
 
 
-$(document).ready(function() { jsBackend.analyticsDashboard.init(); });
+$(document).ready(jsBackend.analyticsDashboard.init);

--- a/default_www/backend/modules/blog/js/blog.js
+++ b/default_www/backend/modules/blog/js/blog.js
@@ -63,4 +63,4 @@ jsBackend.blog.controls =
 }
 
 
-$(document).ready(function() { jsBackend.blog.init(); });
+$(document).ready(jsBackend.blog.init);

--- a/default_www/backend/modules/dashboard/js/dashboard.js
+++ b/default_www/backend/modules/dashboard/js/dashboard.js
@@ -172,4 +172,4 @@ jsBackend.dashboard =
 }
 
 
-$(document).ready(function() { jsBackend.dashboard.init(); });
+$(document).ready(jsBackend.dashboard.init);

--- a/default_www/backend/modules/faq/js/index.js
+++ b/default_www/backend/modules/faq/js/index.js
@@ -129,4 +129,4 @@ jsBackend.faq =
 }
 
 
-$(document).ready(function() { jsBackend.faq.init(); });
+$(document).ready(jsBackend.faq.init);

--- a/default_www/backend/modules/form_builder/js/form_builder.js
+++ b/default_www/backend/modules/form_builder/js/form_builder.js
@@ -1197,4 +1197,4 @@ jsBackend.formBuilder.fields =
 	eoo: true
 }
 
-$(document).ready(function() { jsBackend.formBuilder.init(); });
+$(document).ready(jsBackend.formBuilder.init);

--- a/default_www/backend/modules/locale/js/locale.js
+++ b/default_www/backend/modules/locale/js/locale.js
@@ -52,4 +52,4 @@ jsBackend.locale.controls =
 }
 
 
-$(document).ready(function() { jsBackend.locale.init(); });
+$(document).ready(jsBackend.locale.init);

--- a/default_www/backend/modules/mailmotor/js/mailmotor.js
+++ b/default_www/backend/modules/mailmotor/js/mailmotor.js
@@ -543,4 +543,4 @@ jsBackend.mailmotor.templateSelection =
 }
 
 
-$(document).ready(function() { jsBackend.mailmotor.init(); });
+$(document).ready(jsBackend.mailmotor.init);

--- a/default_www/backend/modules/pages/js/pages.js
+++ b/default_www/backend/modules/pages/js/pages.js
@@ -711,4 +711,4 @@ jsBackend.pages.tree =
 }
 
 
-$(document).ready(function() { jsBackend.pages.init(); });
+$(document).ready(jsBackend.pages.init);

--- a/default_www/backend/modules/search/js/search.js
+++ b/default_www/backend/modules/search/js/search.js
@@ -36,4 +36,4 @@ jsBackend.search =
 }
 
 
-$(document).ready(function() { jsBackend.search.init(); });
+$(document).ready(jsBackend.search.init);

--- a/default_www/backend/modules/settings/js/index.js
+++ b/default_www/backend/modules/settings/js/index.js
@@ -27,4 +27,4 @@ jsBackend.settings =
 }
 
 
-$(document).ready(function() { jsBackend.settings.init(); });
+$(document).ready(jsBackend.settings.init);

--- a/default_www/backend/modules/tags/js/tags.js
+++ b/default_www/backend/modules/tags/js/tags.js
@@ -27,4 +27,4 @@ jsBackend.tags =
 }
 
 
-$(document).ready(function() { jsBackend.tags.init(); });
+$(document).ready(jsBackend.tags.init);

--- a/default_www/backend/modules/users/js/users.js
+++ b/default_www/backend/modules/users/js/users.js
@@ -65,4 +65,4 @@ jsBackend.users.controls =
 }
 
 
-$(document).ready(function() { jsBackend.users.init(); });
+$(document).ready(jsBackend.users.init);

--- a/default_www/frontend/core/js/frontend.js
+++ b/default_www/frontend/core/js/frontend.js
@@ -384,4 +384,4 @@ jsFrontend.search =
 }
 
 
-$(document).ready(function() { jsFrontend.init(); });
+$(document).ready(jsFrontend.init);

--- a/default_www/install/js/backend.js
+++ b/default_www/install/js/backend.js
@@ -298,4 +298,4 @@ jsBackend.layout =
 }
 
 
-$(document).ready(function() { jsBackend.init(); });
+$(document).ready(jsBackend.init);


### PR DESCRIPTION
Because the following two cases are equivalent:

$(document).ready(function() { jsBackend.analyticsDashboard.init(); });
$(document).ready(jsBackend.analyticsDashboard.init);
