### PR TITLE
Search autosuggest show 'null' as text with items that don't have text set in the search index.

### DIFF
--- a/default_www/frontend/modules/search/ajax/autosuggest.php
+++ b/default_www/frontend/modules/search/ajax/autosuggest.php
@@ -218,7 +218,7 @@ class FrontendSearchAjaxAutosuggest extends FrontendBaseAJAXAction
 			$item['full_url'] .= $glue . http_build_query($utm, '', '&');
 
 			// format description
-			$item['text'] = mb_strlen($item['text']) > $this->length ? substr(strip_tags($item['text']), 0, $this->length) . '…' : $item['text'];
+			$item['text'] = !empty($item['text']) ? (mb_strlen($item['text']) > $this->length ? substr(strip_tags($item['text']), 0, $this->length) . '…' : $item['text']) : '';
 		}
 
 		// output


### PR DESCRIPTION
This commit fixes that by first checking if a text is given for the item.
