### PR TITLE
It's better to return an empty array now, than to add an empty settings...

### DIFF
--- a/backend/modules/users/engine/model.php
+++ b/backend/modules/users/engine/model.php
@@ -149,6 +149,11 @@ class BackendUsersModel
 			array($id)
 		);
 
+		// Don't add a settings element, just return an empty array here if no user is found.
+		if (empty($user)) {
+			return array();
+		}
+
 		// get user-settings
 		$user['settings'] = (array) $db->getPairs(
 			'SELECT s.name, s.value


### PR DESCRIPTION
...array as only element.

We can then use empty() on the return value of this method, to check if
a user was found for the given id. An even better solution would be to
work with User Entity Objects, with a known type.
