### PR TITLE
Ticket 294: Blog: next and previous don't work when blog-items has same publish_on date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Bugfixes:
 * Form: encode html entities in hidden field values to prevent XSS.
 * Mailmotor: add jsData to iframe template.
 * Blog: Use full links for the navigation below the blogposts.
+* Blog: Ticket 294: Next and previous don't work when blog-items has same publish_on date
 
 
 3.4.4 (2012-09-12)

--- a/frontend/modules/blog/engine/model.php
+++ b/frontend/modules/blog/engine/model.php
@@ -548,10 +548,10 @@ class FrontendBlogModel implements FrontendTagsInterface
 			'SELECT i.id, i.title, CONCAT(?, m.url) AS url
 			 FROM blog_posts AS i
 			 INNER JOIN meta AS m ON i.meta_id = m.id
-			 WHERE i.id != ? AND i.status = ? AND i.hidden = ? AND i.language = ? AND i.publish_on <= ?
-			 ORDER BY i.publish_on DESC
+			 WHERE i.id != ? AND i.status = ? AND i.hidden = ? AND i.language = ? AND ((i.publish_on = ? AND i.id < ?) OR i.publish_on < ?)
+			 ORDER BY i.publish_on DESC, i.id DESC
 			 LIMIT 1',
-			array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date)
+			array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date, $id, $date)
 		);
 
 		// get next post
@@ -559,10 +559,10 @@ class FrontendBlogModel implements FrontendTagsInterface
 			'SELECT i.id, i.title, CONCAT(?, m.url) AS url
 			 FROM blog_posts AS i
 			 INNER JOIN meta AS m ON i.meta_id = m.id
-			 WHERE i.id != ? AND i.status = ? AND i.hidden = ? AND i.language = ? AND i.publish_on > ?
-			 ORDER BY i.publish_on ASC
+			 WHERE i.id != ? AND i.status = ? AND i.hidden = ? AND i.language = ? AND ((i.publish_on = ? AND i.id > ?) OR i.publish_on > ?)
+			 ORDER BY i.publish_on ASC, i.id ASC
 			 LIMIT 1',
-			array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date)
+			array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date, $id, $date)
 		);
 
 		return $navigation;


### PR DESCRIPTION
Problem description forum:
http://forum.fork-cms.com/discussions/3xx/509-blog-next-and-previous-dont-work-when-blog-items-has-same-publish_on-date

Lighthouse Ticket:
http://forkcms.lighthouseapp.com/projects/61890/tickets/294-via-tender-blog-next-and-previous-dont-work-when-blog-items-has-same-publish_on-date
