### PR TITLE
Add info about removing the installer.

### DIFF
--- a/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step6.html.twig
+++ b/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step6.html.twig
@@ -18,6 +18,9 @@
       </td>
     </tr>
   </table>
+  <p class="helpTxt">
+    You can disable the installer by removing the installer routes in app/config/routing.yml and clearing the cache.
+  </p>
 
   <div class="buttonHolder">
     <a class="button" href="/">View your new website</a>


### PR DESCRIPTION
This way, developers will less likely forget to remove the installer
from the routes.
