### PR TITLE
Mailmotor: fixed typo in installer

### DIFF
--- a/src/Backend/Modules/Mailmotor/Installer/Installer.php
+++ b/src/Backend/Modules/Mailmotor/Installer/Installer.php
@@ -161,7 +161,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, 'Mailmotor', 'SendMailing');
         $this->setActionRights(1, 'Mailmotor', 'Settings');
         $this->setActionRights(1, 'Mailmotor', 'Statistics');
-        $this->setActionRights(1, 'Mailmotor', 'StatisticsMounces');
+        $this->setActionRights(1, 'Mailmotor', 'StatisticsBounces');
         $this->setActionRights(1, 'Mailmotor', 'StatisticsCampaign');
         $this->setActionRights(1, 'Mailmotor', 'StatisticsLink');
     }


### PR DESCRIPTION
Noticed this small typo in the mailmotor module. This was probably caused by renaming the action to the CamelCase notation.

`StatisticsMounces` has to be `StatisticsBounces` obviously
