### PR TITLE
Show difference between widgets and actions in the logs.

### DIFF
--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -395,7 +395,8 @@ class Page extends FrontendBaseObject
         // loop all extras
         foreach ($this->extras as $extra) {
             $this->getContainer()->get('logger')->info(
-                "Executing frontend action '{$extra->getAction()}' for module '{$extra->getModule()}'."
+                "Executing " . get_class($extra)
+                . " '{$extra->getAction()}' for module '{$extra->getModule()}'."
             );
 
             // all extras extend FrontendBaseObject, which extends KernelLoader


### PR DESCRIPTION
This makes sure we can see a difference between executed frontend widgets and executed frontendblocks. If we would have a widget with the same name as an action, the logs would be identical. This is fixed by this tiny PR.
