### PR TITLE
Bugfix: fixed error in backend user edit, when updating your own account...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.8.6 (2015-xx-xx)
+--
+Bugfixes:
+
+* Users: Fixed error in backend user edit, when updating your own account.
+
+
 3.8.5 (2015-01-14)
 --
 Improvements:
@@ -9,6 +16,7 @@ Bugfixes:
 
 * Core: Make sure logs aren't publically accessible
 * Core: Make sure PHP 5.5+'s opcode cache is now cleared after updating code
+
 
 3.8.4 (2014-12-26)
 --

--- a/src/Backend/Modules/Users/Actions/Edit.php
+++ b/src/Backend/Modules/Users/Actions/Edit.php
@@ -307,7 +307,7 @@ class Edit extends BackendBaseActionEdit
                 }
 
                 // user is now de-activated, we now remove all sessions for this user so he is logged out immediately
-                if ($user['active'] === 'N' && $this->record['active'] !== $user['active']) {
+                if (isset($user['active']) && $user['active'] === 'N' && $this->record['active'] !== $user['active']) {
                     // delete all sessions for user
                     BackendModel::get('database')->delete(
                         'users_sessions',


### PR DESCRIPTION
When editing your own user account in the backend you will get this error:
```
Notice: Undefined index: active in /data/www/myproject/htdocs/src/Backend/Modules/Users/Actions/Edit.php line 310
```

This has been fixed.
