### PR TITLE
Change old ajax endpoint to the new one

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -260,7 +260,7 @@ jsBackend.ckeditor =
 	init: function()
 	{
 		// the language isn't know before this init-method is called, so we set the url for the template-files just now
-		jsBackend.ckeditor.defaultConfig.templates_files = ['/src/Backend/Ajax.php?fork[module]=Core&fork[action]=Templates&fork[language]=' + jsBackend.current.language];
+		jsBackend.ckeditor.defaultConfig.templates_files = ['/backend/ajax?fork[module]=Core&fork[action]=Templates&fork[language]=' + jsBackend.current.language];
 
 		// load the editor
 		if($('textarea.inputEditor, textarea.inputEditorError, textarea.inputEditorNewsletter, textarea.inputEditorNewsletterError').length > 0)


### PR DESCRIPTION
The new endpoint for ajax is `/backend/ajax`. This file still used the old one.
