### PR TITLE
Mailmotor subscribe widget uses form token.

### DIFF
--- a/frontend/modules/mailmotor/layout/widgets/subscribe.tpl
+++ b/frontend/modules/mailmotor/layout/widgets/subscribe.tpl
@@ -1,16 +1,15 @@
 <section id="subscribeFormWidget" class="mod">
 	<div class="inner">
 		<div class="bd">
-			<form action="{$var|geturlforblock:'mailmotor':'subscribe'}" method="post">
-				<input type="hidden" name="form" value="subscribe" />
+			{form:subscribe}
 				<p>
 					<label for="email">{$lblEmail|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
-					<input type="text" value="" id="email" name="email" class="inputText" />
+					{$txtEmail} {$txtEmailError}
 				</p>
 				<p>
 					<input id="send" class="inputSubmit" type="submit" name="send" value="{$lblSubscribe|ucfirst}" />
 				</p>
-			</form>
+			{/form:subscribe}
 		</div>
 	</div>
 </section>

--- a/frontend/modules/mailmotor/widgets/subscribe.php
+++ b/frontend/modules/mailmotor/widgets/subscribe.php
@@ -21,5 +21,20 @@ class FrontendMailmotorWidgetSubscribe extends FrontendBaseWidget
 	{
 		parent::execute();
 		$this->loadTemplate();
+		$this->loadForm();
+	}
+
+	/**
+	 * Load the form
+	 */
+	private function loadForm()
+	{
+		$this->frm = new FrontendForm('subscribe', null, null, 'subscribeForm');
+		$this->frm->setAction(
+			FrontendNavigation::getURLForBlock('mailmotor', 'subscribe')
+		);
+		$this->frm->addText('email')
+			->setAttributes(array('required' => null, 'type' => 'email'));
+		$this->frm->parse($this->tpl);
 	}
 }


### PR DESCRIPTION
The Mailmotor widget for subscribing was not using FrontendForm to
create the subscription form.  This meant that the form token was not
generated and the receiving action (which does use form token) bailed
out.

This change set generates the form 'as it should', thus allowing
FrontendForm to generate the form token and the receiving 'subscribe'
action processing the form correctly.

I did not see an issue upon first sight, so there is no "closes..." part
in this commit message, if there was, I'm sorry ;-)
