### PR TITLE
Clear the PHP5.5+ opcode cache after changing php files.

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -1170,6 +1170,11 @@ class Model extends \BaseModel
                 $fs->remove($file->getRealPath());
             }
         }
+
+        // clear the php5.5+ opcode cache
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
     }
 
     /**

--- a/src/Backend/Modules/Locale/Engine/CacheBuilder.php
+++ b/src/Backend/Modules/Locale/Engine/CacheBuilder.php
@@ -145,11 +145,19 @@ class CacheBuilder
      */
     protected function dumpPhpCache($language, $application)
     {
+        $filePath = constant(mb_strtoupper($application) . '_CACHE_PATH')
+            . '/Locale/' . $language . '.php';
+
         $fs = new Filesystem();
         $fs->dumpFile(
-            constant(mb_strtoupper($application) . '_CACHE_PATH') . '/Locale/' . $language . '.php',
+            $filePath,
             $this->buildPhpCache($language, $application)
         );
+
+        // clear the php5.5+ opcode cache
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($filePath);
+        }
     }
 
     /**

--- a/src/Backend/Modules/Pages/Engine/CacheBuilder.php
+++ b/src/Backend/Modules/Pages/Engine/CacheBuilder.php
@@ -44,18 +44,23 @@ class CacheBuilder
         list($keys, $navigation) = $this->getData($language);
 
         $fs = new Filesystem();
+        $cachePath = FRONTEND_CACHE_PATH . '/Navigation/';
+        $keysFile = $cachePath . 'keys_' . $language . '.php';
+        $fs->dumpFile($keysFile, $this->dumpKeys($keys, $language));
+
+        $phpFile = $cachePath . 'navigation_' . $language . '.php';
+        $fs->dumpFile($phpFile, $this->dumpNavigation($navigation, $language));
+
         $fs->dumpFile(
-            FRONTEND_CACHE_PATH . '/Navigation/keys_' . $language . '.php',
-           $this->dumpKeys($keys, $language)
-        );
-        $fs->dumpFile(
-            FRONTEND_CACHE_PATH . '/Navigation/navigation_' . $language . '.php',
-            $this->dumpNavigation($navigation, $language)
-        );
-        $fs->dumpFile(
-            FRONTEND_CACHE_PATH . '/Navigation/editor_link_list_' . $language . '.js',
+            $cachePath . 'editor_link_list_' . $language . '.js',
             $this->dumpEditorLinkList($navigation, $keys, $language)
         );
+
+        // clear the php5.5+ opcode cache
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($keysFile);
+            opcache_invalidate($phpFile);
+        }
     }
 
     /**

--- a/src/Backend/Modules/Search/Engine/Model.php
+++ b/src/Backend/Modules/Search/Engine/Model.php
@@ -172,6 +172,11 @@ class Model
         foreach ($finder->files()->in(FRONTEND_CACHE_PATH . '/Search/') as $file) {
             $fs->remove($file->getRealPath());
         }
+
+        // clear the php5.5+ opcode cache
+        if (function_exists('opcache_reset')) {
+            opcache_reset();
+        }
     }
 
     /**


### PR DESCRIPTION
Some stuff in Fork is cached in php files. The php5.5+ opcode cache doesn't see any changes when we manipulate this file. We thus need to clear the opcode cache after changing/removing these files.