### PR TITLE
Fix cached links dropdown in editor

### DIFF
--- a/backend/modules/pages/engine/model.php
+++ b/backend/modules/pages/engine/model.php
@@ -60,6 +60,11 @@ class BackendPagesModel
 	 */
 	public static function buildCache($language = null)
 	{
+		// clear compiled templates
+		$templateObject = new SpoonTemplate();
+		$templateObject->setCompileDirectory(BACKEND_CACHE_PATH . '/compiled_templates');
+		$templateObject->clearCompiled();
+
 		// redefine
 		$language = ($language !== null) ? (string) $language : BackendLanguage::getWorkingLanguage();
 


### PR DESCRIPTION
When changing the navigation and with cached templates on the backend, the timestamp of the editor link list js file doesn't change, so browser keeps getting this from cache.
If we clear the compiled templates, this problem is automatically solved.
