### PR TITLE
Use one label instead of a separate label for each word

### DIFF
--- a/frontend/modules/faq/layout/templates/detail.tpl
+++ b/frontend/modules/faq/layout/templates/detail.tpl
@@ -12,7 +12,7 @@
 				<ul>
 					<li>
 						{* Category*}
-						{$lblIn|ucfirst} {$lblThe} {$lblCategory} <a href="{$item.category_full_url}" title="{$item.category_title}">{$item.category_title}</a>
+						{$lblInTheCategory|ucfirst} <a href="{$item.category_full_url}" title="{$item.category_title}">{$item.category_title}</a>
                         {option:!item.tags}.{/option:!item.tags}
 
 						{* Tags*}


### PR DESCRIPTION
Use `{$lblInTheCategory}` instead of `{$lblIn} {$lblThe} {$lblCategory}`. Using separate words can give bad translations in different languages.
For example, in french `the` can be `le` or `la`.
