### PR TITLE
Fix the hook when activating a profile.

### DIFF
--- a/default_www/frontend/modules/profiles/actions/activate.php
+++ b/default_www/frontend/modules/profiles/actions/activate.php
@@ -44,7 +44,7 @@ class FrontendProfilesActivate extends FrontendBaseBlock
 				FrontendProfilesAuthentication::login($profileId);
 
 				// trigger event
-				FrontendModel::triggerEvent('profiles', 'after_activate', array('id' => $this->profile->getId()));
+				FrontendModel::triggerEvent('profiles', 'after_activate', array('id' => $profileId));
 
 				// show success message
 				$this->tpl->assign('activationSuccess', true);


### PR DESCRIPTION
The hook used an undefined variable for the profileId.
