### PR TITLE
content blocks should be treated as HTML.

### DIFF
--- a/frontend/core/engine/page.php
+++ b/frontend/core/engine/page.php
@@ -339,7 +339,7 @@ class FrontendPage extends FrontendBaseObject
 						// parse extra
 						$positions[$position][$i] = array(
 							'variables' => $block['extra']->getTemplate()->getAssignedVariables(),
-							'blockIsHTML' => false,
+							'blockIsHTML' => ($block['extra']->getModule() == 'content_blocks'),
 							'blockContent' => $block['extra']->getContent()
 						);
 					}


### PR DESCRIPTION
Content blocks are reusable editor fields. Let's treat them them the same way.
