### PR TITLE
Add module prefix to the dashboard widget checkboxes.

### DIFF
--- a/src/Backend/Modules/Groups/Actions/Add.php
+++ b/src/Backend/Modules/Groups/Actions/Add.php
@@ -234,6 +234,8 @@ class Add extends BackendBaseActionAdd
 
                     // add to array
                     $this->widgets[] = array(
+                        'module_name' => $module,
+                        'checkbox_name' => \SpoonFilter::toCamelCase($module) . \SpoonFilter::toCamelCase($widgetName),
                         'label' => \SpoonFilter::toCamelCase($widgetName),
                         'value' => $widgetName,
                         'description' => $description
@@ -366,13 +368,22 @@ class Add extends BackendBaseActionAdd
                 )
             );
 
+            // loop through selected widgets
             foreach ($widgetPresets as $preset) {
+                // if selected
                 if ($preset->getChecked()) {
-                    // remove widgets_ prefix
-                    $selected = str_replace('widgets_', '', $preset->getName());
+                    // get the preset module name
+                    $presetModule = str_replace('widgets_', '', str_replace($widget['widget'], '', $preset->getName()));
 
-                    // if right widget set visible
-                    if ($selected == $widget['widget']) $this->dashboardSequence[$widget['module']][$widget['widget']]['present'] = true;
+                    // if the preset module name matches the widget module name
+                    if($presetModule == $widget['module'])
+                    {
+                        // remove widgets_[modulename] prefix
+                        $selected = str_replace('widgets_' . $widget['module'], '', $preset->getName());
+
+                        // if right widget set visible
+                        if ($selected == $widget['widget']) $this->dashboardSequence[$widget['module']][$widget['widget']]['present'] = true;
+                    }
                 }
             }
         }
@@ -403,7 +414,8 @@ class Add extends BackendBaseActionAdd
             // loop through widgets
             foreach ($this->widgets as $j => $widget) {
                 // add widget checkboxes
-                $widgetBoxes[$j]['checkbox'] = '<span>' . $this->frm->addCheckbox('widgets_' . $widget['label'])->parse() . '</span>';
+                $widgetBoxes[$j]['checkbox'] = '<span>' . $this->frm->addCheckbox('widgets_' . $widget['checkbox_name'])->parse() . '</span>';
+                $widgetBoxes[$j]['module'] = \SpoonFilter::ucfirst(BL::lbl($widget['module_name']));
                 $widgetBoxes[$j]['widget'] = '<label for="widgets' . \SpoonFilter::toCamelCase($widget['label']) . '">' . $widget['label'] . '</label>';
                 $widgetBoxes[$j]['description'] = $widget['description'];
             }
@@ -517,7 +529,7 @@ class Add extends BackendBaseActionAdd
             }
 
             // loop through widgets and collect presets
-            foreach ($this->widgets as $widget) $widgetPresets[] = $this->frm->getField('widgets_' . $widget['label']);
+            foreach ($this->widgets as $widget) $widgetPresets[] = $this->frm->getField('widgets_' . $widget['checkbox_name']);
 
             // validate fields
             $nameField->isFilled(BL::err('NameIsRequired'));

--- a/src/Backend/Modules/Groups/Actions/Edit.php
+++ b/src/Backend/Modules/Groups/Actions/Edit.php
@@ -250,6 +250,8 @@ class Edit extends BackendBaseActionEdit
 
                     // add to array
                     $this->widgets[] = array(
+                        'checkbox_name' => \SpoonFilter::toCamelCase($module) . \SpoonFilter::toCamelCase($widgetName),
+                        'module_name' => $module,
                         'label' => \SpoonFilter::toCamelCase($widgetName),
                         'value' => $widgetName,
                         'description' => $description
@@ -306,16 +308,19 @@ class Edit extends BackendBaseActionEdit
         foreach ($this->modules as $key => $module) {
             // widgets available?
             if (isset($this->widgets)) {
+
                 // loop through widgets
                 foreach ($this->widgets as $j => $widget) {
                     // widget is present?
-                    if (isset($this->dashboardSequence[$module['value']][$widget['value']]['present']) && $this->dashboardSequence[$module['value']][$widget['value']]['present'] === true) {
-                        // add to array
-                        $selectedWidgets[$j] = $widget['value'];
+                    if (isset($this->dashboardSequence[$module['value']][$widget['value']]['present']) &&
+                        $this->dashboardSequence[$module['value']][$widget['value']]['present'] === true &&
+                        $widget['checkbox_name'] == $module['value'] . $widget['value']) {
+                        $selectedWidgets[$j] = $widget['checkbox_name'];
                     }
 
                     // add widget checkboxes
-                    $widgetBoxes[$j]['checkbox'] = '<span>' . $this->frm->addCheckbox('widgets_' . $widget['label'], isset($selectedWidgets[$j]) ? $selectedWidgets[$j] : null)->parse() . '</span>';
+                    $widgetBoxes[$j]['checkbox'] = '<span>' . $this->frm->addCheckbox('widgets_' . $widget['checkbox_name'], isset($selectedWidgets[$j]) ? $selectedWidgets[$j] : null)->parse() . '</span>';
+                    $widgetBoxes[$j]['module'] = \SpoonFilter::ucfirst(BL::lbl($widget['module_name']));
                     $widgetBoxes[$j]['widget'] = '<label for="widgets' . \SpoonFilter::toCamelCase($widget['label']) . '">' . $widget['label'] . '</label>';
                     $widgetBoxes[$j]['description'] = $widget['description'];
                 }
@@ -546,11 +551,18 @@ class Edit extends BackendBaseActionEdit
             foreach ($widgetPresets as $preset) {
                 // if selected
                 if ($preset->getChecked()) {
-                    // remove widgets_ prefix
-                    $selected = str_replace('widgets_', '', $preset->getName());
+                    // get the preset module name
+                    $presetModule = str_replace('widgets_', '', str_replace($widget['widget'], '', $preset->getName()));
 
-                    // if selected is the right widget, set visible
-                    if ($selected == $widget['widget']) $this->dashboardSequence[$widget['module']][$widget['widget']]['present'] = true;
+                    // if the preset module name matches the widget module name
+                    if($presetModule == $widget['module'])
+                    {
+                        // remove widgets_[modulename] prefix
+                        $selected = str_replace('widgets_' . $widget['module'], '', $preset->getName());
+
+                        // if right widget set visible
+                        if ($selected == $widget['widget']) $this->dashboardSequence[$widget['module']][$widget['widget']]['present'] = true;
+                    }
                 }
             }
         }
@@ -673,7 +685,7 @@ class Edit extends BackendBaseActionEdit
             }
 
             // loop through widgets and collect presets
-            foreach ($this->widgets as $widget) $widgetPresets[] = $this->frm->getField('widgets_' . $widget['label']);
+            foreach ($this->widgets as $widget) $widgetPresets[] = $this->frm->getField('widgets_' . $widget['checkbox_name']);
 
             // validate fields
             $nameField->isFilled(BL::err('NameIsRequired'));


### PR DESCRIPTION
Dashboard widget checkboxes are oblivious of the fact that a widget can
have the same name in two different modules. Allowing only one of these
will add none/all of them to the group.

Specifying the module fixes this behaviour.