### PR TITLE
Bugfix: Multiple contentblocks on the same page

### DIFF
--- a/default_www/frontend/modules/content_blocks/widgets/detail.php
+++ b/default_www/frontend/modules/content_blocks/widgets/detail.php
@@ -39,6 +39,21 @@ class FrontendContentBlocksWidgetDetail extends FrontendBaseWidget
 
 		// parse
 		$this->parse();
+
+		// check if the given template exists
+		try
+		{
+			$template = FrontendTheme::getPath(FRONTEND_MODULES_PATH . '/content_blocks/layout/widgets/' . $this->item['template']);
+		}
+
+		// template does not exist; assume default.tpl
+		catch(Exception $e)
+		{
+			$template = FRONTEND_MODULES_PATH . '/content_blocks/layout/widgets/default.tpl';
+		}
+
+		// display the widget
+		return $this->tpl->getContent($template);
 	}
 
 
@@ -65,17 +80,8 @@ class FrontendContentBlocksWidgetDetail extends FrontendBaseWidget
 		// redefine (and trick codesniffer)
 		$path = ($path !== null) ? (string) $path : null;
 
-		// check if the given template exists
-		try
-		{
-			parent::loadTemplate(FrontendTheme::getPath(FRONTEND_MODULES_PATH . '/content_blocks/layout/widgets/' . $this->item['template']));
-		}
-
-		// template does not exist; assume default.tpl
-		catch(FrontendException $e)
-		{
-			parent::loadTemplate(FRONTEND_MODULES_PATH . '/content_blocks/layout/widgets/default.tpl');
-		}
+		// overwrite the template with an empty one
+		$this->tpl = new FrontendTemplate(false);
 	}
 
 


### PR DESCRIPTION
Fixed issue where multiple contentblocks on the same page would always parse the last one due to them being pushed in the same template.
