### PR TITLE
KernelLoader fixes

### DIFF
--- a/app/KernelLoader.php
+++ b/app/KernelLoader.php
@@ -61,7 +61,7 @@ class KernelLoader
 	 * @param string $reference The service id
 	 * @return Boolean true if the service id is defined, false otherwise
 	 */
-	public static function has($reference)
+	public function has($reference)
 	{
 		return $this->getKernel()->getContainer()->has($reference);
 	}


### PR DESCRIPTION
For the PHPDoc of getContainer I used the FQN of the interface, because it is not provided in a use statement (fixes hinting in IDE)
