### PR TITLE
IMPROVED: tools can be run from anywhere

### DIFF
--- a/tools/prepare_for_reinstall
+++ b/tools/prepare_for_reinstall
@@ -2,28 +2,31 @@
 #
 # This script will remove all cache-files.
 #
-# @version	1.0.0
+# @version	1.0.1
+# @author	Yohann Bianchi <nstCactus@gmail.com>
 # @author	Tijs Verkoyen <tijs@sumocoders.be>
 
-rm -f `find ../install/cache/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+SCRIPT_PATH="`dirname \"$0\"`"
 
-rm -f `find ../frontend/cache/cached_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/config/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/minified_css/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/minified_js/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../install/cache/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
 
-rm -f `find ../backend/cache/analytics/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/config/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/cronjobs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/mailmotor/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/logs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/cached_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/config/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/minified_css/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/minified_js/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
 
-rm -f ../app/config/parameters.yml
+rm -f `find ${SCRIPT_PATH}/../backend/cache/analytics/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/config/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/cronjobs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/mailmotor/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/logs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+
+rm -f ${SCRIPT_PATH}/../app/config/parameters.yml
 
 echo 'All done! Ready for reinstall.'

--- a/tools/remove_cache
+++ b/tools/remove_cache
@@ -2,25 +2,28 @@
 #
 # This script will remove all cache-files.
 #
-# @version	1.1.1
+# @version	1.1.2
+# @author	Yohann Bianchi <nstCactus@gmail.com>
 # @author	Johan Ronsse <johan@netlash.com>
 # @author	Tijs Verkoyen <tijs@sumocoders.be>
 
-rm -f `find ../frontend/cache/cached_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/minified_css/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/minified_js/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../frontend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+SCRIPT_PATH="`dirname \"$0\"`"
 
-rm -f `find ../backend/cache/analytics/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/cronjobs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/mailmotor/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
-rm -f `find ../backend/cache/logs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/cached_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/minified_css/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/minified_js/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../frontend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
 
-rm -f `find ../app/cache/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/analytics/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/cronjobs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/locale/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/mailmotor/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/navigation/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/compiled_templates/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+rm -f `find ${SCRIPT_PATH}/../backend/cache/logs/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
+
+rm -f `find ${SCRIPT_PATH}/../app/cache/ ! -name ".gitignore" -type f ! -path *.svn/* -type f`
 
 echo 'All done! Cache files removed.'

--- a/tools/stats
+++ b/tools/stats
@@ -3,29 +3,32 @@
 # This script will run some other scripts to generate reports.
 #
 # @later	find a decent way to run multiple processes at once (maybe use `wait`)
-# @version	1.0.0
+# @version	1.0.1
+# @author	Yohann Bianchi <nstCactus@gmail.com>
 # @author	Tijs Verkoyen <tijs@sumocoders.be>
 
+SCRIPT_PATH="`dirname \"$0\"`"
+
 # create folder
-mkdir -p reports
+mkdir -p ${SCRIPT_PATH}/reports
 
 # tell user
 echo "* Running PHP Mess Detection (will take a while)"
 
 # run PHP Mess Detection
-phpmd ../ xml codesize,unusedcode,naming --exclude ../backend/core/js/ckeditor,../backend/core/js/ckfinder,../frontend/cache,../backend/cache,../install/cache,../tools,../library/external --reportfile ./reports/phpmd.xml
+phpmd ${SCRIPT_PATH}/../ xml codesize,unusedcode,naming --exclude ${SCRIPT_PATH}/../backend/core/js/ckeditor,${SCRIPT_PATH}/../backend/core/js/ckfinder,${SCRIPT_PATH}/../frontend/cache,${SCRIPT_PATH}/../backend/cache,${SCRIPT_PATH}/../install/cache,${SCRIPT_PATH}/../tools,${SCRIPT_PATH}/../library/external --reportfile ${SCRIPT_PATH}/reports/phpmd.xml
 
 # tell user
 echo "* Running PHP Depend (will take a while)"
 
 # run PHP Depend
-pdepend --jdepend-chart=./reports/pdepend_chart.svg --overview-pyramid=./reports/pdepend_pyramid.svg --summary-xml=./reports/pdepend.xml --suffix=php --ignore=../backend/core/js/ckeditor,../backend/core/js/ckfinder,../frontend/cache,../backend/cache,../install/cache,../tools,../library/external ../ > /dev/null
+pdepend --jdepend-chart=${SCRIPT_PATH}/reports/pdepend_chart.svg --overview-pyramid=${SCRIPT_PATH}/reports/pdepend_pyramid.svg --summary-xml=${SCRIPT_PATH}/reports/pdepend.xml --suffix=php --ignore=${SCRIPT_PATH}/../backend/core/js/ckeditor,${SCRIPT_PATH}/../backend/core/js/ckfinder,${SCRIPT_PATH}/../frontend/cache,${SCRIPT_PATH}/../backend/cache,${SCRIPT_PATH}/../install/cache,${SCRIPT_PATH}/../tools,${SCRIPT_PATH}/../library/external ${SCRIPT_PATH}/../ > /dev/null
 
 # tell user
 echo "* Running PHP Loc"
 
 # run PHP Loc
-phploc --log-xml ./reports/phploc.xml --suffixes php ../ > /dev/null
+phploc --log-xml ${SCRIPT_PATH}/reports/phploc.xml --names php ${SCRIPT_PATH}/../ > /dev/null
 
 # tell user
 echo "Done"


### PR DESCRIPTION
One can invoke (for example) `/full/path/to/fork/tools/remove_cache` to clear the cache of the fork instance located at `/full/path/to/fork/`.
