### PR TITLE
Added '_blank' option to external redirects

### DIFF
--- a/backend/modules/pages/actions/add.php
+++ b/backend/modules/pages/actions/add.php
@@ -228,6 +228,7 @@ class BackendPagesAdd extends BackendBaseActionAdd
 		$this->frm->addRadiobutton('redirect', $redirectValues, 'none');
 		$this->frm->addDropdown('internal_redirect', BackendPagesModel::getPagesForDropdown());
 		$this->frm->addText('external_redirect', null, null, null, null, true);
+		$this->frm->addCheckbox('external_redirect_target_blank');
 
 		// page info
 		$this->frm->addCheckbox('navigation_title_overwrite');

--- a/backend/modules/pages/actions/edit.php
+++ b/backend/modules/pages/actions/edit.php
@@ -328,6 +328,7 @@ class BackendPagesEdit extends BackendBaseActionEdit
 		$this->frm->addRadiobutton('redirect', $redirectValues, $redirectValue);
 		$this->frm->addDropdown('internal_redirect', BackendPagesModel::getPagesForDropdown(), ($redirectValue == 'internal') ? $this->record['data']['internal_redirect']['page_id'] : null);
 		$this->frm->addText('external_redirect', ($redirectValue == 'external') ? $this->record['data']['external_redirect']['url'] : null, null, null, null, true);
+		$this->frm->addCheckbox('external_redirect_target_blank', (isset($this->record['data']['external_redirect']['target_blank']) && $this->record['data']['external_redirect']['target_blank'] == 'Y'));
 
 		// page info
 		$this->frm->addCheckbox('navigation_title_overwrite', ($this->record['navigation_title_overwrite'] == 'Y'));
@@ -464,7 +465,8 @@ class BackendPagesEdit extends BackendBaseActionEdit
 				// build data
 				if($this->frm->getField('is_action')->isChecked()) $data['is_action'] = true;
 				if($redirectValue == 'internal') $data['internal_redirect'] = array('page_id' => $this->frm->getField('internal_redirect')->getValue(), 'code' => '301');
-				if($redirectValue == 'external') $data['external_redirect'] = array('url' => $this->frm->getField('external_redirect')->getValue(), 'code' => '301');
+				if($redirectValue == 'external') $data['external_redirect'] = array('url' => $this->frm->getField('external_redirect')->getValue(), 'code' => '301', 'target_blank' => 'N');
+				if($this->frm->getField('external_redirect_target_blank')->isChecked()) $data['external_redirect']['target_blank'] = 'Y';
 
 				// build page record
 				$page['id'] = $this->record['id'];

--- a/backend/modules/pages/engine/model.php
+++ b/backend/modules/pages/engine/model.php
@@ -198,6 +198,7 @@ class BackendPagesModel
 					{
 						$temp['redirect_url'] = $data['external_redirect']['url'];
 						$temp['redirect_code'] = $data['external_redirect']['code'];
+						$temp['redirect_blank'] = (isset($data['external_redirect']['target_blank'])) ? $data['external_redirect']['target_blank'] : 'N';
 						$treeType = 'redirect';
 					}
 

--- a/backend/modules/pages/installer/data/locale.xml
+++ b/backend/modules/pages/installer/data/locale.xml
@@ -57,6 +57,10 @@
         <translation language="hu"><![CDATA[external link]]></translation>
         <translation language="es"><![CDATA[enlace externo]]></translation>
       </item>
+	  <item type="label" name="ExternalRedirectTargetBlank">
+        <translation language="nl"><![CDATA[Open link in een nieuw scherm]]></translation>
+        <translation language="en"><![CDATA[Open link in a new window]]></translation>
+	  </item>
       <item type="label" name="ExtraTypeBlock">
         <translation language="nl"><![CDATA[module]]></translation>
         <translation language="en"><![CDATA[module]]></translation>
@@ -318,6 +322,10 @@
         <translation language="hu"><![CDATA[Használd ezt, ha a menü-elemet külső linkre akarod átirányítani.]]></translation>
         <translation language="es"><![CDATA[Ua esto si tienes que redirigir un elemento del menú al un sitio web externo.]]></translation>
       </item>
+	  <item type="message" name="HelpExternalRedirectTargetBlank">
+        <translation language="nl"><![CDATA[Hiermee kan je de link in nieuw browser scherm laten openen]]></translation>
+        <translation language="en"><![CDATA[Use this if you want a new browser window to open if you click this link]]></translation>
+	  </item>
       <item type="message" name="HelpInternalRedirect">
         <translation language="nl"><![CDATA[Hiermee kan je een item in het menu laten doorverwijzen naar een andere pagina binnen de website.]]></translation>
         <translation language="en"><![CDATA[Use this if you need to redirect a menu-item to another page on this website.]]></translation>

--- a/backend/modules/pages/layout/templates/add.tpl
+++ b/backend/modules/pages/layout/templates/add.tpl
@@ -254,6 +254,14 @@
 										<label for="externalRedirect" class="visuallyHidden">{$redirect.label}</label>
 										{$txtExternalRedirect} {$txtExternalRedirectError}
 										<span class="helpTxt">{$msgHelpExternalRedirect}</span>
+										<ul>
+											<li>
+											{$chkExternalRedirectTargetBlank}
+											<label for="externalRedirectTargetBlank" class="visuallyHidden">{$redirect.blank}</label>
+											{$lblExternalRedirectTargetBlank}
+											<span class="helpTxt">{$msgHelpExternalRedirectTargetBlank}</span>
+											</li>
+										</ul>
 								{/option:redirect.isExternal}
 							</li>
 						{/iteration:redirect}

--- a/backend/modules/pages/layout/templates/edit.tpl
+++ b/backend/modules/pages/layout/templates/edit.tpl
@@ -134,6 +134,14 @@
 										<label for="externalRedirect" class="visuallyHidden">{$redirect.label}</label>
 										{$txtExternalRedirect} {$txtExternalRedirectError}
 										<span class="helpTxt">{$msgHelpExternalRedirect}</span>
+										<ul>
+											<li>
+											{$chkExternalRedirectTargetBlank}
+											<label for="externalRedirectTargetBlank" class="visuallyHidden">{$redirect.blank}</label>
+											{$lblExternalRedirectTargetBlank}
+											<span class="helpTxt">{$msgHelpExternalRedirectTargetBlank}</span>
+											</li>
+										</ul>
 								{/option:redirect.isExternal}
 							</li>
 						{/iteration:redirect}

--- a/frontend/core/engine/navigation.php
+++ b/frontend/core/engine/navigation.php
@@ -156,7 +156,7 @@ class FrontendNavigation extends FrontendBaseObject
 			$temp['title'] = $data['title'];
 			$temp['navigation_title'] = $data['navigation_title'];
 			$temp['selected'] = (bool) in_array($id, self::$selectedPageIds);
-
+			$temp['redirect_blank'] = (isset($data['redirect_blank']) && $data['redirect_blank'] == 'Y') ? true : false;
 			// add
 			$return[] = $temp;
 		}
@@ -328,7 +328,10 @@ class FrontendNavigation extends FrontendBaseObject
 				if(isset($page['redirect_page_id']) && $page['redirect_page_id'] != '') $navigation[$type][$parentId][$id]['link'] = FrontendNavigation::getURL((int) $page['redirect_page_id']);
 
 				// is this an external redirect?
-				if(isset($page['redirect_url']) && $page['redirect_url'] != '') $navigation[$type][$parentId][$id]['link'] = $page['redirect_url'];
+				if(isset($page['redirect_url']) && $page['redirect_url'] != ''){
+					$navigation[$type][$parentId][$id]['link'] = $page['redirect_url'];
+					$navigation[$type][$parentId][$id]['redirect_blank'] = (isset($navigation[$type][$parentId][$id]['redirect_blank']) && $navigation[$type][$parentId][$id]['redirect_blank'] == 'Y') ? true : false;
+				}
 			}
 
 			// break the loop (it is only used for the special construction with home)

--- a/frontend/core/layout/templates/footer.tpl
+++ b/frontend/core/layout/templates/footer.tpl
@@ -2,7 +2,7 @@
 	<li>&copy; {$now|date:'Y'} {$siteTitle}</li>
 	{iteration:footerLinks}
 		<li{option:footerLinks.selected} class="selected"{/option:footerLinks.selected}>
-			<a href="{$footerLinks.url}" title="{$footerLinks.title}"{option:footerLinks.rel} rel="{$footerLinks.rel}"{/option:footerLinks.rel}>
+			<a href="{$footerLinks.url}" title="{$footerLinks.title}"{option:footerLinks.rel} rel="{$footerLinks.rel}"{/option:footerLinks.rel}{option:footerLinks.redirect_blank} target="_blank"{/option:footerLinks.redirect_blank}>
 				{$footerLinks.navigation_title}
 			</a>
 		</li>

--- a/frontend/core/layout/templates/navigation.tpl
+++ b/frontend/core/layout/templates/navigation.tpl
@@ -2,7 +2,7 @@
 	<ul>
 		{iteration:navigation}
 			<li{option:navigation.selected} class="selected"{/option:navigation.selected}>
-				<a href="{$navigation.link}" title="{$navigation.navigation_title}"{option:navigation.nofollow} rel="nofollow"{/option:navigation.nofollow}>{$navigation.navigation_title}</a>
+				<a href="{$navigation.link}" title="{$navigation.navigation_title}"{option:navigation.nofollow} rel="nofollow"{/option:navigation.nofollow}{option:navigation.redirect_blank} target="_blank"{/option:navigation.redirect_blank}>{$navigation.navigation_title}</a>
 				{option:navigation.selected}{$navigation.children}{/option:navigation.selected}
 			</li>
 		{/iteration:navigation}

--- a/frontend/themes/triton/core/layout/templates/footer.tpl
+++ b/frontend/themes/triton/core/layout/templates/footer.tpl
@@ -8,7 +8,7 @@
 			<ul>
 				{iteration:footerLinks}
 					<li{option:footerLinks.selected} class="selected"{/option:footerLinks.selected}>
-						<a href="{$footerLinks.url}" title="{$footerLinks.title}"{option:footerLinks.rel} rel="{$footerLinks.rel}"{/option:footerLinks.rel}>
+						<a href="{$footerLinks.url}" title="{$footerLinks.title}"{option:footerLinks.rel} rel="{$footerLinks.rel}"{/option:footerLinks.rel}{option:footerLinks.redirect_blank} target="_blank"{/option:footerLinks.redirect_blank}>
 							{$footerLinks.navigation_title}
 						</a>
 					</li>


### PR DESCRIPTION
Added an option to indicate that a link in the navigation tree should open in a new browser window. (Redirects are not affected)

Although some usability experts think that '_blank' is a bad option, I believe it should be possible for the administrators to decide for themselves.

Let me know what you think!

Signed-off-by: PeterMuusers peter@vak18.com
