### PR TITLE
Tags: inline-edit should also check upon existence

### DIFF
--- a/default_www/backend/modules/tags/ajax/edit.php
+++ b/default_www/backend/modules/tags/ajax/edit.php
@@ -29,6 +29,9 @@ class BackendTagsAjaxEdit extends BackendBaseAJAXAction
 		if($id === 0) $this->output(self::BAD_REQUEST, null, 'no id provided');
 		if($tag === '') $this->output(self::BAD_REQUEST, null, BL::err('NameIsRequired'));
 
+		// check if tag exists
+		if(BackendTagsModel::existsTag($tag)) $this->output(self::BAD_REQUEST, null, BL::err('TagAlreadyExists'));
+
 		// build array
 		$item['id'] = $id;
 		$item['tag'] = SpoonFilter::htmlspecialchars($tag);

--- a/default_www/backend/modules/tags/engine/model.php
+++ b/default_www/backend/modules/tags/engine/model.php
@@ -60,6 +60,21 @@ class BackendTagsModel
 
 
 	/**
+	 * Check if a tag exists
+	 *
+	 * @return	bool
+	 * @param	string $tag		The tag to check for existence.
+	 */
+	public static function existsTag($tag)
+	{
+		return (bool) BackendModel::getDB()->getVar('SELECT i.tag
+		                                             FROM tags AS i
+		                                             WHERE i.tag = ?',
+		                                             array((string) $tag));
+	}
+
+
+	/**
 	 * Get tag record.
 	 *
 	 * @return	array

--- a/default_www/backend/modules/tags/installer/data/locale.xml
+++ b/default_www/backend/modules/tags/installer/data/locale.xml
@@ -60,6 +60,10 @@
         <translation language="nl"><![CDATA[Er waren geen tags geselecteerd.]]></translation>
         <translation language="en"><![CDATA[No tags were selected.]]></translation>
       </item>
+      <item type="error" name="TagAlreadyExists">
+        <translation language="nl"><![CDATA[Deze tag bestaat al.]]></translation>
+        <translation language="en"><![CDATA[This tags already exists.]]></translation>
+      </item>
     </tags>
   </backend>
 </locale>


### PR DESCRIPTION
Giving tags the same name was possible through inline-edit.
