### PR TITLE
Bugfix: Class CommonCookie not found when moving the library folder

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -44,7 +44,7 @@ class Autoloader
 		elseif(substr($unifiedClassName, 0, 11) == 'backendbase') $pathToLoad = __DIR__ . '/backend/core/engine/base.php';
 		elseif(substr($unifiedClassName, 0, 15) == 'backenddatagrid') $pathToLoad = __DIR__ . '/backend/core/engine/datagrid.php';
 		elseif(substr($unifiedClassName, 0, 7) == 'backend') $pathToLoad = __DIR__ . '/backend/core/engine/' . str_replace('backend', '', $unifiedClassName) . '.php';
-		elseif(substr($unifiedClassName, 0, 6) == 'common') $pathToLoad = __DIR__ . '/library/base/' . str_replace('common', '', $unifiedClassName) . '.php';
+		elseif(substr($unifiedClassName, 0, 6) == 'common') $pathToLoad = PATH_LIBRARY . '/base/' . str_replace('common', '', $unifiedClassName) . '.php';
 
 		// file check in core
 		if($pathToLoad != '' && file_exists($pathToLoad)) require_once $pathToLoad;


### PR DESCRIPTION
When moving the library folder to some other location and updating the parameters.yml to reflect this change you will get a fatal error on every request.
Fatal error: Class 'CommonCookie' not found in /data/project/xxxxxxxx/htdocs/frontend/core/engine/model.php on line 561

The autoload.php script did not use the PATH_LIBRARY constant, this has been fixed.
