### PR TITLE
Capitalize blog module & action names

### DIFF
--- a/src/Backend/Modules/Blog/Actions/Add.php
+++ b/src/Backend/Modules/Blog/Actions/Add.php
@@ -201,7 +201,7 @@ class Add extends BackendBaseActionAdd
 
                     // ping
                     if (BackendModel::getModuleSetting($this->getModule(), 'ping_services', false)) {
-                        BackendModel::ping(SITE_URL . BackendModel::getURLForBlock('blog', 'detail') . '/' . $this->meta->getURL());
+                        BackendModel::ping(SITE_URL . BackendModel::getURLForBlock('Blog', 'Detail') . '/' . $this->meta->getURL());
                     }
 
                     // everything is saved, so redirect to the overview

--- a/src/Backend/Modules/Blog/Actions/Comments.php
+++ b/src/Backend/Modules/Blog/Actions/Comments.php
@@ -46,7 +46,7 @@ class Comments extends BackendBaseActionIndex
     public static function addPostData($text, $title, $URL, $id)
     {
         // reset URL
-        $URL = BackendModel::getURLForBlock('blog', 'detail') . '/' . $URL . '#comment-' . $id;
+        $URL = BackendModel::getURLForBlock('Blog', 'Detail') . '/' . $URL . '#comment-' . $id;
 
         // build HTML
         return '<p><em>' . sprintf(BL::msg('CommentOnWithURL'), $URL, $title) . '</em></p>' . "\n" . (string) $text;

--- a/src/Backend/Modules/Blog/Engine/Api.php
+++ b/src/Backend/Modules/Blog/Engine/Api.php
@@ -98,7 +98,7 @@ class Api
                 $item['comment']['article']['@attributes']['lang'] = $row['post_language'];
                 $item['comment']['article']['title'] = $row['post_title'];
                 $item['comment']['article']['url'] = SITE_URL .
-                    BackendModel::getURLForBlock('blog', 'detail', $row['post_language']) . '/' . $row['post_url']
+                    BackendModel::getURLForBlock('Blog', 'Detail', $row['post_language']) . '/' . $row['post_url']
                 ;
 
                 // set attributes
@@ -152,7 +152,7 @@ class Api
             $item['comment']['article']['@attributes']['lang'] = $comment['language'];
             $item['comment']['article']['title'] = $comment['post_title'];
             $item['comment']['article']['url'] = SITE_URL .
-                BackendModel::getURLForBlock('blog', 'detail', $comment['language']) . '/' . $comment['post_url']
+                BackendModel::getURLForBlock('Blog', 'Detail', $comment['language']) . '/' . $comment['post_url']
             ;
 
             // set attributes


### PR DESCRIPTION
I noticed on a live server that I got a /404 instead of the blog name & action url. When I capitalized "Blog" and "Detail", I got the correct url...
