### PR TITLE
Make the BackendBlogModel::get() method get the latest revision

### DIFF
--- a/backend/modules/blog/engine/model.php
+++ b/backend/modules/blog/engine/model.php
@@ -333,7 +333,8 @@ class BackendBlogModel
 			'SELECT i.*, UNIX_TIMESTAMP(i.publish_on) AS publish_on, UNIX_TIMESTAMP(i.created_on) AS created_on, UNIX_TIMESTAMP(i.edited_on) AS edited_on, m.url
 			 FROM blog_posts AS i
 			 INNER JOIN meta AS m ON m.id = i.meta_id
-			 WHERE i.id = ? AND (i.status = ? OR i.status = ?) AND i.language = ?',
+			 WHERE i.id = ? AND (i.status = ? OR i.status = ?) AND i.language = ?
+			 ORDER BY i.revision_id DESC',
 			array((int) $id, 'active', 'draft', BL::getWorkingLanguage())
 		);
 	}


### PR DESCRIPTION
Before this commit, the first occurence was returned. This meant that
you didn't get the latest version of the post, which results in some
strange bugs and constructions in other places of the blog module.

e.g.:
- In backend blog edit, if you have multiple drafts of a post that is
  not published, and you edit it without the draft=xxx parameter, you
  get the oldest draft instead of the newest. That's also the reason why
  the index page needs to specify draft versions (not its repsonsibility)
- In backend blog delete, when you delete a post, the oldest version is
  used, which means that if you changed the post image over time, for instance,
  that file won't be deleted. Also, if you changed the title over time,
  the success message after deletion will report the old title.

And there are others...

This commit makes sure you're working with the latest version of a post
