### PR TITLE
the hash wasn't used in the constructor

### DIFF
--- a/src/Frontend/Core/Engine/Form.php
+++ b/src/Frontend/Core/Engine/Form.php
@@ -50,12 +50,22 @@ class Form extends \SpoonForm
         $this->header = Model::getContainer()->get('header');
 
         $name = (string) $name;
-        $hash = ($hash !== null) ? (string) $hash : null;
+
+        if ($hash !== null && strlen($hash) > 0) {
+            $hash = (string) $hash;
+            // check if the # is present
+            if ($hash[0] !== '#') {
+                $hash = '#' . $hash;
+            }
+        } else {
+            $hash = null;
+        }
+
         $useToken = (bool) $useToken;
         $action = ($action === null) ? '/' . $this->URL->getQueryString() : (string) $action;
 
         // call the real form-class
-        parent::__construct((string) $name, $action, $method, (bool) $useToken);
+        parent::__construct((string) $name, $action . $hash, $method, (bool) $useToken);
 
         // add default classes
         $this->setParameter('id', $name);


### PR DESCRIPTION
now we can link to the hash of the form so that the page loads at the position of the hash if there are errors