### PR TITLE
don't replace the content of an editor by default when adding a snippet

### DIFF
--- a/backend/core/js/backend.js
+++ b/backend/core/js/backend.js
@@ -246,6 +246,7 @@ jsBackend.ckeditor =
 
 		// templates
 		templates_files: [],
+		templates_replaceContent: false,
 
 		// custom vars
 		editorType: 'default',


### PR DESCRIPTION
People keep overwriting their content when adding a template. This shouldn't be the default behaviour
