### PR TITLE
Bugfix right aligned tabs

### DIFF
--- a/src/Backend/Core/Layout/Css/imports/core_modules.css
+++ b/src/Backend/Core/Layout/Css/imports/core_modules.css
@@ -457,10 +457,18 @@
 
 		/* Less important tabs go on the right side */
 
-		#pages.pagesAddEdit .ui-tabs-nav li { float: right; }
-		#pages.pagesAddEdit .ui-tabs-nav li:first-child { float: left; }
+		#pages.pagesAdd .ui-tabs-nav li,
+		#pages.pagesEdit .ui-tabs-nav li { 
+			float: right; 
+		}
 
-		#pages.pagesAddEdit .ui-tabs-nav li:nth-child(2) {
+		#pages.pagesAdd .ui-tabs-nav li:first-child,
+		#pages.pagesEdit .ui-tabs-nav li:first-child { 
+			float: left; 
+		}
+
+		#pages.pagesAdd .ui-tabs-nav li:nth-child(2),
+		#pages.pagesEdit .ui-tabs-nav li:nth-child(2) {
 			margin-right: 0;
 		}
 


### PR DESCRIPTION
In previous versions of Fork, the less important tabs were aligned on to the right side. The body element of the page was in 3.6.6: `body#pages.pagesAddEdit`.
This is now (apparently) divided into: `body#pages.pagesAdd`(if you add a page) and `body#pages.pagesEdit` (if you edit an existing page).

So the CSS rules needed to change to these two classes instead of one.

This commit fixes #766
