### PR TITLE
FIX: Form token usage in form builder.

### DIFF
--- a/frontend/modules/form_builder/layout/widgets/form.tpl
+++ b/frontend/modules/form_builder/layout/widgets/form.tpl
@@ -7,7 +7,11 @@
 			{option:formBuilderError}<div class="message error"><p>{$formBuilderError}</p></div>{/option:formBuilderError}
 
 			{option:fields}
-				<form id="{$formName}" method="post" action="{$formAction}">
+				<form {option:hidUtf8}accept-charset="UTF-8" {/option:hidUtf8}id="{$formName}" method="post" action="{$formAction}">
+					{option:formToken}
+						<input type="hidden" name="form_token" id="formToken{$formName|ucfirst}" value="{$formToken}" />
+					{/option:formToken}
+
 					<input type="hidden" name="form" value="{$formName}" />
 
 					{iteration:fields}

--- a/frontend/modules/form_builder/widgets/form.php
+++ b/frontend/modules/form_builder/widgets/form.php
@@ -299,6 +299,7 @@ class FrontendFormBuilderWidgetForm extends FrontendBaseWidget
 
 			// parse form
 			$this->frm->parse($this->tpl);
+			$this->tpl->assign('formToken', $this->frm->getToken());
 
 			// assign form error
 			$this->tpl->assign('error', ($this->frm->getErrors() != '' ? $this->frm->getErrors() : false));


### PR DESCRIPTION
When submitting a form with the form builder, this results in a
"something went wrong"; this is because the form generates a form token,
but since the form is built manually in the template, not taking
form_token into account, this results in a mismatch between the form
token in the session and that coming in from the form (that is to say;
none is coming in from the form).

Unfortunately, we cannot resolve to using {form:{$formName}} because
SpoonTemplate does not parse this correctly, so we built it manually
again in the template.

A better solution might be to fix SpoonTemplate so that it parses
{form:{$formName}} correctly, but I'd rather not touch external
dependencies and fork code in 1 change.

"accept-charset" when dealing with UTF8 was also broken, this changeset
fixes that too.

Closes #533
