### PR TITLE
Doctrine integration: Use DateTime-objects directly in the template

### DIFF
--- a/src/Backend/Core/Engine/TemplateModifiers.php
+++ b/src/Backend/Core/Engine/TemplateModifiers.php
@@ -31,10 +31,10 @@ class TemplateModifiers
     }
 
     /**
-     * Format a UNIX-timestamp as a date
+     * Format a UNIX-timestamp or DateTime-object as a date
      * syntax: {$var|formatdate}
      *
-     * @param int $var The UNIX-timestamp to format.
+     * @param mixed $var The UNIX-timestamp or DateTime-object to format.
      * @return string
      */
     public static function formatDate($var)
@@ -42,21 +42,29 @@ class TemplateModifiers
         // get setting
         $format = Authentication::getUser()->getSetting('date_format');
 
+        if ($var instanceof \DateTime) {
+            $var = BackendModel::getUTCDate('U', $var->format('U'));
+        }
+
         // format the date
         return \SpoonDate::getDate($format, (int) $var, Language::getInterfaceLanguage());
     }
 
     /**
-     * Format a UNIX-timestamp as a datetime
+     * Format a UNIX-timestamp or DateTime-object as a datetime
      * syntax: {$var|formatdatetime}
      *
-     * @param int $var The UNIX-timestamp to format.
+     * @param mixed $var The UNIX-timestamp or DateTime-object to format.
      * @return string
      */
     public static function formatDateTime($var)
     {
         // get setting
         $format = Authentication::getUser()->getSetting('datetime_format');
+
+        if ($var instanceof \DateTime) {
+            $var = BackendModel::getUTCDate('U', $var->format('U'));
+        }
 
         // format the date
         return \SpoonDate::getDate($format, (int) $var, Language::getInterfaceLanguage());
@@ -124,16 +132,20 @@ class TemplateModifiers
     }
 
     /**
-     * Format a UNIX-timestamp as a date
+     * Format a UNIX-timestamp or DateTime-object as a time
      * syntax: {$var|formatdate}
      *
-     * @param int $var The UNIX-timestamp to format.
+     * @param mixed $var The UNIX-timestamp or DateTime-object to format.
      * @return string
      */
     public static function formatTime($var)
     {
         // get setting
         $format = Authentication::getUser()->getSetting('time_format');
+
+        if ($var instanceof \DateTime) {
+            $var = BackendModel::getUTCDate('U', $var->format('U'));
+        }
 
         // format the date
         return \SpoonDate::getDate($format, (int) $var, Language::getInterfaceLanguage());

--- a/src/Frontend/Core/Engine/Template.php
+++ b/src/Frontend/Core/Engine/Template.php
@@ -237,6 +237,8 @@ class Template extends \SpoonTemplate
         $this->mapModifier('stripnewlines', array('Frontend\Core\Engine\TemplateModifiers', 'stripNewlines'));
 
         // dates
+        $this->mapModifier('date', array('Frontend\Core\Engine\TemplateModifiers', 'date'));
+        $this->mapModifier('formatdatetime', array('Frontend\Core\Engine\TemplateModifiers', 'formatDateTime'));
         $this->mapModifier('timeago', array('Frontend\Core\Engine\TemplateModifiers', 'timeAgo'));
 
         // users

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -53,6 +53,21 @@ class TemplateModifiers
     }
 
     /**
+     * Format a UNIX-timestamp or DateTime-object as a date
+     * syntax: {$var|date[:format][:language][:GMT]}
+     *
+     * @param mixed   $var      The UNIX-timestamp or DateTime-object to format.
+     * @param string  $format   The date format, if not provided we will use the date_format_long.
+     * @param string  $language The language to use, if not provided we will use the loaded language.
+     * @param boolean $GMT      Should we consider this timestamp or DateTime-object to be GMT/UTC?
+     * @return string
+     */
+    public static function date($var, $format = null, $language = null, $GMT = false)
+    {
+        return self::formatDateTime($var, $format, $language, $GMT);
+    }
+
+    /**
      * Dumps the data
      *    syntax: {$var|dump}
      *
@@ -84,6 +99,29 @@ class TemplateModifiers
                 return '€ ' . number_format((float) $var, $decimals, ',', ' ');
                 break;
         }
+    }
+
+    /**
+     * Format a UNIX-timestamp or DateTime-object as a datetime
+     * syntax: {$var|formatdatetime[:format][:language][:GMT]}
+     *
+     * @param mixed   $var      The UNIX-timestamp or DateTime-object to format.
+     * @param string  $format   The date format, if not provided we will use the date_format_long.
+     * @param string  $language The language to use, if not provided we will use the loaded language.
+     * @param boolean $GMT      Should we consider this timestamp or DateTime-object to be GMT/UTC?
+     * @return string
+     */
+    public static function formatDateTime($var, $format = null, $language = null, $GMT = false)
+    {
+        if ($var instanceof \DateTime) $var = $var->format('U');
+        if ($format === null) $format = Model::getModuleSetting('Core', 'date_format_long');
+
+        $var = (int) $var;
+
+        // invalid timestamp
+        if ($var == 0) return '';
+
+        return \SpoonDate::getDate($format, $var, $language, $GMT);
     }
 
     /**
@@ -456,14 +494,15 @@ class TemplateModifiers
     }
 
     /**
-     * Formats a timestamp as a string that indicates the time ago
+     * Formats a timestamp or DateTime-object as a string that indicates the time ago
      *    syntax: {$var|timeago}
      *
-     * @param string $var A UNIX-timestamp that will be formatted as a time-ago-string.
+     * @param string|DateTime $var A UNIX-timestamp or DateTime-object that will be formatted as a time-ago-string.
      * @return string
      */
     public static function timeAgo($var = null)
     {
+        if ($var instanceof \DateTime) $var = $var->format('U');
         $var = (int) $var;
 
         // invalid timestamp


### PR DESCRIPTION
With this PR it's possible to use DateTime-objects directly in the template using the default Fork CMS template modifiers 

Backend modifiers: formatdate, formatdatetime, formattime.
Frontend modifiers: date, formatdatetime.

Temporary solution until twig is integrated.