### PR TITLE
Removes unnecessary parameter for addTextArea for add form of locale.

### DIFF
--- a/backend/modules/locale/actions/add.php
+++ b/backend/modules/locale/actions/add.php
@@ -73,7 +73,7 @@ class BackendLocaleAdd extends BackendBaseActionAdd
 		$this->frm->addDropdown('module', BackendModel::getModulesForDropDown(false), $isCopy ? $translation['module'] : $this->filter['module']);
 		$this->frm->addDropdown('type', BackendLocaleModel::getTypesForDropDown(), $isCopy ? $translation['type'] : $this->filter['type'][0]);
 		$this->frm->addText('name', $isCopy ? $translation['name'] : $this->filter['name']);
-		$this->frm->addTextarea('value', $isCopy ? $translation['value'] : $this->filter['value'], null, null, null, true);
+		$this->frm->addTextarea('value', $isCopy ? $translation['value'] : $this->filter['value'], null, null, true);
 		$this->frm->addDropdown('language', BackendLanguage::getWorkingLanguages(), $isCopy ? $translation['language'] : $this->filter['language'][0]);
 	}
 


### PR DESCRIPTION
This solves a bug that when you add HTML to your label/message/error, it won't convert the HTML entities.
