### PR TITLE
Replace SPOON_DEBUG with kernel.debug

### DIFF
--- a/UPGRADE_3.9.md
+++ b/UPGRADE_3.9.md
@@ -25,3 +25,10 @@ use it like this:
 
 All occurences of sending emails in the core are replaced by this, so you can use
 this as a reference.
+
+
+## SPOON_DEBUG
+
+SPOON_DEBUG is removed. From now on you need to check if DEBUG is on by using the kernel.debug parameter, f.e.
+
+	if ($this->getContainer()->getParameter('kernel.debug')) { ...

--- a/src/Api/V1/Engine/Api.php
+++ b/src/Api/V1/Engine/Api.php
@@ -9,6 +9,8 @@ namespace Api\V1\Engine;
  * file that was distributed with this source code.
  */
 
+use Backend\Core\Engine\Exception;
+use Symfony\Component\CssSelector\Exception\ExpressionErrorException;
 use Symfony\Component\HttpFoundation\Response;
 
 use Backend\Core\Engine\Authentication as BackendAuthentication;
@@ -164,7 +166,7 @@ class Api extends \KernelLoader implements \ApplicationInterface
             }
         } catch (\Exception $e) {
             // if we are debugging we should see the exceptions
-            if (SPOON_DEBUG) {
+            if ($this->getContainer()->getParameter('kernel.debug')) {
                 if (isset($parameters['debug']) && $parameters['debug'] == 'false') {
                     // do nothing
                 } else {

--- a/src/Backend/Core/Cronjobs/ProcessQueuedHooks.php
+++ b/src/Backend/Core/Cronjobs/ProcessQueuedHooks.php
@@ -71,7 +71,7 @@ class ProcessQueuedHooks extends Cronjob
                 // check if the item is callable
                 if (!is_callable($item['callback'])) {
                     // in debug mode we want to know if there are errors
-                    if (SPOON_DEBUG) {
+                    if ($this->getContainer()->getParameter('kernel.debug')) {
                         throw new Exception('Invalid callback!');
                     }
 
@@ -108,7 +108,7 @@ class ProcessQueuedHooks extends Cronjob
                     $processedSuccessfully = false;
 
                     // logging when we are in debugmode
-                    if (SPOON_DEBUG) {
+                    if ($this->getContainer()->getParameter('kernel.debug')) {
                         $log->err('Callback (' . serialize($item['callback']) . ') failed.');
                     }
                 }
@@ -119,7 +119,7 @@ class ProcessQueuedHooks extends Cronjob
                 }
 
                 // logging when we are in debugmode
-                if (SPOON_DEBUG) {
+                if ($this->getContainer()->getParameter('kernel.debug')) {
                     $log->info('Callback (' . serialize($item['callback']) . ') finished.');
                 }
             } else {

--- a/src/Backend/Core/Engine/Base/Cronjob.php
+++ b/src/Backend/Core/Engine/Base/Cronjob.php
@@ -100,7 +100,7 @@ class Cronjob extends Object
     protected function setBusyFile()
     {
         // do not set busy file in debug mode
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             return;
         }
 

--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -33,7 +33,7 @@ class DataGrid extends \SpoonDataGrid
         parent::__construct($source);
 
         // set debugmode, this will force the recompile for the used templates
-        $this->setDebug(\SPOON_DEBUG);
+        $this->setDebug(BackendModel::getContainer()->getParameter('kernel.debug'));
 
         // set the compile-directory, so compiled templates will be in a folder that is writable
         $this->setCompileDirectory(BACKEND_CACHE_PATH . '/CompiledTemplates');

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -112,7 +112,7 @@ class Header extends Base\Object
         }
 
         // no minifying when debugging
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             $minify = false;
         }
 
@@ -162,7 +162,7 @@ class Header extends Base\Object
         $addTimestamp = (bool) $addTimestamp;
 
         // no minifying when debugging
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             $minify = false;
         }
 
@@ -368,7 +368,7 @@ class Header extends Base\Object
         }
 
         // some default stuff
-        $this->jsData['debug'] = SPOON_DEBUG;
+        $this->jsData['debug'] = $this->getContainer()->getParameter('kernel.debug');
         $this->jsData['site']['domain'] = SITE_DOMAIN;
         $this->jsData['editor']['language'] = $interfaceLanguage;
         $this->jsData['interface_language'] = $interfaceLanguage;

--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -16,6 +16,7 @@ use TijsVerkoyen\Akismet\Akismet;
 
 use Backend\Modules\Extensions\Engine\Model as BackendExtensionsModel;
 use Backend\Modules\Pages\Engine\Model as BackendPagesModel;
+use Backend\Core\Engine\Model as BackendModel;
 
 use Frontend\Core\Engine\Language as FrontendLanguage;
 
@@ -98,7 +99,7 @@ class Model extends \BaseModel
         $warnings = array();
 
         // check if debug-mode is active
-        if (SPOON_DEBUG) {
+        if (BackendModel::getContainer()->getParameter('kernel.debug')) {
             $warnings[] = array('message' => Language::err('DebugModeIsActive'));
         }
 
@@ -1233,7 +1234,7 @@ class Model extends \BaseModel
                 if (strpos($e->getMessage(), 'Operation timed out') === false &&
                     strpos($e->getMessage(), 'Invalid headers') === false
                 ) {
-                    if (SPOON_DEBUG) {
+                    if (BackendModel::getContainer()->getParameter('kernel.debug')) {
                         throw $e;
                     } else {
                         // stop, hammertime
@@ -1286,7 +1287,7 @@ class Model extends \BaseModel
                 if (strpos($e->getMessage(), 'Operation timed out') === false &&
                     strpos($e->getMessage(), 'Invalid headers') === false
                 ) {
-                    if (SPOON_DEBUG) {
+                    if (BackendModel::getContainer()->getParameter('kernel.debug')) {
                         throw $e;
                     }
                 }
@@ -1442,7 +1443,7 @@ class Model extends \BaseModel
                 $others
             );
         } catch (Exception $e) {
-            if (SPOON_DEBUG) {
+            if (BackendModel::getContainer()->getParameter('kernel.debug')) {
                 throw $e;
             }
         }
@@ -1504,7 +1505,7 @@ class Model extends \BaseModel
                 $others
             );
         } catch (Exception $e) {
-            if (SPOON_DEBUG) {
+            if (BackendModel::getContainer()->getParameter('kernel.debug')) {
                 throw $e;
             }
         }

--- a/src/Backend/Core/Engine/Template.php
+++ b/src/Backend/Core/Engine/Template.php
@@ -64,7 +64,9 @@ class Template extends \SpoonTemplate
         $this->setCompileDirectory(BACKEND_CACHE_PATH . '/CompiledTemplates');
 
         // when debugging, the template should be recompiled every time
-        $this->setForceCompile(SPOON_DEBUG);
+        $this->setForceCompile(
+            BackendModel::getContainer()->getParameter('kernel.debug')
+        );
 
         // map custom modifiers
         $this->mapCustomModifiers();
@@ -260,7 +262,10 @@ class Template extends \SpoonTemplate
      */
     private function parseDebug()
     {
-        $this->assign('debug', SPOON_DEBUG);
+        $this->assign(
+            'debug',
+            BackendModel::getContainer()->getParameter('kernel.debug')
+        );
     }
 
     /**

--- a/src/Backend/Core/Engine/Url.php
+++ b/src/Backend/Core/Engine/Url.php
@@ -156,7 +156,7 @@ class Url extends Base\Object
                 // set action
                 $action = ($config->getDefaultAction() !== null) ? $config->getDefaultAction() : 'Index';
             } catch (Exception $ex) {
-                if (SPOON_DEBUG) {
+                if (BackendModel::getContainer()->getParameter('kernel.debug')) {
                     throw new Exception('The config file for the module (' . $module . ') can\'t be found.');
                 } else {
                     // @todo    don't use redirects for error, we should have something like an invoke method.

--- a/src/Backend/Init.php
+++ b/src/Backend/Init.php
@@ -47,8 +47,8 @@ class Init extends \KernelLoader
         // get last modified time for globals
         $lastModifiedTime = @filemtime(PATH_WWW . '/app/config/parameters.yml');
 
-        // reset lastmodified time if needed (SPOON_DEBUG is enabled or we don't get a decent timestamp)
-        if ($lastModifiedTime === false || SPOON_DEBUG) {
+        // reset lastmodified time if needed when invalid or debug is active
+        if ($lastModifiedTime === false || $this->getContainer()->getParameter('kernel.debug')) {
             $lastModifiedTime = time();
         }
 

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -116,7 +116,7 @@ class Header extends FrontendBaseObject
         $this->addCSS('/src/Frontend/Core/Layout/Css/screen.css');
 
         // debug stylesheet
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             $this->addCSS('/src/Frontend/Core/Layout/Css/debug.css');
         }
 
@@ -143,7 +143,7 @@ class Header extends FrontendBaseObject
         $file = Theme::getPath($file);
 
         // no minifying when debugging
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             $minify = false;
         }
 
@@ -185,7 +185,7 @@ class Header extends FrontendBaseObject
         }
 
         // no minifying when debugging
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             $minify = false;
         }
 
@@ -593,8 +593,11 @@ class Header extends FrontendBaseObject
         $this->parseSeo();
 
         // in debug mode we don't want our pages to be indexed.
-        if (SPOON_DEBUG) {
-            $this->addMetaData(array('name' => 'robots', 'content' => 'noindex, nofollow'), true);
+        if ($this->getContainer()->getParameter('kernel.debug')) {
+            $this->addMetaData(
+                array('name' => 'robots', 'content' => 'noindex, nofollow'),
+                true
+            );
         }
 
         $this->parseMetaAndLinks();

--- a/src/Frontend/Core/Engine/Language.php
+++ b/src/Frontend/Core/Engine/Language.php
@@ -12,6 +12,7 @@ namespace Frontend\Core\Engine;
 use Symfony\Component\Filesystem\Filesystem;
 use Backend\Modules\Locale\Engine\CacheBuilder;
 
+
 /**
  * This class will store the language-dependant content for the frontend.
  *
@@ -76,7 +77,11 @@ class Language
         }
 
         // If we should fallback and the fallback label exists, return it
-        if (isset(self::$fallbackAct[$key]) && $fallback === true && SPOON_DEBUG === false) {
+        if (
+            isset(self::$fallbackAct[$key]) &&
+            $fallback === true &&
+            Model::getContainer()->getParameter('kernel.debug') === false
+        ) {
             return self::$fallbackAct[$key];
         }
 
@@ -91,7 +96,7 @@ class Language
      */
     public static function getActions()
     {
-        return (SPOON_DEBUG === true) ? self::$act : array_merge(self::$fallbackAct, self::$act);
+        return (Model::getContainer()->getParameter('kernel.debug')) ? self::$act : array_merge(self::$fallbackAct, self::$act);
     }
 
     /**
@@ -187,7 +192,11 @@ class Language
         }
 
         // If we should fallback and the fallback label exists, return it
-        if (isset(self::$fallbackErr[$key]) && $fallback === true && SPOON_DEBUG === false) {
+        if (
+            isset(self::$fallbackErr[$key]) &&
+            $fallback === true &&
+            Model::getContainer()->getParameter('kernel.debug') === false
+        ) {
             return self::$fallbackErr[$key];
         }
 
@@ -202,7 +211,7 @@ class Language
      */
     public static function getErrors()
     {
-        return (SPOON_DEBUG === true) ? self::$err : array_merge(self::$fallbackErr, self::$err);
+        return (Model::getContainer()->getParameter('kernel.debug')) ? self::$err : array_merge(self::$fallbackErr, self::$err);
     }
 
     /**
@@ -223,7 +232,11 @@ class Language
         }
 
         // If we should fallback and the fallback label exists, return it
-        if (isset(self::$fallbackLbl[$key]) && $fallback === true && SPOON_DEBUG === false) {
+        if (
+            isset(self::$fallbackLbl[$key]) &&
+            $fallback === true &&
+            Model::getContainer()->getParameter('kernel.debug') === false
+        ) {
             return self::$fallbackLbl[$key];
         }
 
@@ -238,7 +251,7 @@ class Language
      */
     public static function getLabels()
     {
-        return (SPOON_DEBUG === true) ? self::$lbl : array_merge(self::$fallbackLbl, self::$lbl);
+        return (Model::getContainer()->getParameter('kernel.debug')) ? self::$lbl : array_merge(self::$fallbackLbl, self::$lbl);
     }
 
     /**
@@ -259,7 +272,11 @@ class Language
         }
 
         // If we should fallback and the fallback label exists, return it
-        if (isset(self::$fallbackMsg[$key]) && $fallback === true && SPOON_DEBUG === false) {
+        if (
+            isset(self::$fallbackMsg[$key]) &&
+            $fallback === true &&
+            Model::getContainer()->getParameter('kernel.debug') === false
+        ) {
             return self::$fallbackMsg[$key];
         }
 
@@ -274,7 +291,7 @@ class Language
      */
     public static function getMessages()
     {
-        return (SPOON_DEBUG === true) ? self::$msg : array_merge(self::$fallbackMsg, self::$msg);
+        return (Model::getContainer()->getParameter('kernel.debug') === true) ? self::$msg : array_merge(self::$fallbackMsg, self::$msg);
     }
 
     /**

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -708,7 +708,7 @@ class Model extends \BaseModel
             return $akismet->isSpam($content, $author, $email, $URL, $permaLink, $type);
         } catch (\Exception $e) {
             // in debug mode we want to see exceptions, otherwise the fallback will be triggered
-            if (SPOON_DEBUG) {
+            if (self::getContainer()->getParameter('kernel.debug')) {
                 throw $e;
             }
 
@@ -825,7 +825,7 @@ class Model extends \BaseModel
                 }
             }
         } catch (Exception $e) {
-            if (SPOON_DEBUG) {
+            if (self::getContainer()->getParameter('kernel.debug')) {
                 throw $e;
             }
         }

--- a/src/Frontend/Core/Engine/Template.php
+++ b/src/Frontend/Core/Engine/Template.php
@@ -46,7 +46,7 @@ class Template extends \SpoonTemplate
 
         $this->setCacheDirectory(FRONTEND_CACHE_PATH . '/CachedTemplates');
         $this->setCompileDirectory(FRONTEND_CACHE_PATH . '/CompiledTemplates');
-        $this->setForceCompile(SPOON_DEBUG);
+        $this->setForceCompile(Model::getContainer()->getParameter('kernel.debug'));
         $this->mapCustomModifiers();
     }
 
@@ -189,7 +189,7 @@ class Template extends \SpoonTemplate
     public function isCached($name)
     {
         // never cached in debug
-        if (SPOON_DEBUG) {
+        if (Model::getContainer()->getParameter('kernel.debug')) {
             return false;
         } else {
             // let parent do the actual check
@@ -355,7 +355,7 @@ class Template extends \SpoonTemplate
      */
     private function parseDebug()
     {
-        if (SPOON_DEBUG) {
+        if (Model::getContainer()->getParameter('kernel.debug')) {
             $this->assign('debug', true);
         }
     }

--- a/src/Frontend/Core/Engine/TemplateCompiler.php
+++ b/src/Frontend/Core/Engine/TemplateCompiler.php
@@ -71,7 +71,7 @@ class TemplateCompiler extends \SpoonTemplateCompiler
                                realpath($this->template)
                            ) . '\');
                 }' . "\n";
-                if (SPOON_DEBUG) {
+                if (Model::getContainer()->getParameter('kernel.debug')) {
                     $replace .= 'if($return === false) {
                     ?>' . $match[0] . '<?php
                 }' . "\n";

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -394,7 +394,7 @@ class TemplateModifiers
             return $content;
         } catch (Exception $e) {
             // if we are debugging, we want to see the exception
-            if (SPOON_DEBUG) {
+            if (Model::getContainer()->getParameter('kernel.debug')) {
                 throw $e;
             }
 

--- a/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
@@ -105,7 +105,7 @@ class Subscribe extends FrontendBaseBlock
                     );
                 } catch (\Exception $e) {
                     // when debugging we need to see the exceptions
-                    if (SPOON_DEBUG) {
+                    if ($this->getContainer()->getParameter('kernel.debug')) {
                         throw $e;
                     }
 

--- a/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
@@ -147,7 +147,7 @@ class Unsubscribe extends FrontendBaseBlock
                     );
                 } catch (\Exception $e) {
                     // when debugging we need to see the exceptions
-                    if (SPOON_DEBUG) {
+                    if ($this->getContainer()->getParameter('kernel.debug')) {
                         throw $e;
                     }
 

--- a/src/Frontend/Modules/Profiles/Actions/Register.php
+++ b/src/Frontend/Modules/Profiles/Actions/Register.php
@@ -189,7 +189,7 @@ class Register extends FrontendBaseBlock
                     $this->redirect(SITE_URL . '/' . $this->URL->getQueryString() . '?sent=true');
                 } catch (\Exception $e) {
                     // when debugging we need to see the exceptions
-                    if (SPOON_DEBUG) {
+                    if ($this->getContainer()->getParameter('kernel.debug')) {
                         throw $e;
                     }
 

--- a/src/Frontend/Modules/Search/Actions/Index.php
+++ b/src/Frontend/Modules/Search/Actions/Index.php
@@ -140,7 +140,7 @@ class Index extends FrontendBaseBlock
         }
 
         // debug mode = no cache
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             return false;
         }
 
@@ -209,7 +209,7 @@ class Index extends FrontendBaseBlock
         }
 
         // debug mode = no cache
-        if (!SPOON_DEBUG) {
+        if (!$this->getContainer()->getParameter('kernel.debug')) {
             // set cache content
             $fs = new Filesystem();
             $fs->dumpFile(

--- a/src/Frontend/Modules/Search/Ajax/Autosuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Autosuggest.php
@@ -126,7 +126,7 @@ class Autosuggest extends FrontendBaseAJAXAction
         }
 
         // debug mode = no cache
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             return false;
         }
 
@@ -197,7 +197,7 @@ class Autosuggest extends FrontendBaseAJAXAction
         }
 
         // debug mode = no cache
-        if (!SPOON_DEBUG) {
+        if (!$this->getContainer()->getParameter('kernel.debug')) {
             // set cache content
             $fs = new Filesystem();
             $fs->dumpFile(

--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -135,7 +135,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         }
 
         // debug mode = no cache
-        if (SPOON_DEBUG) {
+        if ($this->getContainer()->getParameter('kernel.debug')) {
             return false;
         }
 
@@ -206,7 +206,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         }
 
         // debug mode = no cache
-        if (!SPOON_DEBUG) {
+        if (!$this->getContainer()->getParameter('kernel.debug')) {
             // set cache content
             $fs = new Filesystem();
             $fs->dumpFile(


### PR DESCRIPTION
SPOON_DEBUG is now replaced with kernel.debug everywhere except in one place: Kernel.php where it is used in combination with SPOON_DEBUG_EMAIL.
Once the SwiftMailer is implemented for, SPOON_DEBUG_EMAIL can be removed and then SPOON_DEBUG can be a goner too. Closes #812