### PR TITLE
formbuilder: force set locale

### DIFF
--- a/backend/modules/form_builder/actions/add.php
+++ b/backend/modules/form_builder/actions/add.php
@@ -111,7 +111,7 @@ class BackendFormBuilderAdd extends BackendBaseActionAdd
 				BackendModel::triggerEvent($this->getModule(), 'after_add', array('item' => $values));
 
 				// set frontend locale
-				FL::setLocale(BL::getWorkingLanguage());
+				FL::setLocale(BL::getWorkingLanguage(), true);
 
 				// create submit button
 				$field['form_id'] = $id;

--- a/backend/modules/form_builder/actions/edit.php
+++ b/backend/modules/form_builder/actions/edit.php
@@ -130,7 +130,7 @@ class BackendFormBuilderEdit extends BackendBaseActionEdit
 	private function parseErrorMessages()
 	{
 		// set frontend locale
-		FL::setLocale(BL::getWorkingLanguage());
+		FL::setLocale(BL::getWorkingLanguage(), true);
 
 		// assign error messages
 		$this->tpl->assign('errors', BackendFormBuilderModel::getErrors());


### PR DESCRIPTION
If the working language is not active, you get an exception when adding/editing a form in the formbuilder.
