### PR TITLE
Trigger an event on users undelete action success

### DIFF
--- a/backend/modules/users/actions/undo_delete.php
+++ b/backend/modules/users/actions/undo_delete.php
@@ -32,6 +32,13 @@ class BackendUsersUndoDelete extends BackendBaseAction
 				// get user
 				$user = new BackendUser(null, $email);
 
+				// trigger event
+				$item = array(
+					'id' => $user->getUserId(),
+					'email' => $email,
+				);
+				BackendModel::triggerEvent($this->getModule(), 'after_undelete', array('item' => $item));
+
 				// item was deleted, so redirect
 				$this->redirect(BackendModel::createURLForAction('edit') . '&id=' . $user->getUserId() . '&report=restored&var=' . $user->getSetting('nickname') . '&highlight=row-' . $user->getUserId());
 			}


### PR DESCRIPTION
All other users actions have handy triggers on which you can hook in other modules. The undelete action should have one too... That's the why of this commit.
I'm deliberately not sending the BackendUser object along when I trigger the event because it's a backend specific object and this could theoretically be handled in frontend modules too. The user's id and email should be enough in that case.
