### PR TITLE
Redirect pages can have children

### DIFF
--- a/default_www/backend/modules/pages/js/pages.js
+++ b/default_www/backend/modules/pages/js/pages.js
@@ -598,7 +598,7 @@ jsBackend.pages.tree =
 				'pages': { icon: { position: false } },
 				'error': { draggable: false, max_children: 0, icon: { position: '0 -160px' } },
 				'sitemap': { max_children: 0, icon: { position: '0 -176px' } },
-				'redirect': { max_children: 0, icon: { position: '0 -264px' } }
+				'redirect': { icon: { position: '0 -264px' } }
 			},
 			plugins:
 			{


### PR DESCRIPTION
Internal redirect pages must be dealt with as normal parent pages. Therefor you must be able to move children into a redirect page.
Downside: also the external redirect pages will be able to have children. Which is a bit unlogical.
