### PR TITLE
Bugfix: Unable to select templates in IE7/IE8

### DIFF
--- a/backend/core/layout/css/conditionals/ie7.css
+++ b/backend/core/layout/css/conditionals/ie7.css
@@ -32,3 +32,8 @@
 	padding-top: 12px;
 	border-top: 0;
 }
+
+/* IE7 cant target hidden elements */
+.selectThumbList li input {
+	visibility: visible;
+}

--- a/backend/core/layout/css/conditionals/ie8.css
+++ b/backend/core/layout/css/conditionals/ie8.css
@@ -21,3 +21,8 @@
 	padding-top: 12px;
 	border-top: 0;
 }
+
+/* IE8 cant target hidden elements */
+.selectThumbList li input {
+	visibility: visible;
+}


### PR DESCRIPTION
It was not possible to select the template radiobutton while the element was hidden in IE7/IE8. Making it visible in the CSS fixed the issue.
