### PR TITLE
FIXED: Form_builder Reply-To field flag not saved (thus not used)

### DIFF
--- a/backend/modules/form_builder/ajax/save_field.php
+++ b/backend/modules/form_builder/ajax/save_field.php
@@ -142,7 +142,10 @@ class BackendFormBuilderAjaxSaveField extends BackendBaseAJAXAction
 						if($label != '') $settings['label'] = SpoonFilter::htmlspecialchars($label);
 						if($values != '') $settings['values'] = $values;
 						if($defaultValues != '') $settings['default_values'] = $defaultValues;
-				
+
+						// reply-to, only for textboxes
+						if($type == 'textbox') $settings['reply_to'] = $replyTo == 'Y' ? true : false;
+
 						// build array
 						$field = array();
 						$field['form_id'] = $formId;

--- a/backend/modules/form_builder/js/form_builder.js
+++ b/backend/modules/form_builder/js/form_builder.js
@@ -391,7 +391,7 @@ jsBackend.formBuilder.fields =
 								$('#textboxId').val(data.data.field.id);
 								$('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
-								if(data.data.field.settings.reply_to) $('#textboxReplyTo').prop('checked', true);
+								if(data.data.field.settings.reply_to && data.data.field.settings.reply_to === true) $('#textboxReplyTo').prop('checked', true);
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox


### PR DESCRIPTION
In form_builder module backend, when editing a textbox field, the flag reply-to was not saved. This prevented you from directly using the reply button of your preferred mail client to answer to email submitted through your contact form. The Reply-To header of the e-mail was set to the one set in backend > Settings > Advanced > E-mail.
