### PR TITLE
This will allow developers to easily ignore  pages in the menus

### DIFF
--- a/frontend/core/engine/navigation.php
+++ b/frontend/core/engine/navigation.php
@@ -255,6 +255,9 @@ class FrontendNavigation extends FrontendBaseObject
 		// get navigation
 		$navigation = self::getNavigation();
 
+		// merge the exclude ids with the previously set exclude ids
+		$excludeIds = array_merge((array) $excludeIds, self::$excludedPageIds);
+
 		// meta-navigation is requested but meta isn't enabled
 		if($type == 'meta' && !FrontendModel::getModuleSetting('pages', 'meta_navigation', true)) return '';
 


### PR DESCRIPTION
Earlier, developers had to go and change the template file. Now it is done by

```
FrontendNavigation::setIgnoredPages(429);
FrontendNavigation::setIgnoredPages(array(429, 428));
```
