### PR TITLE
fixed bug: reference in a foreach was used later on again in a foreach

### DIFF
--- a/backend/modules/pages/actions/add.php
+++ b/backend/modules/pages/actions/add.php
@@ -320,10 +320,10 @@ class BackendPagesAdd extends BackendBaseActionAdd
 				$page['revision_id'] = BackendPagesModel::insert($page);
 
 				// loop blocks
-				foreach($this->blocksContent as $i => &$block)
+				foreach($this->blocksContent as $i => $block)
 				{
 					// add page revision id to blocks
-					$block['revision_id'] = $page['revision_id'];
+					$this->blocksContent[$i]['revision_id'] = $page['revision_id'];
 
 					// validate blocks, only save blocks for valid positions
 					if(!in_array($block['position'], $this->templates[$this->frm->getField('template_id')->getValue()]['data']['names'])) unset($this->blocksContent[$i]);

--- a/backend/modules/pages/actions/edit.php
+++ b/backend/modules/pages/actions/edit.php
@@ -460,10 +460,10 @@ class BackendPagesEdit extends BackendBaseActionEdit
 				$page['revision_id'] = BackendPagesModel::update($page);
 
 				// loop blocks
-				foreach($this->blocksContent as $i => &$block)
+				foreach($this->blocksContent as $i => $block)
 				{
 					// add page revision id to blocks
-					$block['revision_id'] = $page['revision_id'];
+					$this->blocksContent[$i]['revision_id'] = $page['revision_id'];
 
 					// validate blocks, only save blocks for valid positions
 					if(!in_array($block['position'], $this->templates[$this->frm->getField('template_id')->getValue()]['data']['names'])) unset($this->blocksContent[$i]);


### PR DESCRIPTION
a reference (&$block) was used in a foreach and wasn't unset at the end.
Later on the there was another foreach, with the same variable name ($block). This foreach wasn't actually working due to the reference.

This was causing that the search indexes weren't build correctly.
