### PR TITLE
The main content will always be parsed first, we can swap information fr...

### DIFF
--- a/frontend/core/engine/model.php
+++ b/frontend/core/engine/model.php
@@ -313,11 +313,14 @@ class FrontendModel
 		);
 
 		// init positions
-		$record['positions'] = array();
+		$record['positions'] = array('main' => array());
 
 		// loop blocks
 		foreach($blocks as $block)
 		{
+			// set the block to the positions array
+			if(!isset($record['positions'][$block['position']])) $record['positions'][$block['position']] = array();
+
 			// unserialize data if it is available
 			if(isset($block['data'])) $block['data'] = unserialize($block['data']);
 


### PR DESCRIPTION
This makes it possible to use module information in widgets. For instance, you want the blog post id in another modules related items widget. 

You can now use Spoon::set('tag_data', array('module' => 'blog', 'id' => $this->id)); in the blog detail action. Earlier you had the chance that the main content was parsed after the widget, this would not pass this parameters to the widget.
