### PR TITLE
Terminate function is missing in Kernel

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -521,20 +521,20 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 	}
 
 	/**
-     * {@inheritdoc}
-     *
-     * @api
-     */
-    public function terminate(Request $request, Response $response)
-    {
-        if (false === $this->booted) {
-            return;
-        }
+	 * {@inheritdoc}
+	 *
+	 * @api
+	 */
+	public function terminate(Request $request, Response $response)
+	{
+		if (false === $this->booted) {
+			return;
+		}
 
-        if ($this->getHttpKernel() instanceof TerminableInterface) {
-            $this->getHttpKernel()->terminate($request, $response);
-        }
-    }
+		if ($this->getHttpKernel() instanceof TerminableInterface) {
+			$this->getHttpKernel()->terminate($request, $response);
+		}
+	}
 
 	/**
 	 * Handles a request to convert into a response.


### PR DESCRIPTION
IRC user pascal0s reported that we were missing the terminate function in our Kernel.

We execute the function in index.php after merging #561. I now used the terminate function of Symfony: https://github.com/symfony/HttpKernel/blob/master/Kernel.php#L145
