### PR TITLE
Use better label for delete button on tag. Closes #590

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -5101,22 +5101,6 @@
         <translation language="el"><![CDATA[διαγραφή]]></translation>
         <translation language="pl"><![CDATA[usuń]]></translation>
       </item>
-      <item type="label" name="DeleteThisTag">
-        <translation language="nl"><![CDATA[verwijder deze tag]]></translation>
-        <translation language="en"><![CDATA[delete this tag]]></translation>
-        <translation language="hu"><![CDATA[címke törlése]]></translation>
-        <translation language="it"><![CDATA[elimina questo tag]]></translation>
-        <translation language="ru"><![CDATA[Удалить Тэг]]></translation>
-        <translation language="zh"><![CDATA[删除这个标签]]></translation>
-        <translation language="de"><![CDATA[Schlagwort löschen]]></translation>
-        <translation language="fr"><![CDATA[effacer ce tag]]></translation>
-        <translation language="es"><![CDATA[eliminar esta etiqueta]]></translation>
-        <translation language="lt"><![CDATA[pašalinti žymę]]></translation>
-        <translation language="uk"><![CDATA[Видалити тег]]></translation>
-        <translation language="sv"><![CDATA[ta bort denna tagg]]></translation>
-        <translation language="el"><![CDATA[διαγραφή ετικέτας]]></translation>
-        <translation language="pl"><![CDATA[usuń ten tag]]></translation>
-      </item>
       <item type="label" name="Description">
         <translation language="nl"><![CDATA[beschrijving]]></translation>
         <translation language="en"><![CDATA[description]]></translation>

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -1529,7 +1529,7 @@ jsBackend.forms =
 				emptyMessage: jsBackend.locale.msg('NoTags'),
 				errorMessage: jsBackend.locale.err('AddTagBeforeSubmitting'),
 				addLabel: utils.string.ucfirst(jsBackend.locale.lbl('Add')),
-				removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('DeleteThisTag')),
+				removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('Delete')),
 				params: { fork: { module: 'Tags', action: 'Autocomplete' } }
 			});
 		}
@@ -1540,7 +1540,7 @@ jsBackend.forms =
 				emptyMessage: jsBackend.locale.msg('NoTags'),
 				errorMessage: jsBackend.locale.err('AddTagBeforeSubmitting'),
 				addLabel: utils.string.ucfirst(jsBackend.locale.lbl('Add')),
-				removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('DeleteThisTag')),
+				removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('Delete')),
 				params: { fork: { module: 'Tags', action: 'Autocomplete' } },
 				showIconOnly: false
 			});

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -991,7 +991,7 @@
 					for(var i in elements)
 					{
 						html += '	<li><span><strong>' + elements[i] + '</strong>' +
-								'		<a href="#" class="deleteButton-' + id + '" data-id="' + elements[i] + '" title="' + options.removeLabel + '">' + options.removeLabel + '</a></span>' +
+								'		<a href="#" class="deleteButton-' + id + '" data-id="' + elements[i] + '" title="' + options.removeLabel + ' ' + elements[i] + '">' + options.removeLabel + '</a></span>' +
 								'	</li>';
 					}
 

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -935,9 +935,6 @@
 				var value = $('#addValue-' + id).val().replace(/^\s+|\s+$/g, '').replace(options.splitChar, '');
 				var inElements = false;
 
-				// ugly hack to escape entities and quotes
-				// value = $('<div />').text(value).html().replace('"', '&quot;');
-
 				// if multiple arguments aren't allowed, clear before adding
 				if(!options.multiple) elements = [];
 

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -936,7 +936,7 @@
 				var inElements = false;
 
 				// ugly hack to escape entities and quotes
-				value = $('<div />').text(value).html().replace('"', '&quot;');
+				// value = $('<div />').text(value).html().replace('"', '&quot;');
 
 				// if multiple arguments aren't allowed, clear before adding
 				if(!options.multiple) elements = [];
@@ -961,7 +961,7 @@
 					if(!inElements)
 					{
 						// add elements
-						elements.push(value);
+						elements.push(utils.string.decodeForTag(value));
 
 						// set new value
 						$('#' + id).val(elements.join(options.splitChar));
@@ -990,8 +990,10 @@
 					// loop elements
 					for(var i in elements)
 					{
-						html += '	<li><span><strong>' + elements[i] + '</strong>' +
-								'		<a href="#" class="deleteButton-' + id + '" data-id="' + elements[i] + '" title="' + utils.string.htmlEncode(options.removeLabel + ' ' + elements[i]) + '">' + options.removeLabel + '</a></span>' +
+                        var value = utils.string.decodeForTag(elements[i]);
+
+						html += '	<li><span><strong>' + value + '</strong>' +
+								'		<a href="#" class="deleteButton-' + id + '" data-id="' + value + '" title="' + utils.string.decodeForTag(options.removeLabel) + ' ' + value + '">' + options.removeLabel + '</a></span>' +
 								'	</li>';
 					}
 

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -991,7 +991,7 @@
 					for(var i in elements)
 					{
 						html += '	<li><span><strong>' + elements[i] + '</strong>' +
-								'		<a href="#" class="deleteButton-' + id + '" data-id="' + elements[i] + '" title="' + options.removeLabel + ' ' + elements[i] + '">' + options.removeLabel + '</a></span>' +
+								'		<a href="#" class="deleteButton-' + id + '" data-id="' + elements[i] + '" title="' + utils.string.htmlEncode(options.removeLabel + ' ' + elements[i]) + '">' + options.removeLabel + '</a></span>' +
 								'	</li>';
 					}
 

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -961,7 +961,7 @@
 					if(!inElements)
 					{
 						// add elements
-						elements.push(utils.string.decodeForTag(value));
+						elements.push(utils.string.stripForTag(value));
 
 						// set new value
 						$('#' + id).val(elements.join(options.splitChar));
@@ -990,10 +990,10 @@
 					// loop elements
 					for(var i in elements)
 					{
-                        var value = utils.string.decodeForTag(elements[i]);
+						var value = utils.string.stripForTag(elements[i]);
 
 						html += '	<li><span><strong>' + value + '</strong>' +
-								'		<a href="#" class="deleteButton-' + id + '" data-id="' + value + '" title="' + utils.string.decodeForTag(options.removeLabel) + ' ' + value + '">' + options.removeLabel + '</a></span>' +
+								'		<a href="#" class="deleteButton-' + id + '" data-id="' + value + '" title="' + utils.string.stripForTag(options.removeLabel) + ' ' + value + '">' + options.removeLabel + '</a></span>' +
 								'	</li>';
 					}
 

--- a/src/Backend/Core/Js/utils.js
+++ b/src/Backend/Core/Js/utils.js
@@ -357,16 +357,16 @@ utils.string =
 		return decodeURIComponent(value.replace(/\+/g, '%20').replace(/\%21/g, '!').replace(/\%27/g, "'").replace(/\%28/g, '(').replace(/\%29/g, ')').replace(/\%2A/g, '*').replace(/\%7E/g, '~'));
 	},
 
-    /**
-     * Tags cannot contain ", < and >
-     *
-     * @return	string
-     * @param	string value
-     */
-    decodeForTag: function(value)
-    {
-        return value.replace(/"/g, "'").replace(/(<|>)/g, '');
-    },
+	/**
+	 * Tags cannot contain ", < and >
+	 *
+	 * @return	string
+	 * @param	string value
+	 */
+	stripForTag: function(value)
+	{
+		return value.replace(/"/g, "'").replace(/(<|>)/g, '');
+	},
 
 	/**
 	 * Urlise a string (cfr. SpoonFilter::urlise)

--- a/src/Backend/Core/Js/utils.js
+++ b/src/Backend/Core/Js/utils.js
@@ -357,6 +357,17 @@ utils.string =
 		return decodeURIComponent(value.replace(/\+/g, '%20').replace(/\%21/g, '!').replace(/\%27/g, "'").replace(/\%28/g, '(').replace(/\%29/g, ')').replace(/\%2A/g, '*').replace(/\%7E/g, '~'));
 	},
 
+    /**
+     * Tags cannot contain ", < and >
+     *
+     * @return	string
+     * @param	string value
+     */
+    decodeForTag: function(value)
+    {
+        return value.replace(/"/g, "'").replace(/(<|>)/g, '');
+    },
+
 	/**
 	 * Urlise a string (cfr. SpoonFilter::urlise)
 	 *

--- a/src/Backend/Modules/Tags/Engine/Model.php
+++ b/src/Backend/Modules/Tags/Engine/Model.php
@@ -293,12 +293,15 @@ class Model
                 }
             }
 
+            // don't do a regular implode, mysql injection might be possible
+            $placeholders = array_fill(0, count($tags), '?');
+
             // get tag ids
             $tagsAndIds = (array) $db->getPairs(
                 'SELECT i.tag, i.id
                  FROM tags AS i
-                 WHERE i.tag IN ("' . implode('", "', $tags) . '") AND i.language = ?',
-                array($language)
+                 WHERE i.tag IN (' . implode(',', $placeholders) . ') AND i.language = ?',
+                array_merge($tags, array($language))
             );
 
             // loop again and create tags that don't already exist


### PR DESCRIPTION
The "DeleteThisTag" label was removed and replaced by the regular "Delete + *value of tag*".
Adding tags with double quotes (are replaced with single quotes) and < or > (are removed) is now possible, which was not the case previously (They could be added afterwards).

Reasoning behind the stripping of < and >: They will not be used in a tag. Ever.
Reasoning behind the replacing of " with ': Probably also never used in a tag, but when used, always as a quote, so ' is applicable too.

Note that a possible MySQL injection (in the Tags backend) was closed as wel.