### PR TITLE
Remove kernel.charset from parameters file.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -6,7 +6,6 @@ parameters:
     database.user:          <database-user>
     database.password:      <database-password>
 
-    kernel.charset:         'utf-8'
     kernel.secret:          <secret>
 
     fork.debug_email:       <debug-email>

--- a/app/config/parameters_install.yml
+++ b/app/config/parameters_install.yml
@@ -6,7 +6,6 @@ parameters:
     database.user:          ~
     database.password:      ~
 
-    kernel.charset:         'utf-8'
     kernel.secret:          installation
 
     fork.debug_email:       ~


### PR DESCRIPTION
This parameter is automatically set in the Symfony kernel.
https://github.com/symfony/HttpKernel/blob/master/Kernel.php#L596

It uses the getCharset method. https://github.com/symfony/HttpKernel/blob/master/Kernel.php#L448-L451so it's always set to UTF-8
