### PR TITLE
First argument of dg function needs to be an array

### DIFF
--- a/UPGRADE_3.7.md
+++ b/UPGRADE_3.7.md
@@ -190,7 +190,7 @@ After
     use Backend\Core\Engine\DataGridFunctions;
 
     ...
-    $dg->setColumnFunction(new DataGridFunctions(), 'getTimeAgo', '[time]', 'time');
+    $dg->setColumnFunction(array(new DataGridFunctions(), 'getTimeAgo'), '[time]', 'time');
 
 or
 


### PR DESCRIPTION
Fixes this error:
Catchable fatal error: Object of class Backend\Core\Engine\DataGridFunctions could not be converted to string in [website_url] on line 1475
