### PR TITLE
Use custom pagetitle for homepage

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1284,14 +1284,15 @@ class Model
         $html .= '	<ul>' . "\n";
         $html .= '		<li id="page-1" rel="home">';
 
-        // homepage should
+        // create homepage anchor from title
+        $homePage = self::get(1);
         $html .= '			<a href="' .
                  BackendModel::createURLForAction(
                      'Edit',
                      null,
                      null,
                      array('id' => 1)
-                 ) . '"><ins>&#160;</ins>' . \SpoonFilter::ucfirst(BL::lbl('Home')) . '</a>' . "\n";
+                 ) . '"><ins>&#160;</ins>' . $homePage['title'] . '</a>' . "\n";
 
         // add subpages
         $html .= self::getSubTree($navigation, 1);


### PR DESCRIPTION
If you changed the homepage title, the pagetree element didn't change and still used "Home". Now it will use the pagetitle instead of a hardcoded label 'Home'.

This fixes #886
