### PR TITLE
Mailmotor: add jsData to iFrame template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bugfixes:
 * Users: Added fix so users can't edit other profiles.
 * SpoonDate: only replace full matches of date abbreviations, otherwise Montag becomes Mo.tag. Tx to Jan Moesen.
 * DataGrid: do not overwrite existing row attributes when greying out a row.
+* Mailmotor: add jsData to iframe template.
 
 
 3.4.4 (2012-09-12)

--- a/backend/modules/mailmotor/layout/templates/edit_mailing_iframe.tpl
+++ b/backend/modules/mailmotor/layout/templates/edit_mailing_iframe.tpl
@@ -26,6 +26,18 @@
 	<script type="text/javascript" src="/frontend/cache/navigation/editor_link_list_{$LANGUAGE}.js"></script>
 	<script type="text/javascript">
 		//<![CDATA[
+			{$jsData}
+
+			// reports
+			$(function()
+			{
+				{option:formError}jsBackend.messages.add('error', "{$errFormError|addslashes}");{/option:formError}
+				{option:usingRevision}jsBackend.messages.add('notice', "{$msgUsingARevision|addslashes}");{/option:usingRevision}
+				{option:usingDraft}jsBackend.messages.add('notice', "{$msgUsingADraft|addslashes}");{/option:usingDraft}
+				{option:report}jsBackend.messages.add('success', "{$reportMessage|addslashes}");{/option:report}
+				{option:errorMessage}jsBackend.messages.add('error', "{$errorMessage|addslashes}");{/option:errorMessage}
+			});
+
 			var variables = new Array();
 			variables =
 			{


### PR DESCRIPTION
The mailmotor module uses an iFrame to edit the content of a mail. To
make sure the editor loads correctly, we need the jsData variable.
