### PR TITLE
FE: enable redirectless 404 and fix the wrong breadcrumb on those pages.

### DIFF
--- a/frontend/core/engine/breadcrumb.php
+++ b/frontend/core/engine/breadcrumb.php
@@ -24,11 +24,23 @@ class FrontendBreadcrumb extends FrontendBaseObject
 	private $items = array();
 
 	/**
-	 * Default constructor
+	 * Current pageId
+	 *
+	 * @var int
 	 */
-	public function __construct()
+	private $pageId;
+
+	/**
+	 * Default constructor
+	 *
+	 * @param int[optional] The current pageId
+	 */
+	public function __construct($pageId = null)
 	{
 		parent::__construct();
+
+		// store the page id
+		$this->pageId = $pageId;
 
 		// add into the reference
 		Spoon::set('breadcrumb', $this);
@@ -155,6 +167,15 @@ class FrontendBreadcrumb extends FrontendBaseObject
 
 			// add item
 			$items[] = $row;
+		}
+
+		// if we're showing a 404, set the breadcrumb manually
+		if($this->pageId === 404)
+		{
+			$items = array(
+				array('title' => 'Home', 'url' => '/'),
+				array('title' => '404', 'url' => null)
+			);
 		}
 
 		// assign

--- a/frontend/core/engine/navigation.php
+++ b/frontend/core/engine/navigation.php
@@ -47,6 +47,16 @@ class FrontendNavigation extends FrontendBaseObject
 	}
 
 	/**
+	 * Creates and renders a 404 page
+	 */
+	public static function dieWith404()
+	{
+		$page = new FrontendPage(404);
+		$page->display();
+		exit;
+	}
+
+	/**
 	 * Creates a Backend URL for a given action and module
 	 * If you don't specify a language the current language will be used.
 	 *

--- a/frontend/core/engine/page.php
+++ b/frontend/core/engine/page.php
@@ -71,7 +71,13 @@ class FrontendPage extends FrontendBaseObject
 	 */
 	protected $statusCode = 200;
 
-	public function __construct()
+	/**
+	 * Create a new FrontendPage instance for the given page ID. If the page ID is not
+	 * given, it is determined based on the URL path.
+	 *
+	 * @param int[optional] $pageId
+	 */
+	public function __construct($pageId = null)
 	{
 		parent::__construct();
 
@@ -82,13 +88,15 @@ class FrontendPage extends FrontendBaseObject
 		Spoon::set('page', $this);
 
 		// get pageId for requested URL
-		$this->pageId = FrontendNavigation::getPageId(implode('/', $this->URL->getPages()));
+		$this->pageId = ($pageId === null)
+			? FrontendNavigation::getPageId(implode('/', $this->URL->getPages()))
+			: (int) $pageId;
 
 		// set headers if this is a 404 page
 		if($this->pageId == 404) $this->statusCode = 404;
 
 		// create breadcrumb instance
-		$this->breadcrumb = new FrontendBreadcrumb();
+		$this->breadcrumb = new FrontendBreadcrumb($this->pageId);
 
 		// create header instance
 		$this->header = new FrontendHeader();
@@ -203,7 +211,7 @@ class FrontendPage extends FrontendBaseObject
 		else $this->record = (array) FrontendModel::getPage($this->pageId);
 
 		// empty record (pageId doesn't exists, hope this line is never used)
-		if(empty($this->record) && $this->pageId != 404) SpoonHTTP::redirect(FrontendNavigation::getURL(404), 404);
+		if(empty($this->record) && $this->pageId != 404) FrontendNavigation::dieWith404();
 
 		// init var
 		$redirect = true;

--- a/frontend/modules/blog/actions/archive.php
+++ b/frontend/modules/blog/actions/archive.php
@@ -69,14 +69,14 @@ class FrontendBlogArchive extends FrontendBaseBlock
 			$queryString = isset($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '';
 			$this->redirect(FrontendNavigation::getURLForBlock('knowledgebase', 'archive') . '/' . $this->year . '/' . str_pad($this->month, 2, '0', STR_PAD_LEFT) . $queryString, 301);
 		}
-		if(mb_strlen($this->year) != 4) $this->redirect(FrontendNavigation::getURL(404));
+		if(mb_strlen($this->year) != 4) FrontendNavigation::dieWith404();
 
 		// redefine
 		$this->year = (int) $this->year;
 		if($this->month !== null) $this->month = (int) $this->month;
 
 		// validate parameters
-		if($this->year == 0 || $this->month === 0) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->year == 0 || $this->month === 0) FrontendNavigation::dieWith404();
 
 		// requested page
 		$requestedPage = $this->URL->getParameter('page', 'int', 1);
@@ -107,8 +107,7 @@ class FrontendBlogArchive extends FrontendBaseBlock
 		$this->pagination['num_items'] = FrontendBlogModel::getAllForDateRangeCount($this->startDate, $this->endDate);
 		$this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
 
-		// redirect if the request page doesn't exists
-		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// populate calculated fields in pagination
 		$this->pagination['requested_page'] = $requestedPage;

--- a/frontend/modules/blog/actions/article_comments_rss.php
+++ b/frontend/modules/blog/actions/article_comments_rss.php
@@ -45,13 +45,13 @@ class FrontendBlogArticleCommentsRSS extends FrontendBaseBlock
 	private function getData()
 	{
 		// validate incoming parameters
-		if($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->URL->getParameter(1) === null) FrontendNavigation::dieWith404();
 
 		// get record
 		$this->record = FrontendBlogModel::get($this->URL->getParameter(1));
 
 		// anything found?
-		if(empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+		if(empty($this->record)) FrontendNavigation::dieWith404();
 
 		// get articles
 		$this->items = FrontendBlogModel::getComments($this->record['id']);

--- a/frontend/modules/blog/actions/category.php
+++ b/frontend/modules/blog/actions/category.php
@@ -65,7 +65,7 @@ class FrontendBlogCategory extends FrontendBaseBlock
 		$requestedPage = $this->URL->getParameter('page', 'int', 1);
 
 		// validate category
-		if($requestedCategory == 'false') $this->redirect(FrontendNavigation::getURL(404));
+		if($requestedCategory == 'false') FrontendNavigation::dieWith404();
 
 		// set category
 		$this->category = $categories[$possibleCategories[$requestedCategory]];
@@ -78,8 +78,7 @@ class FrontendBlogCategory extends FrontendBaseBlock
 		$this->pagination['num_items'] = FrontendBlogModel::getAllForCategoryCount($requestedCategory);
 		$this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
 
-		// redirect if the request page doesn't exists
-		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// populate calculated fields in pagination
 		$this->pagination['requested_page'] = $requestedPage;

--- a/frontend/modules/blog/actions/detail.php
+++ b/frontend/modules/blog/actions/detail.php
@@ -64,7 +64,7 @@ class FrontendBlogDetail extends FrontendBaseBlock
 	private function getData()
 	{
 		// validate incoming parameters
-		if($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->URL->getParameter(1) === null) FrontendNavigation::dieWith404();
 
 		// load revision
 		if($this->URL->getParameter('revision', 'int') != 0)
@@ -80,7 +80,7 @@ class FrontendBlogDetail extends FrontendBaseBlock
 		else $this->record = FrontendBlogModel::get($this->URL->getParameter(1));
 
 		// anything found?
-		if(empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+		if(empty($this->record)) FrontendNavigation::dieWith404();
 
 		// get comments
 		$this->comments = FrontendBlogModel::getComments($this->record['id']);

--- a/frontend/modules/blog/actions/index.php
+++ b/frontend/modules/blog/actions/index.php
@@ -60,8 +60,7 @@ class FrontendBlogIndex extends FrontendBaseBlock
 		// num pages is always equal to at least 1
 		if($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
 
-		// redirect if the request page doesn't exist
-		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// populate calculated fields in pagination
 		$this->pagination['requested_page'] = $requestedPage;

--- a/frontend/modules/faq/actions/category.php
+++ b/frontend/modules/faq/actions/category.php
@@ -44,13 +44,13 @@ class FrontendFaqCategory extends FrontendBaseBlock
 	private function getData()
 	{
 		// validate incoming parameters
-		if($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->URL->getParameter(1) === null) FrontendNavigation::dieWith404();
 
 		// get by URL
 		$this->record = FrontendFaqModel::getCategory($this->URL->getParameter(1));
 
 		// anything found?
-		if(empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+		if(empty($this->record)) FrontendNavigation::dieWith404();
 
 		$this->record['full_url'] = FrontendNavigation::getURLForBlock('faq', 'category') . '/' . $this->record['url'];
 		$this->questions = FrontendFaqModel::getAllForCategory($this->record['id']);

--- a/frontend/modules/faq/actions/detail.php
+++ b/frontend/modules/faq/actions/detail.php
@@ -67,13 +67,13 @@ class FrontendFaqDetail extends FrontendBaseBlock
 	private function getData()
 	{
 		// validate incoming parameters
-		if($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->URL->getParameter(1) === null) FrontendNavigation::dieWith404();
 
 		// get by URL
 		$this->record = FrontendFaqModel::get($this->URL->getParameter(1));
 
 		// anything found?
-		if(empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+		if(empty($this->record)) FrontendNavigation::dieWith404();
 
 		// overwrite URLs
 		$this->record['category_full_url'] = FrontendNavigation::getURLForBlock('faq', 'category') . '/' . $this->record['category_url'];

--- a/frontend/modules/mailmotor/actions/detail.php
+++ b/frontend/modules/mailmotor/actions/detail.php
@@ -130,7 +130,7 @@ class FrontendMailmotorDetail extends FrontendBaseBlock
 		// no point continueing if the mailing record is not set
 		if(empty($this->mailing))
 		{
-			$this->redirect(FrontendNavigation::getURL(404));
+			FrontendNavigation::dieWith404();
 		}
 	}
 

--- a/frontend/modules/profiles/actions/activate.php
+++ b/frontend/modules/profiles/actions/activate.php
@@ -52,10 +52,10 @@ class FrontendProfilesActivate extends FrontendBaseBlock
 			}
 
 			// failure
-			else $this->redirect(FrontendNavigation::getURL(404));
+			else FrontendNavigation::dieWith404();
 		}
 
 		// missing key
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 }

--- a/frontend/modules/profiles/actions/change_email.php
+++ b/frontend/modules/profiles/actions/change_email.php
@@ -46,7 +46,7 @@ class FrontendProfilesChangeEmail extends FrontendBaseBlock
 		}
 
 		// profile not logged in
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 
 	/**

--- a/frontend/modules/profiles/actions/change_password.php
+++ b/frontend/modules/profiles/actions/change_password.php
@@ -46,7 +46,7 @@ class FrontendProfilesChangePassword extends FrontendBaseBlock
 		}
 
 		// profile not logged in
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 
 	/**

--- a/frontend/modules/profiles/actions/index.php
+++ b/frontend/modules/profiles/actions/index.php
@@ -35,7 +35,7 @@ class FrontendProfilesIndex extends FrontendBaseBlock
 		}
 
 		// only if you are logged in, baby.
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 }
 

--- a/frontend/modules/profiles/actions/resend_activation.php
+++ b/frontend/modules/profiles/actions/resend_activation.php
@@ -30,7 +30,7 @@ class FrontendProfilesResendActivation extends FrontendBaseBlock
 		}
 
 		// profile logged in
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 
 	/**

--- a/frontend/modules/profiles/actions/reset_password.php
+++ b/frontend/modules/profiles/actions/reset_password.php
@@ -53,14 +53,14 @@ class FrontendProfilesResetPassword extends FrontendBaseBlock
 			}
 
 			// invalid key
-			elseif($this->URL->getParameter('sent') != 'true') $this->redirect(FrontendNavigation::getURL(404));
+			elseif($this->URL->getParameter('sent') != 'true') FrontendNavigation::dieWith404();
 
 			// parse
 			$this->parse();
 		}
 
 		// no key set
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 
 	/**

--- a/frontend/modules/profiles/actions/settings.php
+++ b/frontend/modules/profiles/actions/settings.php
@@ -46,7 +46,7 @@ class FrontendProfilesSettings extends FrontendBaseBlock
 		}
 
 		// profile not logged in
-		else $this->redirect(FrontendNavigation::getURL(404));
+		else FrontendNavigation::dieWith404();
 	}
 
 	/**

--- a/frontend/modules/search/actions/index.php
+++ b/frontend/modules/search/actions/index.php
@@ -165,8 +165,7 @@ class FrontendSearchIndex extends FrontendBaseBlock
 		// num pages is always equal to at least 1
 		if($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
 
-		// redirect if the request page doesn't exist
-		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// debug mode = no cache
 		if(!SPOON_DEBUG)

--- a/frontend/modules/search/ajax/autosuggest.php
+++ b/frontend/modules/search/ajax/autosuggest.php
@@ -155,8 +155,7 @@ class FrontendSearchAjaxAutosuggest extends FrontendBaseAJAXAction
 		// num pages is always equal to at least 1
 		if($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
 
-		// redirect if the request page doesn't exist
-		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// debug mode = no cache
 		if(!SPOON_DEBUG)

--- a/frontend/modules/search/ajax/livesuggest.php
+++ b/frontend/modules/search/ajax/livesuggest.php
@@ -160,8 +160,7 @@ class FrontendSearchAjaxLivesuggest extends FrontendBaseAJAXAction
 		// num pages is always equal to at least 1
 		if($this->pagination['num_pages'] == 0) $this->pagination['num_pages'] = 1;
 
-		// redirect if the request page doesn't exist
-		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) FrontendNavigation::dieWith404();
 
 		// debug mode = no cache
 		if(!SPOON_DEBUG)

--- a/frontend/modules/tags/actions/detail.php
+++ b/frontend/modules/tags/actions/detail.php
@@ -49,13 +49,13 @@ class FrontendTagsDetail extends FrontendBaseBlock
 	private function getData()
 	{
 		// validate incoming parameters
-		if($this->URL->getParameter(1) === null) $this->redirect(FrontendNavigation::getURL(404));
+		if($this->URL->getParameter(1) === null) FrontendNavigation::dieWith404();
 
 		// fetch record
 		$this->record = FrontendTagsModel::get($this->URL->getParameter(1));
 
 		// validate record
-		if(empty($this->record)) $this->redirect(FrontendNavigation::getURL(404));
+		if(empty($this->record)) FrontendNavigation::dieWith404();
 
 		// fetch modules
 		$this->modules = FrontendTagsModel::getModulesForTag($this->record['id']);


### PR DESCRIPTION
Fix enables dying as 404 instead of having to get the url and redirect to it. It also replaces all occurrences of this extra step (e.g $this->redirect(FrontendNavigation::getURL(404)); becomes FrontendNavigation::dieWith404(); ). 

Further more it includes a breadcrumb fix so all 404 pages correctly show Home > 404 in the breadcrumb.
