### PR TITLE
Bugfix for Ajax call URL in frontend.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 Bugfixes:
 
 * Core: Mailer uses \Exception.
+* Core: Frontend.js ajax url fixed
 
 
 3.7.0 (2014-04-24)

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -396,7 +396,7 @@ jsFrontend.locale =
 	init: function()
 	{
 		$.ajax({
-			url: '/frontend/cache/locale/' + jsFrontend.current.language + '.json',
+			url: '/src/Frontend/Cache/Locale/' + jsFrontend.current.language + '.json',
 			type: 'GET',
 			dataType: 'json',
 			async: false,


### PR DESCRIPTION
URL for Ajax call was wrong in 

```
src/Frontend/Core/Js/frontend.js
```
