### PR TITLE
Deny access to app logs & config - information disclosure fix

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -17,6 +17,8 @@ FileETag MTime Size
 	RewriteRule composer\.json - [F]
 	RewriteRule composer\.lock - [F]
 	RewriteRule .*\.md - [F]
+	RewriteRule app/logs - [F]
+	RewriteRule app/config - [F]
 	RewriteRule src/Frontend/Cache/CachedTemplates - [F]
 	RewriteRule src/Frontend/Cache/CompiledTemplates - [F]
 	RewriteRule src/Frontend/Cache/Config - [F]


### PR DESCRIPTION
An information disclosure vulnerability exists in all forkcms versions.

Example:
* http://public.teamleader.be/app/logs/logs.log
* http://www.fork-cms.com/app/logs/logs.log

Looks like wouter logged in 4 times since 2014-12-28 :smile:
```
[2014-12-12 08:39:30] app.INFO: Successfully authenticated user 'wouter.sioen@wijs.be'. [] []
[2014-12-26 08:39:39] app.INFO: Successfully authenticated user 'wouter.sioen@wijs.be'. [] []
[2014-12-30 16:03:09] app.INFO: Successfully authenticated user 'wouter.sioen@wijs.be'. [] []
[2014-12-30 16:15:35] app.INFO: Successfully authenticated user 'wouter.sioen@wijs.be'. [] []
```
Older versions of forkcms can also be patches using this fix.

Also added the config folder in case someone forgets the htaccess file in the config directory.
