### PR TITLE
fix export of selected addresses

### DIFF
--- a/backend/modules/mailmotor/actions/mass_address_action.php
+++ b/backend/modules/mailmotor/actions/mass_address_action.php
@@ -122,7 +122,7 @@ class BackendMailmotorMassAddressAction extends BackendBaseAction
 		// fetch the creationdate for the addresses
 		foreach($this->emails as &$email)
 		{
-			$address = self::getAddress($email);
+			$address = BackendMailmotorModel::getAddress($email);
 			$email = array(
 				'email' => $email,
 				'created_on' => strtotime($address['created_on'])


### PR DESCRIPTION
The export of selected addresses in the datagrid created an empty csv (or errors in debug mode). This was caused because the emails was an array of strings instead off an array of arrays containing the right data (email + created_on).
