### PR TITLE
tags: only remove tags for the current module

### DIFF
--- a/backend/modules/tags/engine/model.php
+++ b/backend/modules/tags/engine/model.php
@@ -255,9 +255,15 @@ class BackendTagsModel
 		);
 
 		// remove old links
-		if(!empty($currentTags)) $db->delete('modules_tags', 'tag_id IN (' . implode(', ', array_values($currentTags)) . ') AND other_id = ?', $otherId);
+		if(!empty($currentTags))
+		{
+			$db->delete(
+				'modules_tags',
+				'tag_id IN (' . implode(', ', array_values($currentTags)) . ') AND other_id = ? AND module = ?',
+				array($otherId, $module)
+			);
+		}
 
-		// tags provided
 		if(!empty($tags))
 		{
 			// loop tags


### PR DESCRIPTION
when saving tags, it was possible that the tags from an item from another module but with the same 'other_id', were deleted.
