### PR TITLE
Stop code execution after a redirect.

### DIFF
--- a/backend/core/engine/base.php
+++ b/backend/core/engine/base.php
@@ -329,6 +329,13 @@ class BackendBaseAction extends BackendBaseObject
 		 * response directly after creating.
 		 */
 		$response->send();
+
+		/*
+		 * Stop code executing here
+		 * I know this is ugly as hell, but if we don't do this the code after
+		 * this call is executed and possibly will trigger errors.
+		 */
+		exit;
 	}
 }
 

--- a/frontend/core/engine/base.php
+++ b/frontend/core/engine/base.php
@@ -636,6 +636,13 @@ class FrontendBaseBlock extends FrontendBaseObject
 		 * response directly after creating.
 		 */
 		$response->send();
+
+		/*
+		 * Stop code executing here
+		 * I know this is ugly as hell, but if we don't do this the code after
+		 * this call is executed and possibly will trigger errors.
+		 */
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
I know this is ugly as hell, but if we don't do this the code after
this call is executed and possibly will trigger errors.

This should fix https://github.com/forkcms/forkcms/issues/444
