### PR TITLE
Fix for issue 347 > Can't choose which share buttons to display

### DIFF
--- a/frontend/core/js/jquery/jquery.frontend.js
+++ b/frontend/core/js/jquery/jquery.frontend.js
@@ -47,7 +47,9 @@
 			default_image: document.location.protocol + '//' + document.location.host + '/apple-touch-icon.png',
 			sequence: ['facebook', 'twitter', 'netlog', 'linkedin', 'digg', 'delicious', 'googleplus', 'pinterest'],
 			isDropdown: true,
-
+		}
+		var settings =
+		{
 			delicious: { name: 'delicious', show: true, label: 'Delicious'},
 			digg: { name: 'digg', show: true, label: 'Digg' },
 			facebook: { name: 'facebook', show: true, width: 90, verb: 'like', colorScheme: 'light', font : 'arial' },
@@ -59,7 +61,8 @@
 		};
 
 		// extend options
-		var options = $.extend(true, defaults, options);
+		var options = $.extend(defaults, options);
+		options = $.extend(true, settings, options);
 
 		return this.each(function()
 		{


### PR DESCRIPTION
http://forkcms.lighthouseapp.com/projects/61890-fork-cms/tickets/347-share-buttons-cant-choose-which-buttons-to-display

jquery.extend with true (deep extend) doesn't overwrite an array but merges it. I've split up the defaults into defaults and settings so that they both can be used by jquery.extend. But only the settings will do a deep extend.

More info: http://api.jquery.com/jQuery.extend/ & http://bugs.jquery.com/ticket/9477
