### PR TITLE
Added method to return a stack of languages usable by SpoonForm::addRadioButton

### DIFF
--- a/backend/core/engine/language.php
+++ b/backend/core/engine/language.php
@@ -65,10 +65,10 @@ class BackendLanguage
 	}
 
 	/**
-	* Get all active languages in a format usable by SpoonForm's addRadioButton
-	*
-	* @return array
-	*/
+	 * Get all active languages in a format usable by SpoonForm's addRadioButton
+	 *
+	 * @return array
+	 */
 	public static function getCheckboxValues()
 	{
 		$languages = BL::getActiveLanguages();


### PR DESCRIPTION
The incoming update to mailmotor will use this method. It currently resides in BackendMailmotorModel, which is the wrong place for it.
