### PR TITLE
Bug: Crash because memory limit is too low

### DIFF
--- a/src/Install/Engine/Step7.php
+++ b/src/Install/Engine/Step7.php
@@ -98,6 +98,9 @@ class Step7 extends Step
     {
         // extend execution limit
         set_time_limit(0);
+        
+        // extend memory limit
+        ini_set('memory_limit','256M');
 
         // validate all previous steps
         if (!$this->validateForm()) {


### PR DESCRIPTION
On Step 7 installation crashes and symfony2 exception pops out that says memory limit has been exceeded. We have been talked about this, but no action were taken. :) So i decided to PR.
