### PR TITLE
Throw analytics errors when requesting profiles

### DIFF
--- a/library/external/google_analytics.php
+++ b/library/external/google_analytics.php
@@ -186,7 +186,7 @@ class GoogleAnalytics
 		// catch possible exception
 		catch(Exception $e)
 		{
-			throw $e;
+			throw new Exception($e->getMessage(), $e->getCode());
 		}
 
 		// no accounts - return an empty array


### PR DESCRIPTION
While testing Google Analytics I noticed that not every error is displayed.

It is an odd problem, I thought that `throw $e` would just do the job, but the error wasn't thrown and the function just returned an empty array.

It can be tested by causing an error, e.g. linking a GA account by providing an API key with incorrect Referers.
