### PR TITLE
Aded a validation to see if the old template id has any active/draft page

### DIFF
--- a/default_www/backend/modules/pages/engine/model.php
+++ b/default_www/backend/modules/pages/engine/model.php
@@ -2081,6 +2081,9 @@ class BackendPagesModel
 													WHERE template_id = ? AND status IN (?, ?)',
 													array($oldTemplateId, 'active', 'draft'));
 
+		// there is no active/draft page with the old template id
+		if(empty($pages)) return;
+
 		// loop pages
 		foreach($pages as $page)
 		{


### PR DESCRIPTION
Previously, you would've gotten something like "Warning: Invalid argument supplied for foreach() in /default_www/backend/modules/pages/engine/model.php on line 2085".
