### PR TITLE
Fix: avoid notice and incomplete exception when thrown.

### DIFF
--- a/src/Backend/Core/Engine/Cronjob.php
+++ b/src/Backend/Core/Engine/Cronjob.php
@@ -185,7 +185,7 @@ class Cronjob extends Object implements \ApplicationInterface
             $configClass
         )
         ) {
-            throw new Exception('The config file is present, but the classname should be: ' . $configClassName . '.');
+            throw new Exception('The config file is present, but the classname should be: ' . $configClass . '.');
         }
 
         // create config-object, the constructor will do some magic


### PR DESCRIPTION
Variable `$configClassName`not defined in that scope, better use the `$configClass` and avoid notice when throwing an exception ;)
