### PR TITLE
Installer: get rid of "library/external" writable check

### DIFF
--- a/install/engine/step_2.php
+++ b/install/engine/step_2.php
@@ -141,9 +141,6 @@ class InstallerStep2 extends InstallerStep
 		// check if the library-directory is writable
 		self::checkRequirement('fileSystemLibrary', defined('PATH_LIBRARY') && self::isWritable(PATH_LIBRARY), self::STATUS_ERROR);
 
-		// check if the external-directory is writable
-		self::checkRequirement('fileSystemLibraryExternal', defined('PATH_LIBRARY') && self::isWritable(PATH_LIBRARY . '/external'), self::STATUS_ERROR);
-
 		// check if the installer-directory is writable
 		self::checkRequirement('fileSystemInstaller', defined('PATH_WWW') && self::isWritable(PATH_WWW . '/install/cache'), self::STATUS_ERROR);
 

--- a/install/layout/templates/step_2.tpl
+++ b/install/layout/templates/step_2.tpl
@@ -127,10 +127,7 @@
 
 				<h4><span class="{$fileSystemLibrary}">{$fileSystemLibrary}</span> {$PATH_LIBRARY}</h4>
 				<p>This location must be writable for the installer, afterwards this folder only needs to be readable.</p>
-{*
-				<h4><span class="{$fileSystemLibraryExternal}">{$fileSystemLibraryExternal}</span> {$PATH_LIBRARY}/external</h4>
-				<p>This location must be writable for the installer, afterwards this folder only needs to be readable.</p>
-*}
+
 				<h4><span class="{$fileSystemInstaller}">{$fileSystemInstaller}</span> {$PATH_WWW}/install</h4>
 				<p>This location must be writable for the installer.</p>
 


### PR DESCRIPTION
It was commented out in the template, so I am ass-u-me-ing it was no longer
needed. But it sure did keep me from installing, without any clue as to why my
system did not meet the minimum requirements.

Something needs to change:
- Either remove the check entirely, as this patch does; or
- Uncomment the relevant message in the template
  *\* Optionally, also change the failure from ERROR to WARNING.
