### PR TITLE
Implement notfound.org default 404 page

### DIFF
--- a/backend/modules/pages/installer/data/bg/404.txt
+++ b/backend/modules/pages/installer/data/bg/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/cs/404.txt
+++ b/backend/modules/pages/installer/data/cs/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/de/404.txt
+++ b/backend/modules/pages/installer/data/de/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/el/404.txt
+++ b/backend/modules/pages/installer/data/el/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/en/404.txt
+++ b/backend/modules/pages/installer/data/en/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/es/404.txt
+++ b/backend/modules/pages/installer/data/es/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>Esta página no existe o no es visible en este momento. Echa un vistazo al sitemap:</p>

--- a/backend/modules/pages/installer/data/fr/404.txt
+++ b/backend/modules/pages/installer/data/fr/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>Cette page n'existe plus ou n'est pas accessible en ce moment. Vous pouvez consulter le plan du site:</p>

--- a/backend/modules/pages/installer/data/hu/404.txt
+++ b/backend/modules/pages/installer/data/hu/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/it/404.txt
+++ b/backend/modules/pages/installer/data/it/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/ja/404.txt
+++ b/backend/modules/pages/installer/data/ja/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/lt/404.txt
+++ b/backend/modules/pages/installer/data/lt/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/nl/404.txt
+++ b/backend/modules/pages/installer/data/nl/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>De opgevraagde pagina bestaat niet of is niet beschikbaar op dit ogenblik. Kijk naar de sitemap:</p>

--- a/backend/modules/pages/installer/data/pl/404.txt
+++ b/backend/modules/pages/installer/data/pl/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/ro/404.txt
+++ b/backend/modules/pages/installer/data/ro/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/ru/404.txt
+++ b/backend/modules/pages/installer/data/ru/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>Страница не существует или сейчас не доступна. Взгляните на карту сайта:</p>

--- a/backend/modules/pages/installer/data/sv/404.txt
+++ b/backend/modules/pages/installer/data/sv/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/tr/404.txt
+++ b/backend/modules/pages/installer/data/tr/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/uk/404.txt
+++ b/backend/modules/pages/installer/data/uk/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>

--- a/backend/modules/pages/installer/data/zh/404.txt
+++ b/backend/modules/pages/installer/data/zh/404.txt
@@ -1,1 +1,2 @@
+<iframe src="http://notfound-static.fwebservices.be/404/index.html" width="100%" height="650" frameborder="0"></iframe>
 <p>This page doesn't exist or is not accessible at this time. Take a look at the sitemap:</p>


### PR DESCRIPTION
notfound.org is a great initiative. By default, Fork CMS wil now be
installed with a custom 404-page that will portay missing people,
increasing odds that someone, somewhere, may recognise someone...
