### PR TITLE
Only show the tagbox in the blogmodule when the users has rights on the tags module

### DIFF
--- a/backend/modules/blog/layout/templates/add.tpl
+++ b/backend/modules/blog/layout/templates/add.tpl
@@ -120,10 +120,12 @@
 								<label for="userId">{$lblAuthor|ucfirst}</label>
 								{$ddmUserId} {$ddmUserIdError}
 							</div>
-							<div class="options">
-								<label for="tags">{$lblTags|ucfirst}</label>
-								{$txtTags} {$txtTagsError}
-							</div>
+							{option:showTagsIndex}
+								<div class="options">
+									<label for="tags">{$lblTags|ucfirst}</label>
+									{$txtTags} {$txtTagsError}
+								</div>
+							{/option:showTagsIndex}
 						</div>
 
 					</td>

--- a/backend/modules/blog/layout/templates/edit.tpl
+++ b/backend/modules/blog/layout/templates/edit.tpl
@@ -141,10 +141,12 @@
 								<label for="userId">{$lblAuthor|ucfirst}</label>
 								{$ddmUserId} {$ddmUserIdError}
 							</div>
-							<div class="options">
-								<label for="tags">{$lblTags|ucfirst}</label>
-								{$txtTags} {$txtTagsError}
-							</div>
+							{option:showTagsIndex}
+								<div class="options">
+									<label for="tags">{$lblTags|ucfirst}</label>
+									{$txtTags} {$txtTagsError}
+								</div>
+							{/option:showTagsIndex}
 						</div>
 
 					</td>


### PR DESCRIPTION
This allows you to hide the tags module from the users when you're using the blog module, just by removing the rights from the tags module.
