### PR TITLE
Fixed #653. Support for command line requests and (lighthttpd/nginx) installation 

### DIFF
--- a/index.php
+++ b/index.php
@@ -7,6 +7,9 @@
  * file that was distributed with this source code.
  */
 
+// CLI/Nginx/Cron: We need to set the "current working directory" to this folder
+chdir(dirname(__FILE__));
+
 // vendors not installed
 if(!is_dir(__DIR__ . '/vendor'))
 {

--- a/install/engine/step_2.php
+++ b/install/engine/step_2.php
@@ -139,7 +139,7 @@ class InstallerStep2 extends InstallerStep
 		// define constants
 		if(!defined('PATH_WWW'))
 		{
-			define('PATH_WWW', dirname(realpath($_SERVER['SCRIPT_FILENAME'])));
+			define('PATH_WWW', getcwd());
 		}
 
 		if(!defined('PATH_LIBRARY'))

--- a/install/index.php
+++ b/install/index.php
@@ -1,0 +1,4 @@
+<?php
+
+// If the .htaccess rule doesn't work (nginx) then manually load the index
+require(__DIR__ . '/../index.php');


### PR DESCRIPTION
The index.php should attempt to "reset" the CWD so that the assumptions it makes about paths are correct. Don't assume the CWD will always be `__DIR__ . '/index.php'`.
