### PR TITLE
Breadcrumb: FE: fix wrong breadcrumb on 404 pages

### DIFF
--- a/frontend/core/engine/breadcrumb.php
+++ b/frontend/core/engine/breadcrumb.php
@@ -24,11 +24,21 @@ class FrontendBreadcrumb extends FrontendBaseObject
 	private $items = array();
 
 	/**
+	 * The current pageId
+	 *
+	 * @var int
+	 */
+	private $pageId;
+
+	/**
 	 * Default constructor
 	 */
-	public function __construct()
+	public function __construct($pageId = null)
 	{
 		parent::__construct();
+
+		// store page id
+		$this->pageId = $pageId;
 
 		// add into the reference
 		Spoon::set('breadcrumb', $this);
@@ -155,6 +165,15 @@ class FrontendBreadcrumb extends FrontendBaseObject
 
 			// add item
 			$items[] = $row;
+		}
+
+		// if we're showing a 404, set the breadcrumb manually
+		if($this->pageId = 404)
+		{
+			$items = array(
+				array('title' => 'Home', 'url' => '/'),
+				array('title' => '404', 'url' => null)
+			);
 		}
 
 		// assign

--- a/frontend/core/engine/page.php
+++ b/frontend/core/engine/page.php
@@ -88,7 +88,7 @@ class FrontendPage extends FrontendBaseObject
 		if($this->pageId == 404) $this->statusCode = 404;
 
 		// create breadcrumb instance
-		$this->breadcrumb = new FrontendBreadcrumb();
+		$this->breadcrumb = new FrontendBreadcrumb($this->pageId);
 
 		// create header instance
 		$this->header = new FrontendHeader();


### PR DESCRIPTION
Fix faulty breadcrumbs on 404 pages, often it showed home > home > 404.
Now each and every time we construct a breadcrumb we check if we're showing
a 404, if so we manually set it to home > 404.
