### PR TITLE
JS Syntax error on frontend fix.

### DIFF
--- a/default_www/frontend/core/js/frontend.js
+++ b/default_www/frontend/core/js/frontend.js
@@ -49,7 +49,7 @@ var jsFrontend =
 
 	// end
 	eoo: true
-},
+}
 
 
 /**

--- a/default_www/frontend/core/js/utils.js
+++ b/default_www/frontend/core/js/utils.js
@@ -8,7 +8,7 @@ var utils =
 	// datamembers
 	debug: false,
 	eoo: true
-},
+}
 
 
 /**


### PR DESCRIPTION
Deleted a comma that (i think) was not necessary. Now there are no syntax errors anymore.
