### PR TITLE
fix #1024 : getPageTreeType method update for CacheBuilder class

### DIFF
--- a/src/Backend/Modules/Pages/Engine/CacheBuilder.php
+++ b/src/Backend/Modules/Pages/Engine/CacheBuilder.php
@@ -147,7 +147,7 @@ class CacheBuilder
         return $pageData;
     }
 
-    protected function getPageTreeType($page, $pageData)
+    protected function getPageTreeType($page, &$pageData)
     {
         // calculate tree-type
         $treeType = 'page';


### PR DESCRIPTION
This pull request updates the CacheBuilder getPageTreeType method and fixes the redirection issue.