### PR TITLE
.htaccess file check added

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,7 @@ if(
 	// check .htaccess
 	if(!file_exists('.htaccess') && !isset($_GET['skiphtaccess']))
 	{
-		echo 'Your install is missing the .htaccess file. Make sure you show hidden files while uploading Fork CMS. <a href="?skiphtaccess">Skip .htaccess check</a>';
+		echo 'Your install is missing the .htaccess file. Make sure you show hidden files while uploading Fork CMS. Read the article about <a href="http://www.fork-cms.com/community/documentation/detail/installation/webservers">webservers</a> for further information. <a href="?skiphtaccess">Skip .htaccess check</a>';
 		exit;
 	}
 


### PR DESCRIPTION
Like stated in a previous pull request one of the biggest issues while installing Fork is that the .htaccess file doesn't get uploaded, which breaks the url rewriting. When this happens, the user goes to his url and gets redirected to install/ and everything breaks.

This is a check if the .htaccess file exists in the index.php. I implemented a skip for who didn't upload the file on purpose because they use an alternative webserver.
