### PR TITLE
Optimise composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ should install our dependencies. The dependencies are handled by [composer](http
 
 To install the dependencies, you can run the command below in the document-root:
 
-	composer install
+	composer install -o
 
 ## Bugs
 


### PR DESCRIPTION
From the composer documentation: --optimize-autoloader (-o): Convert PSR-0 autoloading to classmap to get a faster autoloader. This is recommended especially for production, but can take a bit of time to run so it is currently not done by default.

I tested it and it doesn't seem to take a lot of time, so why not?
