### PR TITLE
Warning messages for the installer.

### DIFF
--- a/backend/core/installer/installer.php
+++ b/backend/core/installer/installer.php
@@ -46,6 +46,13 @@ class ModuleInstaller
 	private $variables = array();
 
 	/**
+	 * The warnings thrown during the install
+	 *
+	 * @var array
+	 */
+	private $warnings = array();
+
+	/**
 	 * @param SpoonDatabase $db The database-connection.
 	 * @param array $languages The selected frontend languages.
 	 * @param array $interfaceLanguages The selected backend languages.
@@ -84,6 +91,16 @@ class ModuleInstaller
 
 		// activate and update description
 		else $this->getDB()->update('modules', array('installed_on' => gmdate('Y-m-d H:i:s')), 'name = ?', $name);
+	}
+
+	/**
+	 * Adds a warning to the stack of warnings
+	 *
+	 * @param string $message The message that needs to be displayed.
+	 */
+	protected function addWarning($message)
+	{
+		$this->warnings[] = array('message' => $message);
 	}
 
 	/**
@@ -214,6 +231,16 @@ class ModuleInstaller
 	protected function getVariable($name)
 	{
 		return (!isset($this->variables[$name])) ? null : $this->variables[$name];
+	}
+
+	/**
+	 * Get all warnings
+	 *
+	 * @return array
+	 */
+	public function getWarnings()
+	{
+		return $this->warnings;
 	}
 
 	/**

--- a/backend/modules/extensions/actions/modules.php
+++ b/backend/modules/extensions/actions/modules.php
@@ -108,5 +108,8 @@ class BackendExtensionsModules extends BackendBaseActionIndex
 		// parse data grid
 		$this->tpl->assign('dataGridInstallableModules', (string) $this->dataGridInstallableModules->getContent());
 		$this->tpl->assign('dataGridInstalledModules', (string) $this->dataGridInstalledModules->getContent());
+
+		// parse installer warnings
+		$this->tpl->assign('warnings', (array) SpoonSession::get('installer_warnings'));
 	}
 }

--- a/backend/modules/extensions/engine/model.php
+++ b/backend/modules/extensions/engine/model.php
@@ -743,6 +743,10 @@ class BackendExtensionsModel
 		// execute installation
 		$installer->install();
 
+		// save the warnings in session for later use
+		$warnings = array('module' => $module, 'warnings' => $installer->getWarnings());
+		SpoonSession::set('installer_warnings', $warnings);
+
 		// clear the cache so locale (and so much more) gets rebuilt
 		self::clearCache();
 	}

--- a/backend/modules/extensions/layout/templates/modules.tpl
+++ b/backend/modules/extensions/layout/templates/modules.tpl
@@ -13,6 +13,22 @@
 	</div>
 </div>
 
+{option:warnings}
+	<div class="generalMessage infoMessage">
+		<p><strong>There are some warnings for following modules:</strong></p>
+		<ul>
+			<li>
+				<strong>{$warnings.module}</strong>
+				<ul>
+					{iteration:warnings.warnings}
+						<li>- {$warnings.warnings.message}</li>
+					{/iteration:warnings.warnings}
+				</ul>
+			</li>
+		</ul>
+	</div>
+{/option:warnings}
+
 {option:dataGridInstalledModules}
 <div class="dataGridHolder">
 	<div class="tableHeading">

--- a/install/engine/step_2.php
+++ b/install/engine/step_2.php
@@ -141,8 +141,8 @@ class InstallerStep2 extends InstallerStep
 		// check if the library-directory is writable
 		self::checkRequirement('fileSystemLibrary', defined('PATH_LIBRARY') && self::isWritable(PATH_LIBRARY), self::STATUS_ERROR);
 
-		// check if the library/external-directory is writable
-		// self::checkRequirement('fileSystemLibraryExternal', (defined('PATH_LIBRARY') && self::isWritable(PATH_LIBRARY . '/external')), self::STATUS_ERROR);
+		// check if the external-directory is writable
+		self::checkRequirement('fileSystemLibraryExternal', defined('PATH_LIBRARY') && self::isWritable(PATH_LIBRARY . '/external'), self::STATUS_ERROR);
 
 		// check if the installer-directory is writable
 		self::checkRequirement('fileSystemInstaller', defined('PATH_WWW') && self::isWritable(PATH_WWW . '/install/cache'), self::STATUS_ERROR);

--- a/install/engine/step_7.php
+++ b/install/engine/step_7.php
@@ -305,6 +305,9 @@ class InstallerStep7 extends InstallerStep
 	 */
 	private function installModules()
 	{
+		// init var
+		$warnings = array();
+
 		/**
 		 * First we need to install the core. All the linked modules, settings and sql tables are
 		 * being installed.
@@ -333,6 +336,10 @@ class InstallerStep7 extends InstallerStep
 
 		// install the core
 		$installer->install();
+
+		// add the warnings
+		$moduleWarnings = $installer->getWarnings();
+		if(!empty($moduleWarnings)) $warnings[] = array('module' => 'core', 'warnings' => $moduleWarnings);
 
 		// variables passed to module installers
 		$variables = array();
@@ -371,8 +378,15 @@ class InstallerStep7 extends InstallerStep
 
 				// install the module
 				$installer->install();
+
+				// add the warnings
+				$moduleWarnings = $installer->getWarnings();
+				if(!empty($moduleWarnings)) $warnings[] = array('module' => $module, 'warnings' => $moduleWarnings);
 			}
 		}
+
+		// parse the warnings
+		$this->tpl->assign('warnings', $warnings);
 	}
 
 	/**

--- a/install/layout/css/installer.css
+++ b/install/layout/css/installer.css
@@ -64,6 +64,24 @@ span.error {
 	border: 1px solid #FF9955;
 }
 
+.generalMessage {
+	font-weight: 700;
+	border: 1px solid #CCC;
+	margin: 10px 0 0;
+	padding: 12px;
+
+	/* @inc .rc */
+	-moz-border-radius: 4px;
+	-webkit-border-radius: 4px;
+	border-radius: 4px;
+}
+
+.infoMessage {
+	background-color: #FFA;
+	font-weight: normal;
+	color: #666;
+}
+
 /*
 	Step 3/4: settings
 */

--- a/install/layout/templates/step_7.tpl
+++ b/install/layout/templates/step_7.tpl
@@ -23,4 +23,22 @@
 	<a class="button" href="../private">Log in to Fork CMS</a>
 </div>
 
+{option:warnings}
+	<div class="generalMessage infoMessage">
+		<p><strong>There are some warnings for following modules:</strong></p>
+		{iteration:warnings}
+			<ul>
+				<li>
+					<strong>{$warnings.module}</strong>
+					<ul>
+						{iteration:warnings.warnings}
+							<li>- {$warnings.warnings.message}</li>
+						{/iteration:warnings.warnings}
+					</ul>
+				</li>
+			</ul>
+		{/iteration:warnings}
+	</div>
+{/option:warnings}
+
 {include:{$PATH_WWW}/install/layout/templates/foot.tpl}


### PR DESCRIPTION
You can now add warnings in the installer of your module. These warnings will be shown in the last step of the global installer of in the overview of installed modules after a module install has completed.
