### PR TITLE
Fix token after using datagrid sorting functions

### DIFF
--- a/backend/core/engine/model.php
+++ b/backend/core/engine/model.php
@@ -134,7 +134,7 @@ class BackendModel extends BaseModel
 		if(isset($_GET['sort']) && !isset($parameters['sort'])) $parameters['sort'] = (string) $_GET['sort'];
 
 		// add at least one parameter
-		if(empty($parameters)) $parameters['token'] = self::getToken();
+		$parameters['token'] = self::getToken();
 
 		// init counter
 		$i = 1;


### PR DESCRIPTION
When you use datagrid sorting, you don't get a token anymore.
### How to reproduce the problem?
- Go to the blog index
- Click on a datagrid column title to order (f.e. by title)
- Click on an article title to go to the edit action. (You'll see there is no token in the url)
- Click on the delete button, you'll get a CSRF error ({$errBlogCsrf})

This makes sure we always get a token when we're redirected to an action. This way we don't get errors on our CSRF token.
