### PR TITLE
Avoid the 'The file "/private/nl/blog/index" does not exist' error when you have nog enough rights

### DIFF
--- a/backend/modules/error/actions/index.php
+++ b/backend/modules/error/actions/index.php
@@ -7,13 +7,12 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\Component\HttpFoundation\File\File;
-
 /**
  * This is the index-action (default), it will display an error depending on a given parameters
  *
  * @author Tijs Verkoyen <tijs@sumocoders.be>
  * @author Davy Hellemans <davy.hellemans@netlash.com>
+ * @author Wouter Sioen <wouter.sioen@wijs.be>
  */
 class BackendErrorIndex extends BackendBaseActionIndex
 {
@@ -57,8 +56,7 @@ class BackendErrorIndex extends BackendBaseActionIndex
 			$chunks = explode('?', $this->getParameter('querystring'));
 
 			// get extension
-			$file = new File($chunks[0]);
-			$extension = $file->getExtension();
+			$extension = pathinfo($chunks[0], PATHINFO_EXTENSION);
 
 			// if the file has an extension it is a non-existing-file
 			if($extension != '' && $extension != $chunks[0])


### PR DESCRIPTION
When you want to access an action that exists but you have not enough rights to open it, the error action tried to create a Symfony File object with the url as path. 
This was done to get the extension. Since this is a url and not a path, the file could not be created causing a Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException

![screen shot 2013-11-08 at 15 32 34](https://f.cloud.github.com/assets/1398405/1500934/a4601234-4882-11e3-8d17-c5da8a1651ac.png)

This pull requests makes sure the correct error is shown ({$msgActionNotAllowed})
