### PR TITLE
Pagerfanta, revisited

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "spoon/library": "1.3.*",
         "symfony/monolog-bundle": "2.3.*",
         "behat/transliterator": "~1.0",
+        "pagerfanta/pagerfanta": "v1.0.2",
         "jdorn/sql-formatter": "1.3.*@dev"
     },
     "support": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a38ce2983ba51349ededfbbf012218db",
+    "hash": "9ef47908c3fc0bf9a23ec59f0cbc2df9",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -181,7 +181,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -227,7 +227,7 @@
             ],
             "authors": [
                 {
-                    "name": "Jonathan Wage",
+                    "name": "Jonathan H. Wage",
                     "email": "jonwage@gmail.com",
                     "homepage": "http://www.jwage.com/",
                     "role": "Creator"
@@ -324,7 +324,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -387,9 +387,9 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Johannes Schmitt",
+                    "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -443,7 +443,7 @@
                 {
                     "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
-                    "homepage": "https://github.com/schmittjoh",
+                    "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
                 }
             ],
@@ -662,17 +662,84 @@
             "time": "2014-06-04 16:30:04"
         },
         {
+            "name": "pagerfanta/pagerfanta",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whiteoctober/Pagerfanta.git",
+                "reference": "ac1edfdf81c91a0f1471769071011ebf9b055421"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/ac1edfdf81c91a0f1471769071011ebf9b055421",
+                "reference": "ac1edfdf81c91a0f1471769071011ebf9b055421",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "doctrine/mongodb-odm": "1.0.*@dev",
+                "doctrine/orm": "2.3.*",
+                "doctrine/phpcr-odm": "1.*",
+                "jackalope/jackalope-doctrine-dbal": "1.*",
+                "jmikola/geojson": "1.0.*",
+                "mandango/mandango": "1.0.*@dev",
+                "phpunit/phpunit": "3.7.*",
+                "propel/propel1": "~1.6",
+                "solarium/solarium": "3.1.*"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "To use the DoctrineODMMongoDBAdapter.",
+                "doctrine/orm": "To use the DoctrineORMAdapter.",
+                "doctrine/phpcr-odm": "To use the DoctrineODMPhpcrAdapter. >= 1.1.0",
+                "mandango/mandango": "To use the MandangoAdapter.",
+                "propel/propel1": "To use the PropelAdapter",
+                "solarium/solarium": "To use the SolariumAdapter."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pagerfanta\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pablo Díez",
+                    "email": "pablodip@gmail.com",
+                    "homepage": "http://github.com/pablodip"
+                }
+            ],
+            "description": "Pagination for PHP 5.3",
+            "keywords": [
+                "page",
+                "pagination",
+                "paginator",
+                "paging"
+            ],
+            "time": "2014-06-02 09:21:14"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "url": "https://github.com/php-fig/log",
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://github.com/php-fig/log/archive/1.0.0.zip",
+                "reference": "1.0.0",
                 "shasum": ""
             },
             "type": "library",
@@ -705,12 +772,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/forkcms/library.git",
-                "reference": "394a4392db9c93c2f49a8923982a6a6de7035688"
+                "reference": "1.3.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/forkcms/library/zipball/394a4392db9c93c2f49a8923982a6a6de7035688",
-                "reference": "394a4392db9c93c2f49a8923982a6a6de7035688",
+                "url": "https://api.github.com/repos/forkcms/library/zipball/1.3.10",
+                "reference": "1.3.10",
                 "shasum": ""
             },
             "require": {
@@ -785,23 +852,23 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/MonologBundle.git",
-                "reference": "03ed73bc11367b3156cc21f22ac37c7f70fcd10a"
+                "reference": "v2.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/03ed73bc11367b3156cc21f22ac37c7f70fcd10a",
-                "reference": "03ed73bc11367b3156cc21f22ac37c7f70fcd10a",
+                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/v2.3.0",
+                "reference": "v2.3.0",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "~1.3",
+                "monolog/monolog": ">=1.3,<2.0",
                 "php": ">=5.3.2",
-                "symfony/config": "~2.2-beta2",
-                "symfony/dependency-injection": "~2.2-beta2",
-                "symfony/monolog-bridge": "~2.2-beta2"
+                "symfony/config": ">=2.2-beta2,<3.0",
+                "symfony/dependency-injection": ">=2.2-beta2,<3.0",
+                "symfony/monolog-bridge": ">=2.2-beta2,<3.0"
             },
             "require-dev": {
-                "symfony/yaml": "~2.2-beta2"
+                "symfony/yaml": ">=2.2-beta2,<3.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -821,9 +888,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 },
                 {
                     "name": "Symfony Community",
@@ -953,13 +1018,13 @@
             "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/tijsverkoyen/Akismet.git",
-                "reference": "0c5185956e11824ed310d134d38d0b2c936f3d3a"
+                "url": "https://github.com/tijsverkoyen/Akismet",
+                "reference": "1.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/Akismet/zipball/0c5185956e11824ed310d134d38d0b2c936f3d3a",
-                "reference": "0c5185956e11824ed310d134d38d0b2c936f3d3a",
+                "url": "https://github.com/tijsverkoyen/Akismet/zipball/1.1.0",
+                "reference": "1.1.0",
                 "shasum": ""
             },
             "require": {
@@ -985,7 +1050,7 @@
             ],
             "description": "Akismet is a wrapper-class to communicate with the Akismet API.",
             "homepage": "https://github.com/tijsverkoyen/Akismet",
-            "time": "2012-10-13 17:59:41"
+            "time": "2012-10-13 10:59:41"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -993,13 +1058,13 @@
             "target-dir": "TijsVerkoyen/CssToInlineStyles",
             "source": {
                 "type": "git",
-                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "e53f25f6685d167f80b9d51b91b09aa70ea6c1c9"
+                "url": "https://github.com/tijsverkoyen/CssToInlineStyles",
+                "reference": "1.2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/e53f25f6685d167f80b9d51b91b09aa70ea6c1c9",
-                "reference": "e53f25f6685d167f80b9d51b91b09aa70ea6c1c9",
+                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/1.2.1",
+                "reference": "1.2.1",
                 "shasum": ""
             },
             "require": {

--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -304,10 +304,14 @@ class Block extends Object
             throw new InvalidArgumentException('The getUrl parameter should be a callable function.');
         }
 
+        // Create a new pagerfanta object using the given callbacks and pagerfanta's callback adapter.
         $adapter = new \Pagerfanta\Adapter\CallbackAdapter($getNbResults, $getSlice);
         $pagerFanta = new \Pagerfanta\Pagerfanta($adapter);
         $pagerFanta->setMaxPerPage($itemsPerPage);
 
+        // Set the current page to the given value.
+        // If it's less than one, set the current page to the first page.
+        // If it's more than the number of pages we have in total, set it to the last page.
         try {
             $pagerFanta->setCurrentPage($currentPage);
         } catch (\Pagerfanta\Exception\LessThan1CurrentPageException $e) {
@@ -318,6 +322,7 @@ class Block extends Object
             $pagerFanta->setCurrentPage($currentPage);
         }
 
+        // Create a list of all page numbers, with a label, an url and a boolean flag when they're the current page.
         $pages = range(1, $pagerFanta->getNbPages());
         $pages = array_map(
             function($pageNumber) use ($getUrl, $currentPage) {
@@ -330,11 +335,13 @@ class Block extends Object
             $pages
         );
 
+        // Should we show navigation buttons for the previous and next pages?
         $showNext = $pagerFanta->hasNextPage();
         $nextUrl = ($showNext) ? $pages[$currentPage]['url'] : null;
         $showPrevious = $pagerFanta->hasPreviousPage();
         $previousUrl = ($showPrevious) ? $pages[$currentPage - 2]['url'] : null;
 
+        // Calculate for which page numbers we should show navigation buttons
         $first = null;
         $last = null;
         if ($pagerFanta->getNbPages() > 7) {
@@ -351,6 +358,7 @@ class Block extends Object
             }
         }
 
+        // Create pagination data object for the template, and assign it
         $pagination = array(
             'multiple_pages' => $pagerFanta->haveToPaginate(),
             'first' => $first,

--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -17,6 +17,7 @@ use Frontend\Core\Engine\Exception;
 use Frontend\Core\Engine\Header;
 use Frontend\Core\Engine\Url;
 use Frontend\Core\Engine\Template as FrontendTemplate;
+use InvalidArgumentException;
 
 /**
  * This class implements a lot of functionality that can be extended by a specific block

--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -289,199 +289,82 @@ class Block extends Object
 
     /**
      * Parse pagination
+     *
+     * @param callable $getNbResults A function that returns the total number of results
+     * @param callable $getSlice     A function that returns a slice of the collection
+     * @param callable $getUrl       A function to get the correct url for this item
+     * @param int      $currentPage  The current page number
+     * @param int      $itemsPerPage The number of items we want per page
+     *
+     * @return array The items for the current page
      */
-    protected function parsePagination()
+    protected function parsePagination($getNbResults, $getSlice, $getUrl, $currentPage = 1, $itemsPerPage = 10)
     {
-        $pagination = null;
-        $showFirstPages = false;
-        $showLastPages = false;
-        $useQuestionMark = true;
-
-        // validate pagination array
-        if (!isset($this->pagination['limit'])) {
-            throw new Exception('no limit in the pagination-property.');
-        }
-        if (!isset($this->pagination['offset'])) {
-            throw new Exception('no offset in the pagination-property.');
-        }
-        if (!isset($this->pagination['requested_page'])) {
-            throw new Exception('no requested_page available in the pagination-property.');
-        }
-        if (!isset($this->pagination['num_items'])) {
-            throw new Exception('no num_items available in the pagination-property.');
-        }
-        if (!isset($this->pagination['num_pages'])) {
-            throw new Exception('no num_pages available in the pagination-property.');
-        }
-        if (!isset($this->pagination['url'])) {
-            throw new Exception('no URL available in the pagination-property.');
+        if (!is_callable($getUrl)) {
+            throw new InvalidArgumentException('The getUrl parameter should be a callable function.');
         }
 
-        // should we use a questionmark or an ampersand
-        if (mb_strpos($this->pagination['url'], '?') > 0) {
-            $useQuestionMark = false;
+        $adapter = new \Pagerfanta\Adapter\CallbackAdapter($getNbResults, $getSlice);
+        $pagerFanta = new \Pagerfanta\Pagerfanta($adapter);
+        $pagerFanta->setMaxPerPage($itemsPerPage);
+
+        try {
+            $pagerFanta->setCurrentPage($currentPage);
+        } catch (\Pagerfanta\Exception\LessThan1CurrentPageException $e) {
+            $currentPage = 1;
+            $pagerFanta->setCurrentPage($currentPage);
+        } catch (\Pagerfanta\Exception\OutOfRangeCurrentPageException $e) {
+            $currentPage = $pagerFanta->getNbPages();
+            $pagerFanta->setCurrentPage($currentPage);
         }
 
-        // no pagination needed
-        if ($this->pagination['num_pages'] < 1) {
-            return;
-        }
+        $pages = range(1, $pagerFanta->getNbPages());
+        $pages = array_map(
+            function($pageNumber) use ($getUrl, $currentPage) {
+                return array(
+                    'url' => $getUrl($pageNumber),
+                    'label' => $pageNumber,
+                    'current' => ((int) $pageNumber === (int) $currentPage),
+                );
+            },
+            $pages
+        );
 
-        // populate count fields
-        $pagination['num_pages'] = $this->pagination['num_pages'];
-        $pagination['current_page'] = $this->pagination['requested_page'];
+        $showNext = $pagerFanta->hasNextPage();
+        $nextUrl = ($showNext) ? $pages[$currentPage]['url'] : null;
+        $showPrevious = $pagerFanta->hasPreviousPage();
+        $previousUrl = ($showPrevious) ? $pages[$currentPage - 2]['url'] : null;
 
-        // define anchor
-        $anchor = (isset($this->pagination['anchor'])) ? '#' . $this->pagination['anchor'] : '';
-
-        // as long as we have more then 5 pages and are 5 pages from the end we should show all pages till the end
-        if ($this->pagination['requested_page'] > 5 && $this->pagination['requested_page'] >= ($this->pagination['num_pages'] - 4)) {
-            // init vars
-            $pagesStart = ($this->pagination['num_pages'] > 7) ? $this->pagination['num_pages'] - 5 : $this->pagination['num_pages'] - 6;
-            $pagesEnd = $this->pagination['num_pages'];
-
-            // fix for page 6
-            if ($this->pagination['num_pages'] == 6) {
-                $pagesStart = 1;
-            }
-
-            // show first pages
-            if ($this->pagination['num_pages'] > 7) {
-                $showFirstPages = true;
-            }
-        } elseif ($this->pagination['requested_page'] <= 5) {
-            // as long as we are below page 5 and below 5 from the end we should show all pages starting from 1
-            // init vars
-            $pagesStart = 1;
-            $pagesEnd = 6;
-
-            // when we have 7 pages, show 7 as end
-            if ($this->pagination['num_pages'] == 7) {
-                $pagesEnd = 7;
-            } elseif ($this->pagination['num_pages'] <= 6) {
-
-                // when we have less then 6 pages, show the maximum page
-                $pagesEnd = $this->pagination['num_pages'];
-            }
-
-            // show last pages
-            if ($this->pagination['num_pages'] > 7) {
-                $showLastPages = true;
-            }
-        } else {
-            // page 6
-            // init vars
-            $pagesStart = $this->pagination['requested_page'] - 2;
-            $pagesEnd = $this->pagination['requested_page'] + 2;
-            $showFirstPages = true;
-            $showLastPages = true;
-        }
-
-        // show previous
-        if ($this->pagination['requested_page'] > 1) {
-            // build URL
-            if ($useQuestionMark) {
-                $URL = $this->pagination['url'] . '?page=' . ($this->pagination['requested_page'] - 1);
+        $first = null;
+        $last = null;
+        if ($pagerFanta->getNbPages() > 7) {
+            if ($currentPage < 6) {
+                $last = array_slice($pages, -1);
+                $pages = array_slice($pages, 0, 6);
+            } elseif ($currentPage > $pagerFanta->getNbPages() - 5) {
+                $first = array_slice($pages, 0, 1);
+                $pages = array_slice($pages, -6);
             } else {
-                $URL = $this->pagination['url'] . '&amp;page=' . ($this->pagination['requested_page'] - 1);
-            }
-
-            // set
-            $pagination['show_previous'] = true;
-            $pagination['previous_url'] = $URL . $anchor;
-
-            // flip ahead
-            $this->header->addLink(
-                array(
-                    'rel' => 'prev',
-                    'href' => SITE_URL . $URL . $anchor,
-                )
-            );
-        }
-
-        // show first pages?
-        if ($showFirstPages) {
-            // init var
-            $pagesFirstStart = 1;
-            $pagesFirstEnd = 1;
-
-            // loop pages
-            for ($i = $pagesFirstStart; $i <= $pagesFirstEnd; $i++) {
-                // build URL
-                if ($useQuestionMark) {
-                    $URL = $this->pagination['url'] . '?page=' . $i;
-                } else {
-                    $URL = $this->pagination['url'] . '&amp;page=' . $i;
-                }
-
-                // add
-                $pagination['first'][] = array('url' => $URL . $anchor, 'label' => $i);
+                $first = array_slice($pages, 0, 1);
+                $last = array_slice($pages, -1);
+                $pages = array_slice($pages, $currentPage - 3, 5);
             }
         }
 
-        // build array
-        for ($i = $pagesStart; $i <= $pagesEnd; $i++) {
-            // init var
-            $current = ($i == $this->pagination['requested_page']);
+        $pagination = array(
+            'multiple_pages' => $pagerFanta->haveToPaginate(),
+            'first' => $first,
+            'last' => $last,
+            'pages' => $pages,
+            'show_next' => $showNext,
+            'next_url' => $nextUrl,
+            'show_previous' => $showPrevious,
+            'previous_url' => $previousUrl,
+        );
 
-            // build URL
-            if ($useQuestionMark) {
-                $URL = $this->pagination['url'] . '?page=' . $i;
-            } else {
-                $URL = $this->pagination['url'] . '&amp;page=' . $i;
-            }
-
-            // add
-            $pagination['pages'][] = array('url' => $URL . $anchor, 'label' => $i, 'current' => $current);
-        }
-
-        // show last pages?
-        if ($showLastPages) {
-            // init var
-            $pagesLastStart = $this->pagination['num_pages'];
-            $pagesLastEnd = $this->pagination['num_pages'];
-
-            // loop pages
-            for ($i = $pagesLastStart; $i <= $pagesLastEnd; $i++) {
-                // build URL
-                if ($useQuestionMark) {
-                    $URL = $this->pagination['url'] . '?page=' . $i;
-                } else {
-                    $URL = $this->pagination['url'] . '&amp;page=' . $i;
-                }
-
-                // add
-                $pagination['last'][] = array('url' => $URL . $anchor, 'label' => $i);
-            }
-        }
-
-        // show next
-        if ($this->pagination['requested_page'] < $this->pagination['num_pages']) {
-            // build URL
-            if ($useQuestionMark) {
-                $URL = $this->pagination['url'] . '?page=' . ($this->pagination['requested_page'] + 1);
-            } else {
-                $URL = $this->pagination['url'] . '&amp;page=' . ($this->pagination['requested_page'] + 1);
-            }
-
-            // set
-            $pagination['show_next'] = true;
-            $pagination['next_url'] = $URL . $anchor;
-
-            // flip ahead
-            $this->header->addLink(
-                array(
-                    'rel' => 'next',
-                    'href' => SITE_URL . $URL . $anchor,
-                )
-            );
-        }
-
-        // multiple pages
-        $pagination['multiple_pages'] = ($pagination['num_pages'] == 1) ? false : true;
-
-        // assign pagination
         $this->tpl->assign('pagination', $pagination);
+
+        return $pagerFanta->getCurrentPageResults();
     }
 
     /**

--- a/src/Frontend/Modules/Blog/Actions/Archive.php
+++ b/src/Frontend/Modules/Blog/Actions/Archive.php
@@ -44,20 +44,6 @@ class Archive extends FrontendBaseBlock
     private $endDate;
 
     /**
-     * The pagination array
-     * It will hold all needed parameters, some of them need initialization
-     *
-     * @var    array
-     */
-    protected $pagination = array(
-        'limit' => 10,
-        'offset' => 0,
-        'requested_page' => 1,
-        'num_items' => null,
-        'num_pages' => null
-    );
-
-    /**
      * The requested year
      *
      * @var    int
@@ -119,9 +105,6 @@ class Archive extends FrontendBaseBlock
             $this->redirect(FrontendNavigation::getURL(404));
         }
 
-        // requested page
-        $requestedPage = $this->URL->getParameter('page', 'int', 1);
-
         // rebuild url
         $url = $this->year;
 
@@ -136,31 +119,26 @@ class Archive extends FrontendBaseBlock
             $this->endDate = gmmktime(23, 59, 59, 12, 31, $this->year);
         }
 
-        // set URL and limit
-        $this->pagination['url'] = FrontendNavigation::getURLForBlock('Blog', 'Archive') . '/' . $url;
-        $this->pagination['limit'] = FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10);
+        // requested page
+        $requestedPage = $this->URL->getParameter('page', 'int', 1);
 
-        // populate count fields in pagination
-        $this->pagination['num_items'] = FrontendBlogModel::getAllForDateRangeCount($this->startDate, $this->endDate);
-        $this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
-
-        // redirect if the request page doesn't exists
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
-            $this->redirect(
-                FrontendNavigation::getURL(404)
-            );
-        }
-
-        // populate calculated fields in pagination
-        $this->pagination['requested_page'] = $requestedPage;
-        $this->pagination['offset'] = ($this->pagination['requested_page'] * $this->pagination['limit']) - $this->pagination['limit'];
+        $currentArchiveUrl = FrontendNavigation::getURLForBlock('Blog', 'Archive') . '/' . $url;
+        $startDate = $this->startDate;
+        $endDate = $this->endDate;
 
         // get articles
-        $this->items = FrontendBlogModel::getAllForDateRange(
-            $this->startDate,
-            $this->endDate,
-            $this->pagination['limit'],
-            $this->pagination['offset']
+        $this->items = $this->parsePagination(
+            function() use ($startDate, $endDate) {
+                return FrontendBlogModel::getAllForDateRangeCount($startDate, $endDate);
+            },
+            function($offset, $length) use ($startDate, $endDate) {
+                return FrontendBlogModel::getAllForDateRange($startDate, $endDate, $length, $offset);
+            },
+            function($page) use ($currentArchiveUrl) {
+                return $currentArchiveUrl . '?page=' . $page;
+            },
+            $requestedPage,
+            FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10)
         );
     }
 
@@ -217,8 +195,5 @@ class Archive extends FrontendBaseBlock
 
         // assign allowComments
         $this->tpl->assign('allowComments', FrontendModel::getModuleSetting('Blog', 'allow_comments'));
-
-        // parse the pagination
-        $this->parsePagination();
     }
 }

--- a/src/Frontend/Modules/Blog/Actions/Category.php
+++ b/src/Frontend/Modules/Blog/Actions/Category.php
@@ -38,20 +38,6 @@ class Category extends FrontendBaseBlock
     private $category;
 
     /**
-     * The pagination array
-     * It will hold all needed parameters, some of them need initialization
-     *
-     * @var    array
-     */
-    protected $pagination = array(
-        'limit' => 10,
-        'offset' => 0,
-        'requested_page' => 1,
-        'num_items' => null,
-        'num_pages' => null
-    );
-
-    /**
      * Execute the extra
      */
     public function execute()
@@ -81,9 +67,6 @@ class Category extends FrontendBaseBlock
             'false'
         );
 
-        // requested page
-        $requestedPage = $this->URL->getParameter('page', 'int', 1);
-
         // validate category
         if ($requestedCategory == 'false') {
             $this->redirect(FrontendNavigation::getURL(404));
@@ -92,30 +75,24 @@ class Category extends FrontendBaseBlock
         // set category
         $this->category = $categories[$possibleCategories[$requestedCategory]];
 
-        // set URL and limit
-        $this->pagination['url'] = FrontendNavigation::getURLForBlock('Blog', 'Category') . '/' . $requestedCategory;
-        $this->pagination['limit'] = FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10);
+        // requested page
+        $requestedPage = $this->URL->getParameter('page', 'int', 1);
 
-        // populate count fields in pagination
-        $this->pagination['num_items'] = FrontendBlogModel::getAllForCategoryCount($requestedCategory);
-        $this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
-
-        // redirect if the request page doesn't exists
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
-            $this->redirect(
-                FrontendNavigation::getURL(404)
-            );
-        }
-
-        // populate calculated fields in pagination
-        $this->pagination['requested_page'] = $requestedPage;
-        $this->pagination['offset'] = ($this->pagination['requested_page'] * $this->pagination['limit']) - $this->pagination['limit'];
+        $currentCategoryUrl = FrontendNavigation::getURLForBlock('Blog', 'Category') . '/' . $requestedCategory;
 
         // get articles
-        $this->items = FrontendBlogModel::getAllForCategory(
-            $requestedCategory,
-            $this->pagination['limit'],
-            $this->pagination['offset']
+        $this->items = $this->parsePagination(
+            function() use ($requestedCategory) {
+                return FrontendBlogModel::getAllForCategoryCount($requestedCategory);
+            },
+            function($offset, $length) use ($requestedCategory) {
+                return FrontendBlogModel::getAllForCategory($requestedCategory, $length, $offset);
+            },
+            function($page) use ($currentCategoryUrl) {
+                return $currentCategoryUrl . '?page=' . $page;
+            },
+            $requestedPage,
+            FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10)
         );
     }
 
@@ -163,8 +140,5 @@ class Category extends FrontendBaseBlock
 
         // assign articles
         $this->tpl->assign('items', $this->items);
-
-        // parse the pagination
-        $this->parsePagination();
     }
 }

--- a/src/Frontend/Modules/Blog/Actions/Index.php
+++ b/src/Frontend/Modules/Blog/Actions/Index.php
@@ -30,20 +30,6 @@ class Index extends FrontendBaseBlock
     private $items;
 
     /**
-     * The pagination array
-     * It will hold all needed parameters, some of them need initialization.
-     *
-     * @var    array
-     */
-    protected $pagination = array(
-        'limit' => 10,
-        'offset' => 0,
-        'requested_page' => 1,
-        'num_items' => null,
-        'num_pages' => null
-    );
-
-    /**
      * Execute the extra
      */
     public function execute()
@@ -62,32 +48,22 @@ class Index extends FrontendBaseBlock
         // requested page
         $requestedPage = $this->URL->getParameter('page', 'int', 1);
 
-        // set URL and limit
-        $this->pagination['url'] = FrontendNavigation::getURLForBlock('Blog');
-        $this->pagination['limit'] = FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10);
-
-        // populate count fields in pagination
-        $this->pagination['num_items'] = FrontendBlogModel::getAllCount();
-        $this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
-
-        // num pages is always equal to at least 1
-        if ($this->pagination['num_pages'] == 0) {
-            $this->pagination['num_pages'] = 1;
-        }
-
-        // redirect if the request page doesn't exist
-        if ($requestedPage > $this->pagination['num_pages'] || $requestedPage < 1) {
-            $this->redirect(
-                FrontendNavigation::getURL(404)
-            );
-        }
-
-        // populate calculated fields in pagination
-        $this->pagination['requested_page'] = $requestedPage;
-        $this->pagination['offset'] = ($this->pagination['requested_page'] * $this->pagination['limit']) - $this->pagination['limit'];
+        $blogUrl = FrontendNavigation::getURLForBlock('Blog');
 
         // get articles
-        $this->items = FrontendBlogModel::getAll($this->pagination['limit'], $this->pagination['offset']);
+        $this->items = $this->parsePagination(
+            function() {
+                return FrontendBlogModel::getAllCount();
+            },
+            function($offset, $length) {
+                return FrontendBlogModel::getAll($length, $offset);
+            },
+            function($page) use ($blogUrl) {
+                return $blogUrl . '?page=' . $page;
+            },
+            $requestedPage,
+            FrontendModel::getModuleSetting('Blog', 'overview_num_items', 10)
+        );
     }
 
     /**
@@ -111,8 +87,5 @@ class Index extends FrontendBaseBlock
 
         // assign articles
         $this->tpl->assign('items', $this->items);
-
-        // parse the pagination
-        $this->parsePagination();
     }
 }

--- a/src/Frontend/Modules/Search/Actions/Index.php
+++ b/src/Frontend/Modules/Search/Actions/Index.php
@@ -56,20 +56,6 @@ class Index extends FrontendBaseBlock
     private $offset;
 
     /**
-     * The pagination array
-     * It will hold all needed parameters, some of them need initialization.
-     *
-     * @var    array
-     */
-    protected $pagination = array(
-        'limit' => 20,
-        'offset' => 0,
-        'requested_page' => 1,
-        'num_items' => null,
-        'num_pages' => null
-    );
-
-    /**
      * The requested page
      *
      * @var    int
@@ -97,11 +83,10 @@ class Index extends FrontendBaseBlock
     {
         // set variables
         $this->requestedPage = $this->URL->getParameter('page', 'int', 1);
+        $this->url = FrontendNavigation::getURLForBlock('Search') . '?form=search&q=' . $this->term;
         $this->limit = FrontendModel::getModuleSetting('Search', 'overview_num_items', 20);
-        $this->offset = ($this->requestedPage * $this->limit) - $this->limit;
         $this->cacheFile = FRONTEND_CACHE_PATH . '/' . $this->getModule() . '/' .
-                           FRONTEND_LANGUAGE . '_' . md5($this->term) . '_' .
-                           $this->offset . '_' . $this->limit . '.php';
+                           FRONTEND_LANGUAGE . '_' . md5($this->term) . '.php';
 
         // load the cached data
         if (!$this->getCachedData()) {
@@ -159,9 +144,22 @@ class Index extends FrontendBaseBlock
         // include cache file
         require_once $this->cacheFile;
 
+        $url = $this->url;
+
         // set info (received from cache)
-        $this->pagination = $pagination;
-        $this->items = $items;
+        $this->items = $this->parsePagination(
+            function() use ($items) {
+                return count($items);
+            },
+            function($offset, $length) use($items) {
+                return array_slice($items, $offset, $length);
+            },
+            function($page) use ($url) {
+                return $url . '&page=' . $page;
+            },
+            $this->requestedPage,
+            $this->limit
+        );
 
         return true;
     }
@@ -176,38 +174,23 @@ class Index extends FrontendBaseBlock
             return;
         }
 
-        // set url
-        $this->pagination['url'] = FrontendNavigation::getURLForBlock('Search') . '?form=search&q=' . $this->term;
-
-        // populate calculated fields in pagination
-        $this->pagination['limit'] = $this->limit;
-        $this->pagination['offset'] = $this->offset;
-        $this->pagination['requested_page'] = $this->requestedPage;
+        $url = $this->url;
 
         // get items
-        $this->items = FrontendSearchModel::search(
-            $this->term,
-            $this->pagination['limit'],
-            $this->pagination['offset']
+        $allItems = FrontendSearchModel::search($this->term, 0);
+        $this->items = $this->parsePagination(
+            function() use ($allItems) {
+                return count($allItems);
+            },
+            function($offset, $length) use($allItems) {
+                return array_slice($allItems, $offset, $length);
+            },
+            function($page) use ($url) {
+                return $url . '?page=' . $page;
+            },
+            $this->requestedPage,
+            $this->limit
         );
-
-        // populate count fields in pagination
-        // this is done after actual search because some items might be
-        // activated/deactivated (getTotal only does rough checking)
-        $this->pagination['num_items'] = FrontendSearchModel::getTotal($this->term);
-        $this->pagination['num_pages'] = (int) ceil($this->pagination['num_items'] / $this->pagination['limit']);
-
-        // num pages is always equal to at least 1
-        if ($this->pagination['num_pages'] == 0) {
-            $this->pagination['num_pages'] = 1;
-        }
-
-        // redirect if the request page doesn't exist
-        if ($this->requestedPage > $this->pagination['num_pages'] || $this->requestedPage < 1) {
-            $this->redirect(
-                FrontendNavigation::getURL(404)
-            );
-        }
 
         // debug mode = no cache
         if (!SPOON_DEBUG) {
@@ -215,10 +198,7 @@ class Index extends FrontendBaseBlock
             $fs = new Filesystem();
             $fs->dumpFile(
                 $this->cacheFile,
-                "<?php\n" . '$pagination = ' . var_export($this->pagination, true) . ";\n" . '$items = ' . var_export(
-                    $this->items,
-                    true
-                ) . ";\n?>"
+                "<?php\n" . '$items = ' . var_export($allItems, true) . ";\n?>"
             );
         }
     }
@@ -269,9 +249,6 @@ class Index extends FrontendBaseBlock
         // assign articles
         $this->tpl->assign('searchResults', $this->items);
         $this->tpl->assign('searchTerm', $this->term);
-
-        // parse the pagination
-        $this->parsePagination();
     }
 
     /**

--- a/src/Frontend/Modules/Search/Engine/Model.php
+++ b/src/Frontend/Modules/Search/Engine/Model.php
@@ -128,10 +128,14 @@ class Model
                 'SELECT i0.module, i0.other_id, ' . implode(' + ', $order) . ' AS score
                  FROM ' . implode(' INNER JOIN ', $join) . '
                  WHERE ' . implode(' AND ', $where) . '
-                 ORDER BY score DESC
-                 LIMIT ?, ?';
+                 ORDER BY score DESC';
 
-            $params = array_merge($params1, $params2, array($offset, $limit));
+            $params = array_merge($params1, $params2);
+
+            if ($limit > 0) {
+                $query .= ' LIMIT ?, ?';
+                $params = array_merge($params, array($offset, $limit));
+            }
         } else {
             // simple search
             // get all terms to search for (including synonyms)
@@ -163,14 +167,18 @@ class Model
                     -4
                 ) . ') AND i.language = ? AND i.active = ? AND m.searchable = ?
                  GROUP BY module, other_id
-                 ORDER BY score DESC
-                 LIMIT ?, ?';
+                 ORDER BY score DESC';
 
             $params = array_merge(
                 $terms,
                 $terms,
-                array(FRONTEND_LANGUAGE, 'Y', 'Y', $offset, $limit)
+                array(FRONTEND_LANGUAGE, 'Y', 'Y')
             );
+
+            if ($limit > 0) {
+                $query .= ' LIMIT ?, ?';
+                $params = array_merge($params, array($offset, $limit));
+            }
         }
 
         return (array) FrontendModel::getContainer()->get(


### PR DESCRIPTION
This is a revisited version of https://github.com/forkcms/forkcms/pull/789, an effort to make pagerfanta do the pagination, instead of having pagination all mixed up between our real controller/action code. Back then, the whole dataset needed to be loaded to be able to do the pagination.

I've now changed the code to work with pagerfanta's `CallbackAdapter`, which enables us to define two callbacks, one for a 'count' of the whole dataset, and one for a 'slice' of the dataset. As a result, we can now keep using e.g. `FrontendBlogModel::getAllCount()` methods for the counting, while also using pagerfanta in a memory efficient way. I've implemented this for the blog module. For the search module, there's this problem with caching.

Currently, the cache works like this:

- We get a page number
- We calculate the limit / offset for the search results based on the number of results per page
- We store the results for the given query + limit/offset in a file, **along with the pagination data**
- If the cached page is requested, the pagination data is loaded from the cache.

The problem is, to do that, the pagination data needs to be a class variable, accessible to the whole controller/action, which in turn is really bad for the separation of concerns that i'm trying to accomplish by making pagination less of a controller issue. That's why for the search module, i've done it like before: load the whole dataset in an array, and cache the whole thing. I'm aware this is an issue. Please don't merge if you don't feel comfortable about it. Help me find an elegant solution :goat: