### PR TITLE
Removed Bitdeli in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,3 @@ If you're stuck or would like to discuss Fork CMS, check out the [forum](http://
 
 
 _The Fork CMS team_
-
----
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/forkcms/forkcms/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
Doesn't work anymore as [described here](http://blog.bitdeli.com/post/77717727361/on-githubs-image-proxy)
