### PR TITLE
Bugfixes

### DIFF
--- a/default_www/frontend/modules/blog/engine/model.php
+++ b/default_www/frontend/modules/blog/engine/model.php
@@ -571,7 +571,7 @@ class FrontendBlogModel implements FrontendTagsInterface
 		$limit = (int) $limit;
 
 		// get the related IDs
-		$relatedIDs = (array) FrontendTagsModel::getRelatedIdsByTags($id, 'blog', 'blog');
+		$relatedIDs = (array) FrontendTagsModel::getRelatedItemsByTags($id, 'blog', 'blog');
 
 		// no items
 		if(empty($relatedIDs)) return array();


### PR DESCRIPTION
The Blog model called an unexisting Tag function 'getRelatedIdsByTags'. This should be 'getRelatedItemsByTags'.
