### PR TITLE
Image name conflicts - fixes #608

### DIFF
--- a/src/Backend/Modules/Blog/Actions/Add.php
+++ b/src/Backend/Modules/Blog/Actions/Add.php
@@ -179,7 +179,7 @@ class Add extends BackendBaseActionAdd
                     // image provided?
                     if ($this->frm->getField('image')->isFilled()) {
                         // build the image name
-                        $item['image'] = $this->meta->getURL() . '.' . $this->frm->getField('image')->getExtension();
+                        $item['image'] = $this->meta->getURL() . '-' . BL::getWorkingLanguage() . '.' . $this->frm->getField('image')->getExtension();
 
                         // upload the image & generate thumbnails
                         $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);

--- a/src/Backend/Modules/Blog/Actions/Edit.php
+++ b/src/Backend/Modules/Blog/Actions/Edit.php
@@ -411,14 +411,14 @@ class Edit extends BackendBaseActionEdit
                         }
 
                         // build the image name
-                        $item['image'] = $this->meta->getURL() . '.' . $this->frm->getField('image')->getExtension();
+                        $item['image'] = $this->meta->getURL() . '-' . BL::getWorkingLanguage() . '.' . $this->frm->getField('image')->getExtension();
 
                         // upload the image & generate thumbnails
                         $this->frm->getField('image')->generateThumbnails($imagePath, $item['image']);
                     } elseif ($item['image'] != null) {
                         // rename the old image
                         $image = new File($imagePath . '/source/' . $item['image']);
-                        $newName = $this->meta->getURL() . '.' . $image->getExtension();
+                        $newName = $this->meta->getURL() . '-' . BL::getWorkingLanguage() . '.' . $image->getExtension();
 
                         // only change the name if there is a difference
                         if ($newName != $item['image']) {


### PR DESCRIPTION
WorkingLanguage was used to make names unique across multiple languages
