### PR TITLE
Pages copy: create tags in correct language. (REVIEW FIRST)

### DIFF
--- a/backend/modules/pages/engine/model.php
+++ b/backend/modules/pages/engine/model.php
@@ -586,7 +586,19 @@ class BackendPagesModel
 			$tags = BackendTagsModel::getTags('pages', $id, 'string', $from);
 
 			// save tags
-			if($tags != '') BackendTagsModel::saveTags($page['id'], $tags, 'pages');
+			if($tags != '')
+			{
+				$saveWorkingLanguage = BL::getWorkingLanguage();
+
+				// If we don't set the working language to the target language,
+				// BackendTagsModel::getURL() will use the current working
+				// language, possibly causing unnecessary '-2' suffixes in
+				// tags.url
+				BL::setWorkingLanguage($to);
+
+				BackendTagsModel::saveTags($page['id'], $tags, 'pages', $to);
+				BL::setWorkingLanguage($saveWorkingLanguage);
+			}
 		}
 
 		// build cache


### PR DESCRIPTION
During page copy, the tags were not created in the target language.
This change sets the target language when saving tags, and also makes
sure that BackendTagsModel::getURL() uses the correct language, so that
the slug for the tag does not have any unnecessary '-2'-like suffix.
