### PR TITLE
Fix action and module getters for AJAX calls

### DIFF
--- a/backend/core/engine/ajax_action.php
+++ b/backend/core/engine/ajax_action.php
@@ -41,6 +41,10 @@ class BackendAJAXAction extends BackendBaseObject
 
 		// create action-object
 		$object = new $actionClassName($this->getAction(), $this->getModule());
+		
+		// set action and module!
+		$object->setAction($this->getAction(), $this->getModule());
+		
 		$object->execute();
 	}
 


### PR DESCRIPTION
Seems like action and module weren't set correctly anymore.
This should fix it
