### PR TITLE
analytics traffic_sources: fix long referrers with wordwrap

### DIFF
--- a/default_www/backend/modules/analytics/ajax/refresh_traffic_sources.php
+++ b/default_www/backend/modules/analytics/ajax/refresh_traffic_sources.php
@@ -126,10 +126,10 @@ class BackendAnalyticsAjaxRefreshTrafficSources extends BackendBaseAJAXAction
 			$dataGrid->setPaging();
 
 			// hide columns
-			$dataGrid->setColumnsHidden('id', 'date');
+			$datagrid->setColumnsHidden('id', 'date', 'url');
 
 			// set url
-			$dataGrid->setColumnURL('referrer', 'http://[referrer]');
+			$datagrid->setColumnURL('referrer', '[url]');
 		}
 
 		// parse the datagrid

--- a/default_www/backend/modules/analytics/engine/model.php
+++ b/default_www/backend/modules/analytics/engine/model.php
@@ -657,9 +657,22 @@ class BackendAnalyticsModel
 	 */
 	public static function getRecentReferrers()
 	{
-		return (array) BackendModel::getDB()->getRecords('SELECT *
+		// get items
+		$items = (array) BackendModel::getDB()->getRecords('SELECT *
 															FROM analytics_referrers
 															ORDER BY entrances DESC, id');
+
+		// loop items
+		foreach($items as $key => $item)
+		{
+			// assign URL
+			$items[$key]['url'] = 'http://' . $item['referrer'];
+
+			// wordwrap referrer
+			$items[$key]['referrer'] = wordwrap($item['referrer'], 50, ' ', true);
+		}
+
+		return $items;
 	}
 
 

--- a/default_www/backend/modules/analytics/widgets/traffic_sources.php
+++ b/default_www/backend/modules/analytics/widgets/traffic_sources.php
@@ -149,10 +149,10 @@ class BackendAnalyticsWidgetTrafficSources extends BackendBaseWidget
 			$dataGrid->setPaging(false);
 
 			// hide columns
-			$dataGrid->setColumnsHidden('id', 'date');
+			$datagrid->setColumnsHidden('id', 'date', 'url');
 
 			// set url
-			$dataGrid->setColumnURL('referrer', 'http://[referrer]');
+			$datagrid->setColumnURL('referrer', '[url]');
 
 			// parse the datagrid
 			$this->tpl->assign('dgAnalyticsReferrers', $dataGrid->getContent());


### PR DESCRIPTION
Long referrers made "hits" disappear. Fixed with wordwrap.
