### PR TITLE
Output should be the last command to execute

### DIFF
--- a/backend/modules/analytics/ajax/check_status.php
+++ b/backend/modules/analytics/ajax/check_status.php
@@ -25,99 +25,105 @@ class BackendAnalyticsAjaxCheckStatus extends BackendBaseAJAXAction
 
 		// validate
 		if($page == '' || $identifier == '') $this->output(self::BAD_REQUEST, null, 'No page provided.');
-
-		// init vars
-		$filename = BACKEND_CACHE_PATH . '/analytics/' . $page . '_' . $identifier . '.txt';
-
-		// does the temporary file still exist?
-		$status = SpoonFile::getContent($filename);
-
-		// no file - create one
-		if($status === false)
+		
+		// validated
+		else
 		{
-			// create file with initial counter
-			SpoonFile::setContent($filename, 'missing1');
-
-			// return status
-			$this->output(self::OK, array('status' => false), 'Temporary file was missing. We created one.');
-		}
-
-		// busy status
-		elseif(strpos($status, 'busy') !== false)
-		{
-			// get counter
-			$counter = (int) substr($status, 4) + 1;
-
-			// file's been busy for more than hundred cycles - just stop here
-			if($counter > 100)
+			// init vars
+			$filename = BACKEND_CACHE_PATH . '/analytics/' . $page . '_' . $identifier . '.txt';
+	
+			// does the temporary file still exist?
+			$status = SpoonFile::getContent($filename);
+	
+			// no file - create one
+			if($status === false)
+			{
+				// create file with initial counter
+				SpoonFile::setContent($filename, 'missing1');
+	
+				// return status
+				$this->output(self::OK, array('status' => false), 'Temporary file was missing. We created one.');
+			}
+	
+			// busy status
+			elseif(strpos($status, 'busy') !== false)
+			{
+				// get counter
+				$counter = (int) substr($status, 4) + 1;
+	
+				// file's been busy for more than hundred cycles - just stop here
+				if($counter > 100)
+				{
+					// remove file
+					SpoonFile::delete($filename);
+	
+					// return status
+					$this->output(self::ERROR, array('status' => 'timeout'), 'Error while retrieving data - the script took too long to retrieve data.');
+					return;
+				}
+	
+				// change file content to increase counter
+				SpoonFile::setContent($filename, 'busy' . $counter);
+	
+				// return status
+				$this->output(self::OK, array('status' => 'busy', 'temp' => $status), 'Data is being retrieved. (' . $counter . ')');
+			}
+	
+			// unauthorized status
+			elseif($status == 'unauthorized')
 			{
 				// remove file
 				SpoonFile::delete($filename);
-
-				// return status
-				$this->output(self::ERROR, array('status' => 'timeout'), 'Error while retrieving data - the script took too long to retrieve data.');
+	
+				// remove all parameters from the module settings
+				BackendModel::setModuleSetting($this->getModule(), 'session_token', null);
+				BackendModel::setModuleSetting($this->getModule(), 'account_name', null);
+				BackendModel::setModuleSetting($this->getModule(), 'table_id', null);
+				BackendModel::setModuleSetting($this->getModule(), 'profile_title', null);
+	
+				BackendAnalyticsModel::removeCacheFiles();
+				BackendAnalyticsModel::clearTables();
+	
+				$this->output(self::OK, array('status' => 'unauthorized'), 'No longer authorized.');
 			}
-
-			// change file content to increase counter
-			SpoonFile::setContent($filename, 'busy' . $counter);
-
-			// return status
-			$this->output(self::OK, array('status' => 'busy', 'temp' => $status), 'Data is being retrieved. (' . $counter . ')');
-		}
-
-		// unauthorized status
-		elseif($status == 'unauthorized')
-		{
-			// remove file
-			SpoonFile::delete($filename);
-
-			// remove all parameters from the module settings
-			BackendModel::setModuleSetting($this->getModule(), 'session_token', null);
-			BackendModel::setModuleSetting($this->getModule(), 'account_name', null);
-			BackendModel::setModuleSetting($this->getModule(), 'table_id', null);
-			BackendModel::setModuleSetting($this->getModule(), 'profile_title', null);
-
-			BackendAnalyticsModel::removeCacheFiles();
-			BackendAnalyticsModel::clearTables();
-
-			$this->output(self::OK, array('status' => 'unauthorized'), 'No longer authorized.');
-		}
-
-		// done status
-		elseif($status == 'done')
-		{
-			// remove file
-			SpoonFile::delete($filename);
-
-			// return status
-			$this->output(self::OK, array('status' => 'done'), 'Data retrieved.');
-		}
-
-		// missing status
-		elseif(strpos($status, 'missing') !== false)
-		{
-			// get counter
-			$counter = (int) substr($status, 7) + 1;
-
-			// file's been missing for more than ten cycles - just stop here
-			if($counter > 10)
+	
+			// done status
+			elseif($status == 'done')
+			{
+				// remove file
+				SpoonFile::delete($filename);
+	
+				// return status
+				$this->output(self::OK, array('status' => 'done'), 'Data retrieved.');
+			}
+	
+			// missing status
+			elseif(strpos($status, 'missing') !== false)
+			{
+				// get counter
+				$counter = (int) substr($status, 7) + 1;
+	
+				// file's been missing for more than ten cycles - just stop here
+				if($counter > 10)
+				{
+					SpoonFile::delete($filename);
+					$this->output(self::ERROR, array('status' => 'missing'), 'Error while retrieving data - file was never created.');
+					return;
+				}
+	
+				// change file content to increase counter
+				SpoonFile::setContent($filename, 'missing' . $counter);
+	
+				// return status
+				$this->output(self::OK, array('status' => 'busy'), 'Temporary file was still in status missing. (' . $counter . ')');
+			}
+	
+			/* FALLBACK - SOMETHING WENT WRONG */
+			else
 			{
 				SpoonFile::delete($filename);
-				$this->output(self::ERROR, array('status' => 'missing'), 'Error while retrieving data - file was never created.');
+				$this->output(self::ERROR, array('status' => 'error', 'a' => ($status == 'done')), 'Error while retrieving data.');
 			}
-
-			// change file content to increase counter
-			SpoonFile::setContent($filename, 'missing' . $counter);
-
-			// return status
-			$this->output(self::OK, array('status' => 'busy'), 'Temporary file was still in status missing. (' . $counter . ')');
-		}
-
-		/* FALLBACK - SOMETHING WENT WRONG */
-		else
-		{
-			SpoonFile::delete($filename);
-			$this->output(self::ERROR, array('status' => 'error', 'a' => ($status == 'done')), 'Error while retrieving data.');
 		}
 	}
 }

--- a/backend/modules/analytics/ajax/refresh_traffic_sources.php
+++ b/backend/modules/analytics/ajax/refresh_traffic_sources.php
@@ -36,24 +36,29 @@ class BackendAnalyticsAjaxRefreshTrafficSources extends BackendBaseAJAXAction
 			$this->output(self::OK, array('status' => 'unauthorized', 'message' => BL::msg('Redirecting')), 'No longer authorized.');
 		}
 
-		$this->getData();
-
-		// get html
-		$referrersHtml = $this->parseReferrers();
-		$keywordsHtml = $this->parseKeywords();
-
-		// return status
-		$this->output(
-			self::OK,
-			array(
-				'status' => 'success',
-				'referrersHtml' => $referrersHtml,
-				'keywordsHtml' => $keywordsHtml,
-				'date' => BL::lbl('Today'),
-				'message' => BL::msg('RefreshedTrafficSources')
-			),
-			'Data has been retrieved.'
-		);
+		// authorized
+		else
+		{
+			// get data
+			$this->getData();
+	
+			// get html
+			$referrersHtml = $this->parseReferrers();
+			$keywordsHtml = $this->parseKeywords();
+	
+			// return status
+			$this->output(
+				self::OK,
+				array(
+					'status' => 'success',
+					'referrersHtml' => $referrersHtml,
+					'keywordsHtml' => $keywordsHtml,
+					'date' => BL::lbl('Today'),
+					'message' => BL::msg('RefreshedTrafficSources')
+				),
+				'Data has been retrieved.'
+			);
+		}
 	}
 
 	/**

--- a/backend/modules/blog/ajax/add_category.php
+++ b/backend/modules/blog/ajax/add_category.php
@@ -26,24 +26,28 @@ class BackendBlogAjaxAddCategory extends BackendBaseAJAXAction
 
 		// validate
 		if($categoryTitle === '') $this->output(self::BAD_REQUEST, null, BL::err('TitleIsRequired'));
-
-		// get the data
-		// build array
-		$item['title'] = SpoonFilter::htmlspecialchars($categoryTitle);
-		$item['language'] = BL::getWorkingLanguage();
-
-		$meta['keywords'] = $item['title'];
-		$meta['keywords_overwrite'] = 'N';
-		$meta['description'] = $item['title'];
-		$meta['description_overwrite'] = 'N';
-		$meta['title'] = $item['title'];
-		$meta['title_overwrite'] = 'N';
-		$meta['url'] = BackendBlogModel::getURLForCategory(SpoonFilter::urlise($item['title']));
-
-		// update
-		$item['id'] = BackendBlogModel::insertCategory($item, $meta);
-
-		// output
-		$this->output(self::OK, $item, vsprintf(BL::msg('AddedCategory'), array($item['title'])));
+		
+		// validated
+		else
+		{
+			// get the data
+			// build array
+			$item['title'] = SpoonFilter::htmlspecialchars($categoryTitle);
+			$item['language'] = BL::getWorkingLanguage();
+	
+			$meta['keywords'] = $item['title'];
+			$meta['keywords_overwrite'] = 'N';
+			$meta['description'] = $item['title'];
+			$meta['description_overwrite'] = 'N';
+			$meta['title'] = $item['title'];
+			$meta['title_overwrite'] = 'N';
+			$meta['url'] = BackendBlogModel::getURLForCategory(SpoonFilter::urlise($item['title']));
+	
+			// update
+			$item['id'] = BackendBlogModel::insertCategory($item, $meta);
+	
+			// output
+			$this->output(self::OK, $item, vsprintf(BL::msg('AddedCategory'), array($item['title'])));
+		}
 	}
 }

--- a/backend/modules/dashboard/ajax/alter_sequence.php
+++ b/backend/modules/dashboard/ajax/alter_sequence.php
@@ -26,59 +26,67 @@ class BackendDashboardAjaxAlterSequence extends BackendBaseAJAXAction
 
 		// validate
 		if($newSequence == '') $this->output(self::BAD_REQUEST, null, 'no new_sequence provided');
-
-		// convert into array
-		$json = @json_decode($newSequence, true);
-
-		// validate
-		if($json === false) $this->output(self::BAD_REQUEST, null, 'invalid new_sequence provided');
-
-		// initialize
-		$userSequence = array();
-		$hiddenItems = array();
-
-		// loop columns
-		foreach($json as $column => $widgets)
+		
+		// validated
+		else 
 		{
-			$columnValue = 'left';
-			if($column == 1) $columnValue = 'middle';
-			if($column == 2) $columnValue = 'right';
-
-			// loop widgets
-			foreach($widgets as $sequence => $widget)
+			// convert into array
+			$json = @json_decode($newSequence, true);
+	
+			// validate
+			if($json === false) $this->output(self::BAD_REQUEST, null, 'invalid new_sequence provided');
+			
+			// validated
+			else 
 			{
-				// store position
-				$userSequence[$widget['module']][$widget['widget']] = array('column' => $columnValue, 'position' => $sequence, 'hidden' => $widget['hidden'], 'present' => $widget['present']);
-
-				// add to array
-				if($widget['hidden']) $hiddenItems[] = $widget['module'] . '_' . $widget['widget'];
-			}
-		}
-
-		// get previous setting
-		$currentSetting = BackendAuthentication::getUser()->getSetting('dashboard_sequence');
-		$data['reload'] = false;
-
-		// any settings?
-		if($currentSetting !== null)
-		{
-			// loop modules
-			foreach($currentSetting as $module => $widgets)
-			{
-				foreach($widgets as $widget => $values)
+				// initialize
+				$userSequence = array();
+				$hiddenItems = array();
+		
+				// loop columns
+				foreach($json as $column => $widgets)
 				{
-					if($values['hidden'] && isset($userSequence[$module][$widget]['hidden']) && !$userSequence[$module][$widget]['hidden'])
+					$columnValue = 'left';
+					if($column == 1) $columnValue = 'middle';
+					if($column == 2) $columnValue = 'right';
+		
+					// loop widgets
+					foreach($widgets as $sequence => $widget)
 					{
-						$data['reload'] = true;
+						// store position
+						$userSequence[$widget['module']][$widget['widget']] = array('column' => $columnValue, 'position' => $sequence, 'hidden' => $widget['hidden'], 'present' => $widget['present']);
+		
+						// add to array
+						if($widget['hidden']) $hiddenItems[] = $widget['module'] . '_' . $widget['widget'];
 					}
 				}
+		
+				// get previous setting
+				$currentSetting = BackendAuthentication::getUser()->getSetting('dashboard_sequence');
+				$data['reload'] = false;
+		
+				// any settings?
+				if($currentSetting !== null)
+				{
+					// loop modules
+					foreach($currentSetting as $module => $widgets)
+					{
+						foreach($widgets as $widget => $values)
+						{
+							if($values['hidden'] && isset($userSequence[$module][$widget]['hidden']) && !$userSequence[$module][$widget]['hidden'])
+							{
+								$data['reload'] = true;
+							}
+						}
+					}
+				}
+		
+				// store
+				BackendAuthentication::getUser()->setSetting('dashboard_sequence', $userSequence);
+		
+				// output
+				$this->output(self::OK, $data, BL::msg('Saved'));
 			}
 		}
-
-		// store
-		BackendAuthentication::getUser()->setSetting('dashboard_sequence', $userSequence);
-
-		// output
-		$this->output(self::OK, $data, BL::msg('Saved'));
 	}
 }

--- a/backend/modules/faq/ajax/sequence_questions.php
+++ b/backend/modules/faq/ajax/sequence_questions.php
@@ -24,42 +24,46 @@ class BackendFaqAjaxSequenceQuestions extends BackendBaseAJAXAction
 
 		// invalid question id
 		if(!BackendFaqModel::exists($questionId)) $this->output(self::BAD_REQUEST, null, 'question does not exist');
-
-		// list ids
-		$fromCategorySequence = (array) explode(',', ltrim($fromCategorySequence, ','));
-		$toCategorySequence = (array) explode(',', ltrim($toCategorySequence, ','));
-
-		// is the question moved to a new category?
-		if($fromCategoryId != $toCategoryId)
+		
+		// validated
+		else
 		{
-			$item['id'] = $questionId;
-			$item['category_id'] = $toCategoryId;
-
-			BackendFaqModel::update($item);
-
-			// loop id's and set new sequence
-			foreach($toCategorySequence as $i => $id)
+			// list ids
+			$fromCategorySequence = (array) explode(',', ltrim($fromCategorySequence, ','));
+			$toCategorySequence = (array) explode(',', ltrim($toCategorySequence, ','));
+	
+			// is the question moved to a new category?
+			if($fromCategoryId != $toCategoryId)
 			{
-				$item = array();
+				$item['id'] = $questionId;
+				$item['category_id'] = $toCategoryId;
+	
+				BackendFaqModel::update($item);
+	
+				// loop id's and set new sequence
+				foreach($toCategorySequence as $i => $id)
+				{
+					$item = array();
+					$item['id'] = (int) $id;
+					$item['sequence'] = $i + 1;
+	
+					// update sequence if the item exists
+					if(BackendFaqModel::exists($item['id'])) BackendFaqModel::update($item);
+				}
+			}
+	
+			// loop id's and set new sequence
+			foreach($fromCategorySequence as $i => $id)
+			{
 				$item['id'] = (int) $id;
 				$item['sequence'] = $i + 1;
-
+	
 				// update sequence if the item exists
 				if(BackendFaqModel::exists($item['id'])) BackendFaqModel::update($item);
 			}
+	
+			// success output
+			$this->output(self::OK, null, 'sequence updated');
 		}
-
-		// loop id's and set new sequence
-		foreach($fromCategorySequence as $i => $id)
-		{
-			$item['id'] = (int) $id;
-			$item['sequence'] = $i + 1;
-
-			// update sequence if the item exists
-			if(BackendFaqModel::exists($item['id'])) BackendFaqModel::update($item);
-		}
-
-		// success output
-		$this->output(self::OK, null, 'sequence updated');
 	}
 }

--- a/backend/modules/form_builder/ajax/delete_field.php
+++ b/backend/modules/form_builder/ajax/delete_field.php
@@ -28,23 +28,31 @@ class BackendFormBuilderAjaxDeleteField extends BackendBaseAJAXAction
 		// invalid form id
 		if(!BackendFormBuilderModel::exists($formId)) $this->output(self::BAD_REQUEST, null, 'form does not exist');
 
-		// invalid fieldId
-		if(!BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
-
-		// get field
-		$field = BackendFormBuilderModel::getField($fieldId);
-
-		// submit button cannot be deleted
-		if($field['type'] == 'submit') $this->output(self::BAD_REQUEST, null, 'submit button cannot be deleted');
-
-		// delete
+		// validated form
 		else
 		{
-			// delete field
-			BackendFormBuilderModel::deleteField($fieldId);
-
-			// success output
-			$this->output(self::OK, null, 'field deleted');
+			// invalid fieldId
+			if(!BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
+			
+			// validated field
+			else
+			{
+				// get field
+				$field = BackendFormBuilderModel::getField($fieldId);
+		
+				// submit button cannot be deleted
+				if($field['type'] == 'submit') $this->output(self::BAD_REQUEST, null, 'submit button cannot be deleted');
+		
+				// delete
+				else
+				{
+					// delete field
+					BackendFormBuilderModel::deleteField($fieldId);
+		
+					// success output
+					$this->output(self::OK, null, 'field deleted');
+				}
+			}
 		}
 	}
 }

--- a/backend/modules/form_builder/ajax/get_field.php
+++ b/backend/modules/form_builder/ajax/get_field.php
@@ -27,14 +27,22 @@ class BackendFormBuilderAjaxGetField extends BackendBaseAJAXAction
 
 		// invalid form id
 		if(!BackendFormBuilderModel::exists($formId)) $this->output(self::BAD_REQUEST, null, 'form does not exist');
-
-		// invalid fieldId
-		if(!BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
-
-		// get field
-		$field = BackendFormBuilderModel::getField($fieldId);
-
-		// success output
-		$this->output(self::OK, array('field' => $field));
+		
+		// validated form
+		else
+		{
+			// invalid fieldId
+			if(!BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
+	
+			// validated field
+			else
+			{
+				// get field
+				$field = BackendFormBuilderModel::getField($fieldId);
+		
+				// success output
+				$this->output(self::OK, array('field' => $field));
+			}
+		}
 	}
 }

--- a/backend/modules/form_builder/ajax/save_field.php
+++ b/backend/modules/form_builder/ajax/save_field.php
@@ -37,164 +37,180 @@ class BackendFormBuilderAjaxSaveField extends BackendBaseAJAXAction
 		// invalid form id
 		if(!BackendFormBuilderModel::exists($formId)) $this->output(self::BAD_REQUEST, null, 'form does not exist');
 
-		// invalid fieldId
-		if($fieldId !== 0 && !BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
-
-		// invalid type
-		if($type == '') $this->output(self::BAD_REQUEST, null, 'invalid type provided');
-
-		// extra validation is only possible for textfields
-		if($type != 'textbox')
-		{
-			$validation = '';
-			$validationParameter = '';
-			$errorMessage = '';
-		}
-
-		// init
-		$errors = array();
-
-		// validate textbox
-		if($type == 'textbox')
-		{
-			if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
-			if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
-			if($validation != '' && $errorMessage == '') $errors['error_message'] = BL::getError('ErrorMessageIsRequired');
-		}
-
-		// validate textarea
-		elseif($type == 'textarea')
-		{
-			if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
-			if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
-			if($validation != '' && $errorMessage == '') $errors['error_message'] = BL::getError('ErrorMessageIsRequired');
-		}
-
-		// validate heading
-		elseif($type == 'heading' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
-
-		// validate paragraph
-		elseif($type == 'paragraph' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
-
-		// validate submit button
-		elseif($type == 'submit' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
-
-		// validate dropdown
-		elseif($type == 'dropdown')
-		{
-			// values trim
-			$values = trim($values, ',');
-
-			// validate
-			if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
-			if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
-			if($values == '') $errors['values'] = BL::getError('ValueIsRequired');
-		}
-
-		// validate radiobutton
-		elseif($type == 'radiobutton')
-		{
-			if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
-			if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
-			if($values == '') $errors['values'] = BL::getError('ValueIsRequired');
-		}
-
-		// validate checkbox
-		elseif($type == 'checkbox')
-		{
-			if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
-			if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
-		}
-
-		// got errors
-		if(!empty($errors)) $this->output(self::OK, array('errors' => $errors), 'form contains errors');
-
-		// htmlspecialchars except for paragraphs
-		if($type != 'paragraph')
-		{
-			if($values != '') $values = SpoonFilter::htmlspecialchars($values);
-			if($defaultValues != '') $defaultValues = SpoonFilter::htmlspecialchars($defaultValues);
-		}
-
-		// split
-		if($type == 'dropdown' || $type == 'radiobutton' || $type == 'checkbox') $values = (array) explode('|', $values);
-
-		/**
-		 * Save!
-		 */
-		// settings
-		$settings = array();
-		if($label != '') $settings['label'] = SpoonFilter::htmlspecialchars($label);
-		if($values != '') $settings['values'] = $values;
-		if($defaultValues != '') $settings['default_values'] = $defaultValues;
-
-		// build array
-		$field = array();
-		$field['form_id'] = $formId;
-		$field['type'] = $type;
-		$field['settings'] = (!empty($settings) ? serialize($settings) : null);
-
-		// existing field
-		if($fieldId !== 0)
-		{
-			// update field
-			BackendFormBuilderModel::updateField($fieldId, $field);
-
-			// delete all validation (added again later)
-			BackendFormBuilderModel::deleteFieldValidation($fieldId);
-		}
-
-		// create one
+		// validated form
 		else
 		{
-			// sequence
-			$field['sequence'] = BackendFormBuilderModel::getMaximumSequence($formId) + 1;
-
-			// insert
-			$fieldId = BackendFormBuilderModel::insertField($field);
+			// invalid fieldId
+			if($fieldId !== 0 && !BackendFormBuilderModel::existsField($fieldId, $formId)) $this->output(self::BAD_REQUEST, null, 'field does not exist');
+	
+			// validated field
+			else
+			{
+				// invalid type
+				if($type == '') $this->output(self::BAD_REQUEST, null, 'invalid type provided');
+				
+				// validated type
+				else
+				{
+					// extra validation is only possible for textfields
+					if($type != 'textbox')
+					{
+						$validation = '';
+						$validationParameter = '';
+						$errorMessage = '';
+					}
+			
+					// init
+					$errors = array();
+			
+					// validate textbox
+					if($type == 'textbox')
+					{
+						if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
+						if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
+						if($validation != '' && $errorMessage == '') $errors['error_message'] = BL::getError('ErrorMessageIsRequired');
+					}
+			
+					// validate textarea
+					elseif($type == 'textarea')
+					{
+						if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
+						if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
+						if($validation != '' && $errorMessage == '') $errors['error_message'] = BL::getError('ErrorMessageIsRequired');
+					}
+			
+					// validate heading
+					elseif($type == 'heading' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
+			
+					// validate paragraph
+					elseif($type == 'paragraph' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
+			
+					// validate submit button
+					elseif($type == 'submit' && $values == '') $errors['values'] = BL::getError('ValueIsRequired');
+			
+					// validate dropdown
+					elseif($type == 'dropdown')
+					{
+						// values trim
+						$values = trim($values, ',');
+			
+						// validate
+						if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
+						if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
+						if($values == '') $errors['values'] = BL::getError('ValueIsRequired');
+					}
+			
+					// validate radiobutton
+					elseif($type == 'radiobutton')
+					{
+						if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
+						if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
+						if($values == '') $errors['values'] = BL::getError('ValueIsRequired');
+					}
+			
+					// validate checkbox
+					elseif($type == 'checkbox')
+					{
+						if($label == '') $errors['label'] = BL::getError('LabelIsRequired');
+						if($required == 'Y' && $requiredErrorMessage == '') $errors['required_error_message'] = BL::getError('ErrorMessageIsRequired');
+					}
+			
+					// got errors
+					if(!empty($errors)) $this->output(self::OK, array('errors' => $errors), 'form contains errors');
+			
+					// no errors
+					else
+					{
+						// htmlspecialchars except for paragraphs
+						if($type != 'paragraph')
+						{
+							if($values != '') $values = SpoonFilter::htmlspecialchars($values);
+							if($defaultValues != '') $defaultValues = SpoonFilter::htmlspecialchars($defaultValues);
+						}
+				
+						// split
+						if($type == 'dropdown' || $type == 'radiobutton' || $type == 'checkbox') $values = (array) explode('|', $values);
+				
+						/**
+						 * Save!
+						 */
+						// settings
+						$settings = array();
+						if($label != '') $settings['label'] = SpoonFilter::htmlspecialchars($label);
+						if($values != '') $settings['values'] = $values;
+						if($defaultValues != '') $settings['default_values'] = $defaultValues;
+				
+						// build array
+						$field = array();
+						$field['form_id'] = $formId;
+						$field['type'] = $type;
+						$field['settings'] = (!empty($settings) ? serialize($settings) : null);
+				
+						// existing field
+						if($fieldId !== 0)
+						{
+							// update field
+							BackendFormBuilderModel::updateField($fieldId, $field);
+				
+							// delete all validation (added again later)
+							BackendFormBuilderModel::deleteFieldValidation($fieldId);
+						}
+				
+						// create one
+						else
+						{
+							// sequence
+							$field['sequence'] = BackendFormBuilderModel::getMaximumSequence($formId) + 1;
+				
+							// insert
+							$fieldId = BackendFormBuilderModel::insertField($field);
+						}
+				
+						// required
+						if($required == 'Y')
+						{
+							// build array
+							$validate['field_id'] = $fieldId;
+							$validate['type'] = 'required';
+							$validate['error_message'] = SpoonFilter::htmlspecialchars($requiredErrorMessage);
+				
+							// add validation
+							BackendFormBuilderModel::insertFieldValidation($validate);
+				
+							// add to field (for parsing)
+							$field['validations']['required'] = $validate;
+						}
+				
+						// other validation
+						if($validation != '')
+						{
+							// build array
+							$validate['field_id'] = $fieldId;
+							$validate['type'] = $validation;
+							$validate['error_message'] = SpoonFilter::htmlspecialchars($errorMessage);
+							$validate['parameter'] = ($validationParameter != '') ? SpoonFilter::htmlspecialchars($validationParameter) : null;
+				
+							// add validation
+							BackendFormBuilderModel::insertFieldValidation($validate);
+				
+							// add to field (for parsing)
+							$field['validations'][$type] = $validate;
+						}
+				
+						// get item from database (i do this call again to keep the points of failure as low as possible)
+						$field = BackendFormBuilderModel::getField($fieldId);
+				
+						// submit button isnt parsed but handled directly via javascript
+						if($type == 'submit') $fieldHTML = '';
+				
+						// parse field to html
+						else $fieldHTML = FormBuilderHelper::parseField($field);
+				
+						// success output
+						$this->output(self::OK, array('field_id' => $fieldId, 'field_html' => $fieldHTML), 'field saved');
+					}
+				}
+			}
 		}
-
-		// required
-		if($required == 'Y')
-		{
-			// build array
-			$validate['field_id'] = $fieldId;
-			$validate['type'] = 'required';
-			$validate['error_message'] = SpoonFilter::htmlspecialchars($requiredErrorMessage);
-
-			// add validation
-			BackendFormBuilderModel::insertFieldValidation($validate);
-
-			// add to field (for parsing)
-			$field['validations']['required'] = $validate;
-		}
-
-		// other validation
-		if($validation != '')
-		{
-			// build array
-			$validate['field_id'] = $fieldId;
-			$validate['type'] = $validation;
-			$validate['error_message'] = SpoonFilter::htmlspecialchars($errorMessage);
-			$validate['parameter'] = ($validationParameter != '') ? SpoonFilter::htmlspecialchars($validationParameter) : null;
-
-			// add validation
-			BackendFormBuilderModel::insertFieldValidation($validate);
-
-			// add to field (for parsing)
-			$field['validations'][$type] = $validate;
-		}
-
-		// get item from database (i do this call again to keep the points of failure as low as possible)
-		$field = BackendFormBuilderModel::getField($fieldId);
-
-		// submit button isnt parsed but handled directly via javascript
-		if($type == 'submit') $fieldHTML = '';
-
-		// parse field to html
-		else $fieldHTML = FormBuilderHelper::parseField($field);
-
-		// success output
-		$this->output(self::OK, array('field_id' => $fieldId, 'field_html' => $fieldHTML), 'field saved');
 	}
 }

--- a/backend/modules/form_builder/ajax/sequence.php
+++ b/backend/modules/form_builder/ajax/sequence.php
@@ -27,22 +27,26 @@ class BackendFormBuilderAjaxSequence extends BackendBaseAJAXAction
 
 		// invalid form id
 		if(!BackendFormBuilderModel::exists($formId)) $this->output(self::BAD_REQUEST, null, 'form does not exist');
-
-		// list id
-		$ids = (array) explode('|', rtrim($newIdSequence, '|'));
-
-		// loop id's and set new sequence
-		foreach($ids as $i => $id)
+		
+		// validated
+		else
 		{
-			$id = (int) $id;
-
-			// get field
-			$field = BackendFormBuilderModel::getField($id);
-
-			// from this form and not a submit button
-			if(!empty($field) && $field['form_id'] == $formId && $field['type'] != 'submit') BackendFormBuilderModel::updateField($id, array('sequence' => ($i + 1)));
+			// list id
+			$ids = (array) explode('|', rtrim($newIdSequence, '|'));
+	
+			// loop id's and set new sequence
+			foreach($ids as $i => $id)
+			{
+				$id = (int) $id;
+	
+				// get field
+				$field = BackendFormBuilderModel::getField($id);
+	
+				// from this form and not a submit button
+				if(!empty($field) && $field['form_id'] == $formId && $field['type'] != 'submit') BackendFormBuilderModel::updateField($id, array('sequence' => ($i + 1)));
+			}
+	
+			$this->output(self::OK, null, 'sequence updated');
 		}
-
-		$this->output(self::OK, null, 'sequence updated');
 	}
 }

--- a/backend/modules/location/ajax/update_marker.php
+++ b/backend/modules/location/ajax/update_marker.php
@@ -26,18 +26,24 @@ class BackendLocationAjaxUpdateMarker extends BackendBaseAJAXAction
 		$lat = SpoonFilter::getPostValue('lat', null, null, 'float');
 		$lng = SpoonFilter::getPostValue('lng', null, null, 'float');
 
+		// validate id
 		if($itemId == 0) $this->output(self::BAD_REQUEST, null, BL::err('NonExisting'));
 
-		$updateData = array(
-			'id' => $itemId,
-			'lat' => $lat,
-			'lng' => $lng,
-			'language' => BL::getWorkingLanguage()
-		);
-
-		BackendLocationModel::update($updateData);
-
-		// output
-		$this->output(self::OK);
+		// validated
+		else
+		{
+			//update
+			$updateData = array(
+				'id' => $itemId,
+				'lat' => $lat,
+				'lng' => $lng,
+				'language' => BL::getWorkingLanguage()
+			);
+	
+			BackendLocationModel::update($updateData);
+	
+			// output
+			$this->output(self::OK);
+		}
 	}
 }

--- a/backend/modules/mailmotor/ajax/edit_campaign.php
+++ b/backend/modules/mailmotor/ajax/edit_campaign.php
@@ -28,26 +28,34 @@ class BackendMailmotorAjaxEditCampaign extends BackendBaseAJAXAction
 		// validate
 		if($name == '') $this->output(self::BAD_REQUEST, null, 'no name provided');
 
-		// get existing id
-		$existingId = BackendMailmotorModel::getCampaignId($name);
-
-		// existing campaign
-		if($existingId !== 0 && $id !== $existingId) $this->output(self::ERROR, array('id' => $existingId, 'error' => true), BL::err('CampaignExists', $this->getModule()));
-
-		// build array
-		$item = array();
-		$item['id'] = $id;
-		$item['name'] = $name;
-		$item['created_on'] = BackendModel::getUTCDate('Y-m-d H:i:s');
-
-		// get page
-		$rows = BackendMailmotorModel::updateCampaign($item);
-
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'edited_campaign', array('item' => $item));
-
-		// output
-		if($rows !== 0) $this->output(self::OK, array('id' => $id), BL::msg('CampaignEdited', $this->getModule()));
-		else $this->output(self::ERROR, null, BL::err('CampaignNotEdited', $this->getModule()));
+		// validated
+		else
+		{
+			// get existing id
+			$existingId = BackendMailmotorModel::getCampaignId($name);
+	
+			// validate
+			if($existingId !== 0 && $id !== $existingId) $this->output(self::ERROR, array('id' => $existingId, 'error' => true), BL::err('CampaignExists', $this->getModule()));
+			
+			// existing campaign
+			else
+			{
+				// build array
+				$item = array();
+				$item['id'] = $id;
+				$item['name'] = $name;
+				$item['created_on'] = BackendModel::getUTCDate('Y-m-d H:i:s');
+		
+				// get page
+				$rows = BackendMailmotorModel::updateCampaign($item);
+		
+				// trigger event
+				BackendModel::triggerEvent($this->getModule(), 'edited_campaign', array('item' => $item));
+		
+				// output
+				if($rows !== 0) $this->output(self::OK, array('id' => $id), BL::msg('CampaignEdited', $this->getModule()));
+				else $this->output(self::ERROR, null, BL::err('CampaignNotEdited', $this->getModule()));
+			}
+		}
 	}
 }

--- a/backend/modules/mailmotor/ajax/link_account.php
+++ b/backend/modules/mailmotor/ajax/link_account.php
@@ -30,48 +30,59 @@ class BackendMailmotorAjaxLinkAccount extends BackendBaseAJAXAction
 		if(strpos($url, 'http://') !== false) $url = str_replace('http://', '', $url);
 		if(strpos($url, 'https://') !== false) $url = str_replace('https://', '', $url);
 
-		// check input
-		if(empty($url)) $this->output(self::BAD_REQUEST, array('field' => 'url'), BL::err('NoCMAccountCredentials'));
-		if(empty($username)) $this->output(self::BAD_REQUEST, array('field' => 'username'), BL::err('NoCMAccountCredentials'));
-		if(empty($password)) $this->output(self::BAD_REQUEST, array('field' => 'password'), BL::err('NoCMAccountCredentials'));
-
-		try
+		// init validation
+		$errors = array();
+		
+		// validate input
+		if(empty($url)) $errors['url'] = BL::err('NoCMAccountCredentials');
+		if(empty($username)) $errors['username'] = BL::err('NoCMAccountCredentials');
+		if(empty($password)) $errors['password'] = BL::err('NoCMAccountCredentials');
+		
+		// got errors
+		if(!empty($errors)) $this->output(self::OK, array('errors' => $errors), 'form contains errors');
+		
+		// all fiels are filled
+		else
 		{
-			// check if the CampaignMonitor class exists
-			if(!SpoonFile::exists(PATH_LIBRARY . '/external/campaignmonitor.php'))
+			try
 			{
-				// the class doesn't exist, so stop here
-				$this->output(self::BAD_REQUEST, null, BL::err('ClassDoesNotExist', $this->getModule()));
+				// check if the CampaignMonitor class exists
+				if(!SpoonFile::exists(PATH_LIBRARY . '/external/campaignmonitor.php')) throw new Exception(BL::err('ClassDoesNotExist'));
+	
+				// require CampaignMonitor class
+				require_once PATH_LIBRARY . '/external/campaignmonitor.php';
+	
+				// init CampaignMonitor object
+				new CampaignMonitor($url, $username, $password, 10);
+	
+				// save the new data
+				BackendModel::setModuleSetting($this->getModule(), 'cm_url', $url);
+				BackendModel::setModuleSetting($this->getModule(), 'cm_username', $username);
+				BackendModel::setModuleSetting($this->getModule(), 'cm_password', $password);
+	
+				// account was linked
+				BackendModel::setModuleSetting($this->getModule(), 'cm_account', true);
 			}
-
-			// require CampaignMonitor class
-			require_once PATH_LIBRARY . '/external/campaignmonitor.php';
-
-			// init CampaignMonitor object
-			new CampaignMonitor($url, $username, $password, 10);
-
-			// save the new data
-			BackendModel::setModuleSetting($this->getModule(), 'cm_url', $url);
-			BackendModel::setModuleSetting($this->getModule(), 'cm_username', $username);
-			BackendModel::setModuleSetting($this->getModule(), 'cm_password', $password);
-
-			// account was linked
-			BackendModel::setModuleSetting($this->getModule(), 'cm_account', true);
+	
+			catch(Exception $e)
+			{
+				// timeout occurred
+				if($e->getMessage() == 'Error Fetching http headers')
+				{
+					$this->output(self::BAD_REQUEST, null, BL::err('CmTimeout', $this->getModule()));
+					return;
+				}
+	
+				// other error
+				$this->output(self::ERROR, array('field' => 'url'), sprintf(BL::err('CampaignMonitorError', $this->getModule()), $e->getMessage()));
+				return;
+			}
+	
+			// trigger event
+			BackendModel::triggerEvent($this->getModule(), 'after_account_linked');
+	
+			// CM was successfully initialized
+			$this->output(self::OK, array('message' => 'account-linked'), BL::msg('AccountLinked', $this->getModule()));
 		}
-
-		catch(Exception $e)
-		{
-			// timeout occurred
-			if($e->getMessage() == 'Error Fetching http headers') $this->output(self::BAD_REQUEST, null, BL::err('CmTimeout', $this->getModule()));
-
-			// other error
-			$this->output(self::ERROR, array('field' => 'url'), sprintf(BL::err('CampaignMonitorError', $this->getModule()), $e->getMessage()));
-		}
-
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_account_linked');
-
-		// CM was successfully initialized
-		$this->output(self::OK, array('message' => 'account-linked'), BL::msg('AccountLinked', $this->getModule()));
 	}
 }

--- a/backend/modules/mailmotor/ajax/load_client_info.php
+++ b/backend/modules/mailmotor/ajax/load_client_info.php
@@ -26,11 +26,15 @@ class BackendMailmotorAjaxLoadClientInfo extends BackendBaseAJAXAction
 
 		// check input
 		if(empty($clientId)) $this->output(self::BAD_REQUEST);
-
-		// get basic details for this client
-		$client = BackendMailmotorCMHelper::getCM()->getClient($clientId);
-
-		// CM was successfully initialized
-		$this->output(self::OK, $client);
+		
+		// validated
+		else
+		{
+			// get basic details for this client
+			$client = BackendMailmotorCMHelper::getCM()->getClient($clientId);
+	
+			// CM was successfully initialized
+			$this->output(self::OK, $client);
+		}
 	}
 }

--- a/backend/modules/mailmotor/ajax/save_content.php
+++ b/backend/modules/mailmotor/ajax/save_content.php
@@ -35,107 +35,100 @@ class BackendMailmotorAjaxSaveContent extends BackendBaseAJAXAction
 		$contentPlain = SpoonFilter::getPostValue('content_plain', null, '');
 
 		// validate mailing ID
-		if($mailingId == '')
+		if($mailingId == '') $this->output(self::BAD_REQUEST, null, 'No mailing ID provided');
+		
+		// validated mailing ID
+		else
 		{
-			$this->output(self::BAD_REQUEST, null, 'No mailing ID provided');
-		}
-
-		// get mailing record
-		$this->mailing = BackendMailmotorModel::getMailing($mailingId);
-
-		// record is empty
-		if(empty($this->mailing))
-		{
-			$this->output(
-				self::BAD_REQUEST,
-				null,
-				BL::err('MailingDoesNotExist', $this->getModule())
-			);
-		}
-
-		// validate other fields
-		if($subject == '')
-		{
-			$this->output(
-				900,
-				array(
-					'element' => 'subject',
-					'element_error' => BL::err('NoSubject', $this->getModule())
-				),
-				BL::err('FormError')
-			);
-		}
-
-		// set plain content
-		$contentPlain = empty($contentPlain) ? SpoonFilter::stripHTML($contentHTML) : $contentPlain;
-
-		// add unsubscribe link
-		if(mb_strpos($contentPlain, '[unsubscribe]') === false)
-		{
-			$contentPlain .= PHP_EOL . '[unsubscribe]';
-		}
-
-		// build data
-		$item['id'] = $this->mailing['id'];
-		$item['subject'] = $subject;
-		$item['content_plain'] = $contentPlain;
-		$item['content_html'] = $contentHTML;
-		$item['edited_on'] = date('Y-m-d H:i:s');
-
-		// update mailing in our database
-		BackendMailmotorModel::updateMailing($item);
-
-		/*
-			we should insert the draft into campaignmonitor here,
-			so we can use sendCampaignPreview in step 4.
-		*/
-		$item['groups'] = $this->mailing['groups'];
-		$item['name'] = $this->mailing['name'];
-		$item['from_name'] = $this->mailing['from_name'];
-		$item['from_email'] = $this->mailing['from_email'];
-		$item['reply_to_email'] = $this->mailing['reply_to_email'];
-
-		try
-		{
-			BackendMailmotorCMHelper::saveMailingDraft($item);
-		}
-		catch(Exception $e)
-		{
-			// CM did not receive a valid URL
-			if(strpos($e->getMessage(), 'HTML Content URL Required'))
-			{
-				$message = BL::err('HTMLContentURLRequired', $this->getModule());
-			}
-
-			// no payment details were set for the CM client yet
-			elseif(strpos($e->getMessage(), 'Payment details required'))
-			{
-				$error = BL::err('PaymentDetailsRequired', $this->getModule());
-				$cmUsername = BackendModel::getModuleSetting($this->getModule(), 'cm_username');
-				$message = sprintf($error, $cmUsername);
-			}
-
-			// the campaign name already exists in CM
-			elseif(strpos($e->getMessage(), 'Duplicate Campaign Name'))
-			{
-				$message = BL::err('DuplicateCampaignName', $this->getModule());
-			}
-
-			// we received an unknown error
+			// get mailing record
+			$this->mailing = BackendMailmotorModel::getMailing($mailingId);
+	
+			// check if record is empty
+			if(empty($this->mailing)) $this->output(self::BAD_REQUEST, null, BL::err('MailingDoesNotExist', $this->getModule()));
+			
+			// record is filled
 			else
 			{
-				$message = $e->getMessage();
+				// validate subject
+				if($subject == '') $this->output(900, array('element' => 'subject', 'element_error' => BL::err('NoSubject', $this->getModule())), BL::err('FormError'));
+		
+				// validated subject
+				else
+				{
+					// set plain content
+					$contentPlain = empty($contentPlain) ? SpoonFilter::stripHTML($contentHTML) : $contentPlain;
+			
+					// add unsubscribe link
+					if(mb_strpos($contentPlain, '[unsubscribe]') === false)
+					{
+						$contentPlain .= PHP_EOL . '[unsubscribe]';
+					}
+			
+					// build data
+					$item['id'] = $this->mailing['id'];
+					$item['subject'] = $subject;
+					$item['content_plain'] = $contentPlain;
+					$item['content_html'] = $contentHTML;
+					$item['edited_on'] = date('Y-m-d H:i:s');
+			
+					// update mailing in our database
+					BackendMailmotorModel::updateMailing($item);
+			
+					/*
+						we should insert the draft into campaignmonitor here,
+						so we can use sendCampaignPreview in step 4.
+					*/
+					$item['groups'] = $this->mailing['groups'];
+					$item['name'] = $this->mailing['name'];
+					$item['from_name'] = $this->mailing['from_name'];
+					$item['from_email'] = $this->mailing['from_email'];
+					$item['reply_to_email'] = $this->mailing['reply_to_email'];
+			
+					try
+					{
+						BackendMailmotorCMHelper::saveMailingDraft($item);
+					}
+					catch(Exception $e)
+					{
+						// CM did not receive a valid URL
+						if(strpos($e->getMessage(), 'HTML Content URL Required'))
+						{
+							$message = BL::err('HTMLContentURLRequired', $this->getModule());
+						}
+			
+						// no payment details were set for the CM client yet
+						elseif(strpos($e->getMessage(), 'Payment details required'))
+						{
+							$error = BL::err('PaymentDetailsRequired', $this->getModule());
+							$cmUsername = BackendModel::getModuleSetting($this->getModule(), 'cm_username');
+							$message = sprintf($error, $cmUsername);
+						}
+			
+						// the campaign name already exists in CM
+						elseif(strpos($e->getMessage(), 'Duplicate Campaign Name'))
+						{
+							$message = BL::err('DuplicateCampaignName', $this->getModule());
+						}
+			
+						// we received an unknown error
+						else
+						{
+							$message = $e->getMessage();
+						}
+			
+						// stop the script and show our error
+						$this->output(902, null, $message);
+						return;
+					}
+			
+					// trigger event
+					BackendModel::triggerEvent($this->getModule(), 'after_edit_mailing_step3', array('item' => $item));
+			
+					// output
+					$this->output(self::OK, array('mailing_id' => $mailingId), BL::msg('MailingEdited', $this->getModule()));
+				}
 			}
-
-			// stop the script and show our error
-			$this->output(902, null, $message);
 		}
-
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_edit_mailing_step3', array('item' => $item));
-
-		// output
-		$this->output(self::OK, array('mailing_id' => $mailingId), BL::msg('MailingEdited', $this->getModule()));
 	}
 
 	/**

--- a/backend/modules/mailmotor/ajax/save_send_date.php
+++ b/backend/modules/mailmotor/ajax/save_send_date.php
@@ -29,30 +29,44 @@ class BackendMailmotorAjaxSaveSendDate extends BackendBaseAJAXAction
 
 		// validate mailing ID
 		if($mailingId == '') $this->output(self::BAD_REQUEST, null, 'Provide a valid mailing ID');
-		if($sendOnDate == '' || $sendOnTime == '') $this->output(self::BAD_REQUEST, null, 'Provide a valid send date date provided');
-
-		// record is empty
-		if(!BackendMailmotorModel::existsMailing($mailingId)) $this->output(self::BAD_REQUEST, null, BL::err('MailingDoesNotExist', 'mailmotor'));
-
-		// reverse the date and make it a proper
-		$explodedDate = explode('/', $sendOnDate);
-		$sendOnDate = $explodedDate[2] . '-' . $explodedDate[1] . '-' . $explodedDate[0];
-
-		// calc full send timestamp
-		$sendTimestamp = strtotime($sendOnDate . ' ' . $sendOnTime);
-
-		// build data
-		$item['id'] = $mailingId;
-		$item['send_on'] = BackendModel::getUTCDate('Y-m-d H:i:s', $sendTimestamp);
-		$item['edited_on'] = BackendModel::getUTCDate('Y-m-d H:i:s');
-
-		// update mailing
-		BackendMailmotorModel::updateMailing($item);
-
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_edit_mailing_step4', array('item' => $item));
-
-		// output
-		$this->output(self::OK, array('mailing_id' => $mailingId, 'timestamp' => $sendTimestamp), sprintf(BL::msg('SendOn', $this->getModule()), $messageDate, $sendOnTime));
+		
+		// validated mailing ID
+		else
+		{
+			// validate date & time
+			if($sendOnDate == '' || $sendOnTime == '') $this->output(self::BAD_REQUEST, null, 'Provide a valid send date date provided');
+			
+			// validated date & time
+			else
+			{
+				// record is empty
+				if(!BackendMailmotorModel::existsMailing($mailingId)) $this->output(self::BAD_REQUEST, null, BL::err('MailingDoesNotExist', 'mailmotor'));
+		
+				// record is filled
+				else
+				{
+					// reverse the date and make it a proper
+					$explodedDate = explode('/', $sendOnDate);
+					$sendOnDate = $explodedDate[2] . '-' . $explodedDate[1] . '-' . $explodedDate[0];
+			
+					// calc full send timestamp
+					$sendTimestamp = strtotime($sendOnDate . ' ' . $sendOnTime);
+			
+					// build data
+					$item['id'] = $mailingId;
+					$item['send_on'] = BackendModel::getUTCDate('Y-m-d H:i:s', $sendTimestamp);
+					$item['edited_on'] = BackendModel::getUTCDate('Y-m-d H:i:s');
+			
+					// update mailing
+					BackendMailmotorModel::updateMailing($item);
+			
+					// trigger event
+					BackendModel::triggerEvent($this->getModule(), 'after_edit_mailing_step4', array('item' => $item));
+			
+					// output
+					$this->output(self::OK, array('mailing_id' => $mailingId, 'timestamp' => $sendTimestamp), sprintf(BL::msg('SendOn', $this->getModule()), $messageDate, $sendOnTime));
+				}
+			}
+		}
 	}
 }

--- a/backend/modules/mailmotor/ajax/send_mailing.php
+++ b/backend/modules/mailmotor/ajax/send_mailing.php
@@ -27,44 +27,53 @@ class BackendMailmotorAjaxSendMailing extends BackendBaseAJAXAction
 		// validate
 		if($id == '' || !BackendMailmotorModel::existsMailing($id)) $this->output(self::BAD_REQUEST, null, 'No mailing found.');
 
-		// get mailing record
-		$mailing = BackendMailmotorModel::getMailing($id);
-
-		/*
-			mailing was already sent
-			We use a custom status code 900 because we want to do more with JS than triggering an error
-		*/
-		if($mailing['status'] == 'sent') $this->output(900, null, BL::err('MailingAlreadySent', $this->getModule()));
-
-		// make a regular date out of the send_on timestamp
-		$mailing['delivery_date'] = date('Y-m-d H:i:s', $mailing['send_on']);
-
-		// send the mailing
-		try
+		// validated
+		else
 		{
-			// only update the mailing if it was queued
-			if($mailing['status'] == 'queued') BackendMailmotorCMHelper::updateMailing($mailing);
-
-			// send the mailing if it wasn't queued
-			else BackendMailmotorCMHelper::sendMailing($mailing);
+			// get mailing record
+			$mailing = BackendMailmotorModel::getMailing($id);
+	
+			/*
+				mailing was already sent
+				We use a custom status code 900 because we want to do more with JS than triggering an error
+			*/
+			if($mailing['status'] == 'sent') $this->output(900, null, BL::err('MailingAlreadySent', $this->getModule()));
+			
+			// validated mailing
+			else
+			{
+				// make a regular date out of the send_on timestamp
+				$mailing['delivery_date'] = date('Y-m-d H:i:s', $mailing['send_on']);
+		
+				// send the mailing
+				try
+				{
+					// only update the mailing if it was queued
+					if($mailing['status'] == 'queued') BackendMailmotorCMHelper::updateMailing($mailing);
+		
+					// send the mailing if it wasn't queued
+					else BackendMailmotorCMHelper::sendMailing($mailing);
+				}
+				catch(Exception $e)
+				{
+					// stop the script and show our error
+					$this->output(902, null, $e->getMessage());
+					return:
+				}
+		
+				// set status to 'sent'
+				$item['id'] = $id;
+				$item['status'] = ($mailing['send_on'] > time()) ? 'queued' : 'sent';
+		
+				// update the mailing record
+				BackendMailmotorModel::updateMailing($item);
+		
+				// trigger event
+				BackendModel::triggerEvent($this->getModule(), 'after_mailing_status_' . $item['status'], array('item' => $item));
+		
+				// we made it \o/
+				$this->output(self::OK, array('mailing_id' => $item['id']), BL::msg('MailingSent', $this->getModule()));
+			}
 		}
-		catch(Exception $e)
-		{
-			// stop the script and show our error
-			$this->output(902, null, $e->getMessage());
-		}
-
-		// set status to 'sent'
-		$item['id'] = $id;
-		$item['status'] = ($mailing['send_on'] > time()) ? 'queued' : 'sent';
-
-		// update the mailing record
-		BackendMailmotorModel::updateMailing($item);
-
-		// trigger event
-		BackendModel::triggerEvent($this->getModule(), 'after_mailing_status_' . $item['status'], array('item' => $item));
-
-		// we made it \o/
-		$this->output(self::OK, array('mailing_id' => $item['id']), BL::msg('MailingSent', $this->getModule()));
 	}
 }

--- a/backend/modules/pages/ajax/get_info.php
+++ b/backend/modules/pages/ajax/get_info.php
@@ -28,10 +28,14 @@ class BackendPagesAjaxGetInfo extends BackendBaseAJAXAction
 		// validate
 		if($id === 0) $this->output(self::BAD_REQUEST, null, 'no id provided');
 
-		// get page
-		$page = BackendPagesModel::get($id);
-
-		// output
-		$this->output(self::OK, $page);
+		// validated
+		else
+		{
+			// get page
+			$page = BackendPagesModel::get($id);
+	
+			// output
+			$this->output(self::OK, $page);
+		}
 	}
 }

--- a/backend/modules/pages/ajax/move.php
+++ b/backend/modules/pages/ajax/move.php
@@ -28,20 +28,30 @@ class BackendPagesAjaxMove extends BackendBaseAJAXAction
 		$typeOfDrop = SpoonFilter::getPostValue('type', null, '');
 		$tree = SpoonFilter::getPostValue('tree', array('main', 'meta', 'footer', 'root'), '');
 
+		// init validation
+		$errors = array();
+
 		// validate
-		if($id === 0) $this->output(self::BAD_REQUEST, null, 'no id provided');
-		if($droppedOn === -1) $this->output(self::BAD_REQUEST, null, 'no dropped_on provided');
-		if($typeOfDrop == '') $this->output(self::BAD_REQUEST, null, 'no type provided');
-		if($tree == '') $this->output(self::BAD_REQUEST, null, 'no tree provided');
-
-		// get page
-		$success = BackendPagesModel::move($id, $droppedOn, $typeOfDrop, $tree);
-
-		// build cache
-		BackendPagesModel::buildCache(BL::getWorkingLanguage());
-
-		// output
-		if($success) $this->output(self::OK, BackendPagesModel::get($id), 'page moved');
-		else $this->output(self::ERROR, null, 'page not moved');
+		if($id === 0) $errors[] = 'no id provided';
+		if($droppedOn === -1) $errors[] = 'no dropped_on provided';
+		if($typeOfDrop == '') $errors[] = 'no type provided';
+		if($tree == '') $errors[] = 'no tree provided';
+		
+		// got errors
+		if(!empty($errors)) $this->output(self::BAD_REQUEST, array('errors' => $errors), 'not all fields were filled');
+		
+		// validated
+		else
+		{
+			// get page
+			$success = BackendPagesModel::move($id, $droppedOn, $typeOfDrop, $tree);
+	
+			// build cache
+			BackendPagesModel::buildCache(BL::getWorkingLanguage());
+	
+			// output
+			if($success) $this->output(self::OK, BackendPagesModel::get($id), 'page moved');
+			else $this->output(self::ERROR, null, 'page not moved');
+		}
 	}
 }

--- a/backend/modules/tags/ajax/autocomplete.php
+++ b/backend/modules/tags/ajax/autocomplete.php
@@ -28,10 +28,14 @@ class BackendTagsAjaxAutocomplete extends BackendBaseAJAXAction
 		// validate
 		if($term == '') $this->output(self::BAD_REQUEST, null, 'term-parameter is missing.');
 
-		// get tags
-		$tags = BackendTagsModel::getStartsWith($term);
-
-		// output
-		$this->output(self::OK, $tags);
+		// validated
+		else
+		{
+			// get tags
+			$tags = BackendTagsModel::getStartsWith($term);
+	
+			// output
+			$this->output(self::OK, $tags);
+		}
 	}
 }

--- a/backend/modules/tags/ajax/edit.php
+++ b/backend/modules/tags/ajax/edit.php
@@ -25,22 +25,36 @@ class BackendTagsAjaxEdit extends BackendBaseAJAXAction
 		$id = SpoonFilter::getPostValue('id', null, 0, 'int');
 		$tag = trim(SpoonFilter::getPostValue('value', null, '', 'string'));
 
-		// validate
+		// validate id
 		if($id === 0) $this->output(self::BAD_REQUEST, null, 'no id provided');
-		if($tag === '') $this->output(self::BAD_REQUEST, null, BL::err('NameIsRequired'));
-
-		// check if tag exists
-		if(BackendTagsModel::existsTag($tag)) $this->output(self::BAD_REQUEST, null, BL::err('TagAlreadyExists'));
-
-		// build array
-		$item['id'] = $id;
-		$item['tag'] = SpoonFilter::htmlspecialchars($tag);
-		$item['url'] = BackendTagsModel::getURL(SpoonFilter::urlise(SpoonFilter::htmlspecialcharsDecode($item['tag'])), $id);
-
-		// update
-		BackendTagsModel::update($item);
-
-		// output
-		$this->output(self::OK, $item, vsprintf(BL::msg('Edited'), array($item['tag'])));
+		
+		// validated id
+		else
+		{
+			// validate tag name
+			if($tag === '') $this->output(self::BAD_REQUEST, null, BL::err('NameIsRequired'));
+			
+			// validated tag name
+			else
+			{
+				// check if tag exists
+				if(BackendTagsModel::existsTag($tag)) $this->output(self::BAD_REQUEST, null, BL::err('TagAlreadyExists'));
+		
+				// tags doesn't exists yet
+				else
+				{
+					// build array
+					$item['id'] = $id;
+					$item['tag'] = SpoonFilter::htmlspecialchars($tag);
+					$item['url'] = BackendTagsModel::getURL(SpoonFilter::urlise(SpoonFilter::htmlspecialcharsDecode($item['tag'])), $id);
+			
+					// update
+					BackendTagsModel::update($item);
+			
+					// output
+					$this->output(self::OK, $item, vsprintf(BL::msg('Edited'), array($item['tag'])));
+				}
+			}
+		}
 	}
 }

--- a/frontend/modules/search/ajax/autocomplete.php
+++ b/frontend/modules/search/ajax/autocomplete.php
@@ -30,16 +30,20 @@ class FrontendSearchAjaxAutocomplete extends FrontendBaseAJAXAction
 		// validate
 		if($term == '') $this->output(self::BAD_REQUEST, null, 'term-parameter is missing.');
 
-		// get matches
-		$matches = FrontendSearchModel::getStartsWith($term, FRONTEND_LANGUAGE, $limit);
-
-		// get search url
-		$url = FrontendNavigation::getURLForBlock('search');
-
-		// loop items and set search url
-		foreach($matches as &$match) $match['url'] = $url . '?form=search&q=' . $match['term'];
-
-		// output
-		$this->output(self::OK, $matches);
+		// validated
+		else
+		{
+			// get matches
+			$matches = FrontendSearchModel::getStartsWith($term, FRONTEND_LANGUAGE, $limit);
+	
+			// get search url
+			$url = FrontendNavigation::getURLForBlock('search');
+	
+			// loop items and set search url
+			foreach($matches as &$match) $match['url'] = $url . '?form=search&q=' . $match['term'];
+	
+			// output
+			$this->output(self::OK, $matches);
+		}
 	}
 }

--- a/frontend/modules/search/ajax/save.php
+++ b/frontend/modules/search/ajax/save.php
@@ -25,32 +25,36 @@ class FrontendSearchAjaxSave extends FrontendBaseAJAXAction
 		$searchTerm = SpoonFilter::getPostValue('term', null, '');
 		$term = (SPOON_CHARSET == 'utf-8') ? SpoonFilter::htmlspecialchars($searchTerm) : SpoonFilter::htmlentities($searchTerm);
 
-		// validate
+		// validate search term
 		if($term == '') $this->output(self::BAD_REQUEST, null, 'term-parameter is missing.');
 
-		// previous search result
-		$previousTerm = SpoonSession::exists('searchTerm') ? SpoonSession::get('searchTerm') : '';
-		SpoonSession::set('searchTerm', '');
-
-		// save this term?
-		if($previousTerm != $term)
+		// validated search term
+		else
 		{
-			// format data
-			$this->statistics = array();
-			$this->statistics['term'] = $term;
-			$this->statistics['language'] = FRONTEND_LANGUAGE;
-			$this->statistics['time'] = FrontendModel::getUTCDate();
-			$this->statistics['data'] = serialize(array('server' => $_SERVER));
-			$this->statistics['num_results'] = FrontendSearchModel::getTotal($term);
-
-			// save data
-			FrontendSearchModel::save($this->statistics);
+			// previous search result
+			$previousTerm = SpoonSession::exists('searchTerm') ? SpoonSession::get('searchTerm') : '';
+			SpoonSession::set('searchTerm', '');
+	
+			// save this term?
+			if($previousTerm != $term)
+			{
+				// format data
+				$this->statistics = array();
+				$this->statistics['term'] = $term;
+				$this->statistics['language'] = FRONTEND_LANGUAGE;
+				$this->statistics['time'] = FrontendModel::getUTCDate();
+				$this->statistics['data'] = serialize(array('server' => $_SERVER));
+				$this->statistics['num_results'] = FrontendSearchModel::getTotal($term);
+	
+				// save data
+				FrontendSearchModel::save($this->statistics);
+			}
+	
+			// save current search term in cookie
+			SpoonSession::set('searchTerm', $term);
+	
+			// output
+			$this->output(self::OK);
 		}
-
-		// save current search term in cookie
-		SpoonSession::set('searchTerm', $term);
-
-		// output
-		$this->output(self::OK);
 	}
 }


### PR DESCRIPTION
Before 3.5 the output function for Ajax actions did an `exit;`. Now we have to make sure that if the output function is used, it is the last line that will be executed in that function.

E.g. for the validation of adding a Category; If the validation fails, the insert function may not be executed. (duh)
- Most of the time for a BAD_REQUEST I used an `if ... else ...` (See check_status.php from the analytics module)
- If it would become too nested I made an errors array. (See link_account.php from the mailmotor settings)
- If a catch block was used in the middle of a function I used `return;` to prevent executing the additional lines. (See test_email_connection.php:61 from the settings module)

This should fix 23 small bugs, like the validation of adding fields in formbuilder etc.
