### PR TITLE
Remove unused & non-valid argument for getUsers()

### DIFF
--- a/backend/modules/users/engine/model.php
+++ b/backend/modules/users/engine/model.php
@@ -313,7 +313,7 @@ class BackendUsersModel
 			 FROM users AS i
 			 INNER JOIN users_settings AS s ON i.id = s.user_id AND s.name = ?
 			 WHERE i.active = ? AND i.deleted = ?',
-			array('nickname', 'Y', 'N'), 'id'
+			array('nickname', 'Y', 'N')
 		);
 
 		// loop users & unserialize


### PR DESCRIPTION
```
BackendUsersModel::getUsers()
```

This argument is unused and not valid for this method (the `getPairs()` method only supports 2 arguments), removed.
