### PR TITLE
Fixed notices in frontend/ and backend/ generated by an unused $get var in core/engine/url.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 * Pages: when adding an editor field, the editor will immediately open.
 * Core: add a class 'noSelectedState' to the table of a dataGrid to prevent the selected state to show for every row in the datagrid with a checked checkbox.
 * Core: added maxItems and afterAdd options for the multipleSelectbox.
+* Core: fixed core engine url notice in frontend/ and backend/ (Notice: Undefined offset: 1) by removing an unused $get var.
 
 Bugfixes:
 

--- a/backend/core/engine/url.php
+++ b/backend/core/engine/url.php
@@ -352,7 +352,7 @@ class BackendURL
 		if(isset($_GET) && !empty($_GET))
 		{
 			// strip GET from the queryString
-			list($queryString, $get) = explode('?', $queryString, 2);
+			list($queryString) = explode('?', $queryString, 2);
 
 			// readd
 			$queryString = $queryString . '?' . http_build_query($_GET);

--- a/frontend/core/engine/url.php
+++ b/frontend/core/engine/url.php
@@ -447,7 +447,7 @@ class FrontendURL
 		if(isset($_GET) && !empty($_GET))
 		{
 			// strip GET from the queryString
-			list($queryString, $get) = explode('?', $queryString, 2);
+			list($queryString) = explode('?', $queryString, 2);
 
 			// readd
 			$queryString = $queryString . '?' . http_build_query($_GET);


### PR DESCRIPTION
Hi,

After checking out the latest fork version (3.1.9, debug mode on) I encountered a PHP notice whenever you were browsing a page which was not root (domain.tld/) or no question mark (for example: edit?id=1) was found in the url):

Frontend: Notice: Undefined offset: 1 in /home/bart/public_html/fork-cms/forkcms/public/www/frontend/core/engine/url.php on line 450.

Example pages: domain.tld/blog or domain.tld/blog/detail/testing

Backend: Notice: Undefined offset: 1 in /home/bart/public_html/fork-cms/forkcms/public/www/backend/core/engine/url.php on line 355.

Example pages: private/nl/dashboard/index or private/nl/pages/index

Fix: By removing the unused $get var from the list() function the notice is gone.

Bart
1st pull request! ^^
