### PR TITLE
Make sure numeric tags can be removed.

### DIFF
--- a/backend/core/js/jquery/jquery.backend.js
+++ b/backend/core/js/jquery/jquery.backend.js
@@ -1016,6 +1016,8 @@
 			// remove an item
 			function remove(value)
 			{
+				value = String(value);
+
 				// get index for element
 				var index = $.inArray(String(value), elements);
 


### PR DESCRIPTION
The elements array contains all strings. If the value was an integer, the tag couldn't be removed.
