### PR TITLE
Location widget address fixed

### DIFF
--- a/frontend/modules/location/js/location.js
+++ b/frontend/modules/location/js/location.js
@@ -76,23 +76,24 @@ jsFrontend.location =
 	// add a marker
 	addMarker: function(mapId, id, lat, lng, title)
 	{
-		$markerText = $('#markerText' + id);
-		
 		// add the marker
 		var marker = new google.maps.Marker(
 			{
 				position: new google.maps.LatLng(lat, lng),
 				map: jsFrontend.location.map[mapId],
-				title: title
+				title: title,
+				locationId: id
 			}
 		);
-
-		// apparently JS goes bananas with multiline HTMl, so we grab it from the div, this seems like a good idea for SEO
-		if($markerText.length > 0) text = $markerText.html();
-		
+				
 		// show infowindow on click
 		google.maps.event.addListener(marker, 'click', function()
 		{
+			$markerText = $('#markerText' + marker.locationId);
+			
+			// apparently JS goes bananas with multiline HTMl, so we grab it from the div, this seems like a good idea for SEO
+			if($markerText.length > 0) text = $markerText.html();
+		
 			var content = '<h1>' + title + '</h1>';
 			if(typeof text != 'undefined') content += text;
 			


### PR DESCRIPTION
See forum discussion http://forum.fork-cms.com/discussions/3xx/1116-location-module

If you added more than one widget, the last address was used for all locations.

I moved the variable to get the text inside the click handler and gave the marker object a locationId property.
