### PR TITLE
Locale: remove check 'user is god' to change locale.

### DIFF
--- a/backend/modules/locale/actions/edit.php
+++ b/backend/modules/locale/actions/edit.php
@@ -31,7 +31,7 @@ class BackendLocaleEdit extends BackendBaseActionEdit
 		$this->id = $this->getParameter('id', 'int');
 
 		// does the item exists
-		if($this->id !== null && BackendLocaleModel::exists($this->id) && BackendAuthentication::getUser()->isGod())
+		if($this->id !== null && BackendLocaleModel::exists($this->id))
 		{
 			parent::execute();
 			$this->setFilter();


### PR DESCRIPTION
In the action 'edit' from the module Locale there is a check if the user is GOD. This check means that every customer of us can't change any locale anymore. So the isGod check has been removed.
