### PR TITLE
Fix urls containing md

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,9 +13,9 @@ FileETag MTime Size
 
 	# forbidden folders
 	RewriteRule .*\.gitignore - [F]
-	RewriteRule composer.json - [F]
-	RewriteRule composer.lock - [F]
-	RewriteRule .*.md - [F]
+	RewriteRule composer\.json - [F]
+	RewriteRule composer\.lock - [F]
+	RewriteRule .*\.md - [F]
 	RewriteRule frontend/cache/cached_templates - [F]
 	RewriteRule frontend/cache/compiled_templates - [F]
 	RewriteRule frontend/cache/config - [F]


### PR DESCRIPTION
They trew a 403 Forbidden error because of the htaccess

F.E: http://recepten.dev/nl/recepten/salade-wrapper-met-hollandse-garnalen-en-sesamdressing

On the fork demo:
http://demo.fork-cms.com/en/md
http://demo.fork-cms.com/en/blog/detail/nunc-sediam-emd
