### PR TITLE
Redirect instead of error

### DIFF
--- a/backend/core/engine/url.php
+++ b/backend/core/engine/url.php
@@ -246,6 +246,20 @@ class BackendURL extends BackendBaseObject
 							// redirect to the page
 							SpoonHTTP::redirect('/' . NAMED_APPLICATION . '/' . $language . '/' . $value['url']);
 						}
+
+						// loop the children of the navigation too, to find an allowed module
+						foreach($value['children'] as $childKey => $childValue)
+						{
+							// split up chunks
+							list($childModule, $childAction) = explode('/', $childValue['url']);
+
+							// user allowed?
+							if(BackendAuthentication::isAllowedModule($childModule))
+							{
+								// redirect to the page
+								SpoonHTTP::redirect('/' . NAMED_APPLICATION . '/' . $language . '/' . $childValue['url']);
+							}
+						}
 					}
 				}
 				// the user doesn't have access, redirect to error page


### PR DESCRIPTION
Explanation bugfix

A user has limited rights.
For example, he only has rights to the installed blogmodule...

The user is logged in and visits 
example.com/private/nl/

An error is shown: "You have insufficient rights for this action".

Actually, the user should be redirected to the first allowed module (which is blog). 

This fix checks within the subnavigation, which does the trick to redirect to the right module.
