### PR TITLE
Fix bug with hidden validation text field for email in formbuilder

### DIFF
--- a/backend/modules/form_builder/js/form_builder.js
+++ b/backend/modules/form_builder/js/form_builder.js
@@ -630,7 +630,7 @@ jsBackend.formBuilder.fields =
 	{
 		// get dropdown
 		var required = $(wrapper).find('input:checkbox');
-		var validation = $(wrapper).find('select:first');
+		var validation = $(wrapper).find('select').first();
 
 		// toggle required error message
 		if($(required).is(':checked'))


### PR DESCRIPTION
For some reason the `:first` pseudo-selector returned 2 html elements. By
switching to the `.first()` jquery method, the issue is fixed. Other
`:first` pseudo-selectors in the same js file seem to work though.

Formbuilder text fields with selected validation method did not show the
validation error on opening the edit modal. This commit fixes that
issue.
