### PR TITLE
Fix: PSR1 wrong call with $module

### DIFF
--- a/src/Frontend/Modules/Tags/Actions/Detail.php
+++ b/src/Frontend/Modules/Tags/Actions/Detail.php
@@ -82,7 +82,7 @@ class Detail extends FrontendBaseBlock
             );
 
             // set module class
-            $class = 'Frontend\\Modules\\' . $module . '\\Engine\\Model';
+            $class = 'Frontend\\Modules\\' . ucfirst($module) . '\\Engine\\Model';
 
             // get the items that are linked to the tags
             $items = (array) FrontendTagsModel::callFromInterface($module, $class, 'getForTags', $otherIds);


### PR DESCRIPTION
FrontendTagsModel::callFromInterface has to use module name with ucfirst, otherwise PSR1 will not find the class.
