### PR TITLE
Exception when creating a new location

### DIFF
--- a/backend/modules/location/engine/model.php
+++ b/backend/modules/location/engine/model.php
@@ -144,6 +144,7 @@ class BackendLocationModel
 	{
 		$db = BackendModel::getContainer()->get('database');
 		$item['created_on'] = BackendModel::getUTCDate();
+		$item['edited_on'] = BackendModel::getUTCDate();
 
 		// build extra
 		$extra = array(


### PR DESCRIPTION
When I try to create a new location I get the following exception:

> ## PDOException » Main
> 
> Message   SQLSTATE[HY000]: General error: 1364 Field 'edited_on' doesn't have a default value
> ### File  /Users/xxxxx/Sites/Chatterie-fork/vendor/spoon/library/spoon/database/database.php
> 
> Line  884
> Date  Mon, 09 Sep 2013 00:47:35 +0200
> URL   http://fork.chaton-ragdoll.com/private/fr/location/add?token=7zchkl3p
> Referring URL http://fork.chaton-ragdoll.com/private/fr/location/add?token=7zchkl3p
> Request Method    POST
> User-agent    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36
> ## PDOException » Trace
> ### File  /Users/xxxxx/Sites/Chatterie-fork/vendor/spoon/library/spoon/database/database.php
> 
> Line  884
> Class PDOStatement
> Function  execute
> Argument(s)  
> array (size=1)
>   0 => 
>     array (size=11)
>       0 => string 'fr' (length=2)
>       1 => string 'Paris' (length=5)
>       2 => string 'avenue des Champs-Ã‰lysÃ©es' (length=27)
>       3 => string '1' (length=1)
>       4 => string '75000' (length=5)
>       5 => string 'Paris' (length=5)
>       6 => string 'FR' (length=2)
>       7 => float 48.8699009
>       8 => float 2.3058166
>       9 => string '2013-09-08 22:47:35' (length=19)
>       10 => int 32
> ### File  /Users/xxxxx/Sites/Chatterie-fork/backend/modules/location/engine/model.php
> 
> Line  174
> Class SpoonDatabase
> Function  insert
> Argument(s)  
> array (size=2)
>   0 => string 'location' (length=8)
>   1 => 
>     array (size=11)
>       'language' => string 'fr' (length=2)
>       'title' => string 'Paris' (length=5)
>       'street' => string 'avenue des Champs-Ã‰lysÃ©es' (length=27)
>       'number' => string '1' (length=1)
>       'zip' => string '75000' (length=5)
>       'city' => string 'Paris' (length=5)
>       'country' => string 'FR' (length=2)
>       'lat' => float 48.8699009
>       'lng' => float 2.3058166
>       'created_on' => string '2013-09-08 22:47:35' (length=19)
>       'extra_id' => int 32
> ### File  /Users/xxxxx/Sites/Chatterie-fork/backend/modules/location/actions/add.php
> 
> Line  77
> Class BackendLocationModel
> Function  insert
> Argument(s)  
> array (size=1)
>   0 => 
>     array (size=9)
>       'language' => string 'fr' (length=2)
>       'title' => string 'Paris' (length=5)
>       'street' => string 'avenue des Champs-Ã‰lysÃ©es' (length=27)
>       'number' => string '1' (length=1)
>       'zip' => string '75000' (length=5)
>       'city' => string 'Paris' (length=5)
>       'country' => string 'FR' (length=2)
>       'lat' => float 48.8699009
>       'lng' => float 2.3058166
> ### File  /Users/xxxxx/Sites/Chatterie-fork/backend/modules/location/actions/add.php
> 
> Line  24
> Class BackendLocationAdd
> Function  validateForm
> ### File  /Users/xxxxx/Sites/Chatterie-fork/backend/core/engine/action.php
> 
> Line  83
> Class BackendLocationAdd
> Function  execute
> ### File  /Users/xxxxx/Sites/Chatterie-fork/backend/core/engine/backend.php
> 
> Line  31
> Class BackendAction
> Function  execute
> ### File  /Users/xxxxx/Sites/Chatterie-fork/app/routing.php
> 
> Line  137
> Class Backend
> Function  display
> ### File  /Users/xxxxx/Sites/Chatterie-fork/app/Kernel.php
> 
> Line  537
> Class ApplicationRouting
> Function  handleRequest
> ### File  /Users/xxxxx/Sites/Chatterie-fork/index.php
> 
> Line  45
> Class Kernel
> Function  handle
> Argument(s)  
> array (size=1)
>   0 => 
>     object(Symfony\Component\HttpFoundation\Request)[3]
>       public 'attributes' => 
>         object(Symfony\Component\HttpFoundation\ParameterBag)[6]
>           protected 'parameters' => 
>             array (size=0)
>               ...
>       public 'request' => 
>         object(Symfony\Component\HttpFoundation\ParameterBag)[4]
>           protected 'parameters' => 
>             array (size=8)
>               ...
>       public 'query' => 
>         object(Symfony\Component\HttpFoundation\ParameterBag)[5]
>           protected 'parameters' => 
>             array (size=1)
>               ...
>       public 'server' => 
>         object(Symfony\Component\HttpFoundation\ServerBag)[9]
>           protected 'parameters' => 
>             array (size=37)
>               ...
>       public 'files' => 
>         object(Symfony\Component\HttpFoundation\FileBag)[8]
>           protected 'parameters' => 
>             array (size=0)
>               ...
>       public 'cookies' => 
>         object(Symfony\Component\HttpFoundation\ParameterBag)[7]
>           protected 'parameters' => 
>             array (size=5)
>               ...
>       public 'headers' => 
>         object(Symfony\Component\HttpFoundation\HeaderBag)[10]
>           protected 'headers' => 
>             array (size=13)
>               ...
>           protected 'cacheControl' => 
>             array (size=1)
>               ...
>       protected 'content' => null
>       protected 'languages' => null
>       protected 'charsets' => null
>       protected 'acceptableContentTypes' => null
>       protected 'pathInfo' => null
>       protected 'requestUri' => string '/private/fr/location/add?token=7zchkl3p' (length=39)
>       protected 'baseUrl' => null
>       protected 'basePath' => null
>       protected 'method' => null
>       protected 'format' => null
>       protected 'session' => null
>       protected 'locale' => null
>       protected 'defaultLocale' => string 'en' (length=2)
> ## PDOException » Variables
> ### $_GET
> 
> array (size=1)
>   'token' => string '7zchkl3p' (length=8)
> ### $_POST
> 
> array (size=9)
>   'form' => string 'add' (length=3)
>   'form_token' => string '7a8cdc65df47299ecbe203b82f0ebf65' (length=32)
>   'title' => string 'Paris' (length=5)
>   'street' => string 'avenue des Champs-Ã‰lysÃ©es' (length=27)
>   'number' => string '1' (length=1)
>   'zip' => string '75000' (length=5)
>   'city' => string 'Paris' (length=5)
>   'country' => string 'FR' (length=2)
>   '_utf8' => string '' (length=0)
> ### $_COOKIE
> 
> array (size=5)
>   'PHPSESSID' => string 'ls6uk7959muf13s65pfmp0r8m6' (length=26)
>   'interface_language' => string 's:2:"fr";' (length=9)
>   'jstree_open' => string '' (length=0)
>   'frontend_language' => string 's:2:"fr";' (length=9)
>   'track' => string 's:32:"5b6edafde5fd04780acdf7c8c70d52c3";' (length=40)

If I set a dummy default value (i.e. "1970-01-01 00:00:00") for the field `location.edited_on`, it works fine.

I finally fixed it by forcing the same value for both `created_on` and `edited_on`.
