### PR TITLE
Avoid having datagrid rows with a selected state if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 
 * Core: integrated CKEditor into Fork CMS.
 * Pages: when adding an editor field, the editor will immediately open.
+* Core: add a class 'noSelectedState' to the table of a dataGrid to prevent the selected state to show for every row in the datagrid with a checked checkbox.
 
 Bugfixes:
 

--- a/backend/core/js/backend.js
+++ b/backend/core/js/backend.js
@@ -1088,13 +1088,22 @@ jsBackend.controls =
 	bindTableCheckbox: function()
 	{
 		// set classes
-		$('tr td input:checkbox:checked').each(function() { $(this).parents().filter('tr').eq(0).addClass('selected'); });
+		$('tr td input:checkbox:checked').each(function() 
+		{ 
+			if(!$(this).parents('table').hasClass('noSelectedState')) 
+			{
+				$(this).parents().filter('tr').eq(0).addClass('selected');
+			}
+		});
 
 		// bind change-events
 		$(document).on('change', 'tr td input:checkbox', function(e)
 		{
-			if($(this).is(':checked')) $(this).parents().filter('tr').eq(0).addClass('selected');
-			else $(this).parents().filter('tr').eq(0).removeClass('selected');
+			if(!$(this).parents('table').hasClass('noSelectedState')) 
+			{
+				if($(this).is(':checked')) $(this).parents().filter('tr').eq(0).addClass('selected');
+				else $(this).parents().filter('tr').eq(0).removeClass('selected');
+			}
 		});
 	},
 


### PR DESCRIPTION
Don't set the selected state for a datagrid row with checked checkbox if a class noSelectedState has been set for the datagrid table.
