### PR TITLE
Bugfix: meta-overwrite-url with special characters

### DIFF
--- a/backend/core/engine/meta.php
+++ b/backend/core/engine/meta.php
@@ -470,7 +470,7 @@ class BackendMeta
 			$generatedUrl = $this->generateURL($URL);
 
 			// check if urls are different
-			if(SpoonFilter::urlise($URL) != $generatedUrl) $this->frm->getField('url')->addError(BL::err('URLAlreadyExists'));
+			if(CommonUri::getUrl($URL) != $generatedUrl) $this->frm->getField('url')->addError(BL::err('URLAlreadyExists'));
 		}
 
 		// if the form was submitted correctly the data array should be populated


### PR DESCRIPTION
Overwriting an url which contains special characters like é is not possible and always gives an URLAlreadyExists-error message.
Steps to reproduce:
Change a title by adding 'é test'
Go to the SEO tab and overwrite the url to 'é-test-something' and try to save
