### PR TITLE
Save: readOuterXml was just called and stored in a variable.

### DIFF
--- a/src/Backend/Modules/Blog/Actions/ImportWordpress.php
+++ b/src/Backend/Modules/Blog/Actions/ImportWordpress.php
@@ -125,7 +125,7 @@ class ImportWordpress extends BackendBaseActionEdit
 
             // Read the XML as an SimpleXML-object
             /* @var \SimpleXMLElement $xml */
-            $xml = @simplexml_load_string($reader->readOuterXml());
+            $xml = @simplexml_load_string($xmlString);
 
             // Skip element if it isn't a valid SimpleXML-object
             if ($xml === false) {


### PR DESCRIPTION
Afaik does `readOuterXml()` not move the cursor. It was just read out and stored in a variable one line above. @see http://php.net/manual/en/xmlreader.readouterxml.php
