### PR TITLE
Updated comment to fix Doctrine creating getters/setters using CLI

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Copy.php
+++ b/src/Backend/Modules/Pages/Actions/Copy.php
@@ -17,7 +17,7 @@ use Backend\Modules\Pages\Engine\Model as BackendPagesModel;
 /**
  * BackendPagesCopy
  * This is the copy-action, it will copy pages from one language to another
- * @remark :    IMPORTANT existing data will be removed, this feature is also experimental!
+ * Remark :    IMPORTANT existing data will be removed, this feature is also experimental!
  *
  * @author Tijs Verkoyen <tijs@sumocoders.be>
  * @author Sam Tubbax <sam@sumocoders.be>


### PR DESCRIPTION
## Problem

When using the CLI for generating getters/settings with Doctrine,
The following line

``` bash
app/console generate:doctrine:entities
```

Throw the following error:

``` bash
[Doctrine\Common\Annotations\AnnotationException]                                                                                                                               
[Semantical Error] The annotation "@remark" in class Backend\Modules\Pages\Actions\Copy was never imported. Did you maybe forget to add a "use" statement for this annotation? 
```
## Solution

So I removed the "@"-sign.
