### PR TITLE
Bugfix: event subscriptions did not get fired in the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.7.4 (2014-xx-xx)
+--
+Bugfixes:
+
+* Core: event subscriptions did not get fired in the frontend.
+
+
 3.7.3 (2014-08-08)
 --
 Bugfixes:

--- a/UPGRADE_3.7.md
+++ b/UPGRADE_3.7.md
@@ -204,7 +204,7 @@ Before
 
 After
 
-    fork.dev/src/Backend/Cronjob.php?module=Core&action=SendQueuedEmails
+    fork.dev/backend/cronjob?module=Core&action=SendQueuedEmails
 
 ## API isAuthorized() instead of authorize()
 

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -926,7 +926,7 @@ class Model extends \BaseModel
         );
 
         // build the request
-        $request = 'GET /backend/cronjob.php?module=core&action=process_queued_hooks HTTP/1.1' . "\r\n";
+        $request = 'GET /backend/cronjob?module=Core&action=ProcessQueuedHooks HTTP/1.1' . "\r\n";
         $request .= 'Host: ' . $parts['host'] . "\r\n";
         $request .= 'Content-Length: 0' . "\r\n\r\n";
         $request .= 'Connection: Close' . "\r\n\r\n";


### PR DESCRIPTION
The frontend startProcessingHooks function tried to start the ProcessQueuedHooks cronjob request with wrong url.
