### PR TITLE
CodeSniffer: do not expect @return for constructors

### DIFF
--- a/tools/codesniffer/Fork/Sniffs/Styleguide/FunctionsSniff.php
+++ b/tools/codesniffer/Fork/Sniffs/Styleguide/FunctionsSniff.php
@@ -89,7 +89,7 @@ class Fork_Sniffs_Styleguide_FunctionsSniff implements PHP_CodeSniffer_Sniff
 
 				if(trim(substr($tokens[$i]['content'], 0, 10)) == '* @param')
 				{
-					if(!$returnFirst) $phpcsFile->addError('We expect "@return" before "@param".', $i);
+					if(!$returnFirst && $phpcsFile->getDeclarationName($stackPtr) !== '__construct') $phpcsFile->addError('We expect "@return" before "@param".', $i);
 
 					// find part
 					$content = trim(substr($tokens[$i]['content'], strpos($tokens[$i]['content'], "\t", 2)));


### PR DESCRIPTION
I had a constructor with the parameters in its docblock, and CodeSniffer complained because I did not specify @return:

<pre>33 | ERROR | We expect "@return" before "@param".
34 | ERROR | We expect "@return" before "@param".</pre>


Of course, constructors don't have return types as such, so adding them seems a bit awkward.

<pre>class Foo {
  /**
   * @return Foo
   */
  public function __construct() { }
}

class Bar extends Foo {
}</pre>


`@return Foo` would not be detailed enough for `Bar::__construct`, so leave it out entirely. When you do `new X`, you always get an `X` instance.
