### PR TITLE
Images missing width limitations

### DIFF
--- a/src/Backend/Core/Layout/Css/imports/structure.css
+++ b/src/Backend/Core/Layout/Css/imports/structure.css
@@ -71,7 +71,7 @@ body {
 }
 
 #contentHolder .inner img {
-    max-width: 600px;
+	max-width: 600px;
 }
 
 #mainHolder {


### PR DESCRIPTION
Hi, i dunno if i put this in a right way, but fork needs this. When user uploads image on some module like slideshows or similiar and enters into edit view that view will be streched as long as image is, so you cant press save or other buttons easily it ruins whole edit page. Please take this notice this bug is very old.
