### PR TITLE
add language parameter

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -885,7 +885,7 @@ class Model extends \BaseModel
 
         // get the URL, if it doesn't exist return 404
         if (!isset($keys[$pageId])) {
-            return self::getURL(404);
+            return self::getURL(404, $language);
         } else {
             $URL .= $keys[$pageId];
         }


### PR DESCRIPTION
Using this method in the frontend with a non-existing pageId will throw an error. The 404-page can't be found due to the missing language, thus creating an endless loop.
