### PR TITLE
Refactor out BACKEND_MODULE_PATH constant

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -50,6 +50,9 @@
                 <directory>../src/*/*Bundle/Tests</directory>
                 <directory>../src/*/Bundle/*Bundle/Resources</directory>
                 <directory>../src/*/Bundle/*Bundle/Tests</directory>
+                <directory>../src/Backend/Cache</directory>
+                <directory>../src/Backend/Core/Js</directory>
+                <directory>../src/Frontend/Cache</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -112,17 +112,6 @@ class Action extends Base\Object
      */
     public function loadConfig()
     {
-        // check if module path is not yet defined
-        if (!defined('BACKEND_MODULE_PATH')) {
-            // build path for core
-            if ($this->getModule() == 'Core') {
-                define('BACKEND_MODULE_PATH', BACKEND_PATH . '/' . $this->getModule());
-            } else {
-                // build path to the module and define it. This is a constant because we can use this in templates.
-                define('BACKEND_MODULE_PATH', BACKEND_MODULES_PATH . '/' . $this->getModule());
-            }
-        }
-
         // check if we can load the config file
         $configClass = 'Backend\\Modules\\' . $this->getModule() . '\\Config';
         if ($this->getModule() == 'Core') {

--- a/src/Backend/Core/Engine/AjaxAction.php
+++ b/src/Backend/Core/Engine/AjaxAction.php
@@ -67,17 +67,6 @@ class AjaxAction extends Base\Object
      */
     public function loadConfig()
     {
-        // check if module path is not yet defined
-        if (!defined('BACKEND_MODULE_PATH')) {
-            // build path for core
-            if ($this->getModule() == 'Core') {
-                define('BACKEND_MODULE_PATH', BACKEND_PATH . '/' . $this->getModule());
-            } else {
-                // build path to the module and define it. This is a constant because we can use this in templates.
-                define('BACKEND_MODULE_PATH', BACKEND_MODULES_PATH . '/' . $this->getModule());
-            }
-        }
-
         // check if we can load the config file
         $configClass = 'Backend\\Modules\\' . $this->getModule() . '\\Config';
         if ($this->getModule() == 'Core') {

--- a/src/Backend/Core/Engine/Base/Action.php
+++ b/src/Backend/Core/Engine/Base/Action.php
@@ -106,6 +106,15 @@ class Action extends Object
         );
     }
 
+    protected function getBackendModulePath()
+    {
+        if ($this->URL->getModule() == 'Core') {
+            return BACKEND_PATH . '/' . $this->URL->getModule();
+        } else {
+            return BACKEND_MODULES_PATH . '/' . $this->URL->getModule();
+        }
+    }
+
     /**
      * Display, this wil output the template to the browser
      * If no template is specified we build the path form the current module and action
@@ -122,7 +131,7 @@ class Action extends Object
          * based on the name of the current action
          */
         if ($template === null) {
-            $template = BACKEND_MODULE_PATH . '/Layout/Templates/' . $this->URL->getAction() . '.tpl';
+            $template = $this->getBackendModulePath() . '/Layout/Templates/' . $this->URL->getAction() . '.tpl';
         }
 
         $this->content = $this->tpl->getContent($template);
@@ -145,12 +154,12 @@ class Action extends Object
         $this->header->addJS('backend.js', 'Core');
 
         // add module js
-        if (is_file(BACKEND_MODULE_PATH . '/Js/' . $this->getModule() . '.js')) {
+        if (is_file($this->getBackendModulePath() . '/Js/' . $this->getModule() . '.js')) {
             $this->header->addJS($this->getModule() . '.js');
         }
 
         // add action js
-        if (is_file(BACKEND_MODULE_PATH . '/Js/' . $this->getAction() . '.js')) {
+        if (is_file($this->getBackendModulePath() . '/Js/' . $this->getAction() . '.js')) {
             $this->header->addJS($this->getAction() . '.js');
         }
 
@@ -161,7 +170,7 @@ class Action extends Object
         $this->header->addCSS('debug.css', 'Core');
 
         // add module specific css
-        if (is_file(BACKEND_MODULE_PATH . '/Layout/Css/' . $this->getModule() . '.css')) {
+        if (is_file($this->getBackendModulePath() . '/Layout/Css/' . $this->getModule() . '.css')) {
             $this->header->addCSS($this->getModule() . '.css');
         }
 

--- a/src/Backend/Core/Engine/Cronjob.php
+++ b/src/Backend/Core/Engine/Cronjob.php
@@ -163,17 +163,6 @@ class Cronjob extends Object implements \ApplicationInterface
      */
     public function loadConfig()
     {
-        // check if module path is not yet defined
-        if (!defined('BACKEND_MODULE_PATH')) {
-            // build path for core
-            if ($this->getModule() == 'Core') {
-                define('BACKEND_MODULE_PATH', BACKEND_PATH . '/' . $this->getModule());
-            } else {
-                // build path to the module and define it. This is a constant because we can use this in templates.
-                define('BACKEND_MODULE_PATH', BACKEND_MODULES_PATH . '/' . $this->getModule());
-            }
-        }
-
         // check if we can load the config file
         $configClass = 'Backend\\Modules\\' . $this->getModule() . '\\Config';
 

--- a/src/Backend/Core/Engine/Template.php
+++ b/src/Backend/Core/Engine/Template.php
@@ -253,6 +253,18 @@ class Template extends \SpoonTemplate
             'SITE_TITLE',
             BackendModel::getModuleSetting('Core', 'site_title_' . Language::getWorkingLanguage(), SITE_DEFAULT_TITLE)
         );
+
+        if ($this->URL->getModule() == 'Core') {
+            $this->assign(
+                'BACKEND_MODULE_PATH',
+                BACKEND_PATH . '/' . $this->URL->getModule()
+            );
+        } else {
+            $this->assign(
+                'BACKEND_MODULE_PATH',
+                BACKEND_MODULES_PATH . '/' . $this->URL->getModule()
+            );
+        }
     }
 
     /**

--- a/src/Backend/Core/Engine/Url.php
+++ b/src/Backend/Core/Engine/Url.php
@@ -130,20 +130,7 @@ class Url extends Base\Object
         if (isset($chunks[3]) && $chunks[3] != '') {
             $action = \SpoonFilter::toCamelCase($chunks[3]);
         } elseif (!$isAJAX) {
-            // check if module path is not yet defined
-            if (!defined('BACKEND_MODULE_PATH')) {
-                // build path for core
-                if ($module == 'Core') {
-                    define('BACKEND_MODULE_PATH', BACKEND_PATH . '/' . $module);
-                } else {
-                    // build path to the module and define it. This is a constant because we can use this in templates.
-                    define('BACKEND_MODULE_PATH', BACKEND_MODULES_PATH . '/' . $module);
-                }
-            }
-
-            /**
-             * Check if we can load the config file
-             */
+            // Check if we can load the config file
             $configClass = 'Backend\\Modules\\' . $module . '\\Config';
             if ($module == 'Core') {
                 $configClass = 'Backend\\Core\\Config';

--- a/src/Backend/Modules/Authentication/Actions/Index.php
+++ b/src/Backend/Modules/Authentication/Actions/Index.php
@@ -248,7 +248,7 @@ class Index extends BackendBaseActionIndex
                     ->setTo(array($email))
                     ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                     ->parseHtml(
-                        BACKEND_MODULE_PATH . '/Layout/Templates/Mails/ResetPassword.tpl',
+                        BACKEND_MODULES_PATH . '/Authentication/Layout/Templates/Mails/ResetPassword.tpl',
                         $variables
                     )
                 ;

--- a/src/Backend/Modules/Authentication/Tests/Actions/IndexTest.php
+++ b/src/Backend/Modules/Authentication/Tests/Actions/IndexTest.php
@@ -11,14 +11,8 @@ class IndexTest extends WebTestCase
         $client = static::createClient();
         $client->followRedirects();
         $this->loadFixtures($client);
-        $this->markTestIncomplete(
-            'Running this test makes the client anonymously logged in the backend.
-It\'s caused by the BACKEND_MODULE_PATH global being set to Dashboard.
-After refactoring away this global, this test could be ran again.'
-        );
 
         $client->request('GET', '/private');
-
         $this->assertStringEndsWith(
             '/private/en/authentication?querystring=%2Fprivate%2Fen',
             $client->getHistory()->current()->getUri()

--- a/src/Backend/Modules/FormBuilder/Engine/Helper.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Helper.php
@@ -172,7 +172,7 @@ class Helper
                 $tpl->assign('simple', true);
             }
 
-            return $tpl->getContent(BACKEND_MODULE_PATH . '/Layout/Templates/Field.tpl');
+            return $tpl->getContent(BACKEND_MODULES_PATH . '/FormBuilder/Layout/Templates/Field.tpl');
         } else {
             // empty field so return empty string
             return '';

--- a/src/Backend/Modules/Mailmotor/Actions/Edit.php
+++ b/src/Backend/Modules/Mailmotor/Actions/Edit.php
@@ -360,7 +360,7 @@ class Edit extends BackendBaseActionEdit
     {
         // check if this template path exists
         $templatePath = file_exists(
-            BACKEND_MODULE_PATH . '/Templates/' . $this->record['language'] . '/' . $this->record['template']
+            BACKEND_MODULES_PATH . '/Mailmotor/Templates/' . $this->record['language'] . '/' . $this->record['template']
         );
 
         // set wizard values

--- a/src/Backend/Modules/Mailmotor/Actions/EditMailingIframe.php
+++ b/src/Backend/Modules/Mailmotor/Actions/EditMailingIframe.php
@@ -42,7 +42,7 @@ class EditMailingIframe extends BackendBaseActionEdit
             parent::execute();
             $this->getData();
             $this->parse();
-            $this->display(BACKEND_MODULE_PATH . '/Layout/Templates/EditMailingIframe.tpl');
+            $this->display(BACKEND_MODULES_PATH . '/Mailmotor/Layout/Templates/EditMailingIframe.tpl');
         } else {
             $this->redirect(BackendModel::createURLForAction('Index') . '&error=non-existing');
         }

--- a/src/Backend/Modules/Mailmotor/Engine/Model.php
+++ b/src/Backend/Modules/Mailmotor/Engine/Model.php
@@ -1361,7 +1361,7 @@ class Model
     public static function getTemplate($language, $name)
     {
         // set the path to the template folders for this language
-        $path = BACKEND_MODULE_PATH . '/Templates/' . $language;
+        $path = BACKEND_MODULES_PATH . '/Mailmotor/Templates/' . $language;
         $fs = new Filesystem();
 
         // load all templates in the 'templates' folder for this language
@@ -1411,7 +1411,7 @@ class Model
         $records = array();
         $finder = new Finder();
         $finder->depth(0);
-        foreach ($finder->directories()->in(BACKEND_MODULE_PATH . '/Templates/' . $language) as $directory) {
+        foreach ($finder->directories()->in(BACKEND_MODULES_PATH . '/Mailmotor/Templates/' . $language) as $directory) {
             $item = array();
             $item['language'] = $language;
             $item['value'] = $directory->getBaseName();


### PR DESCRIPTION
It caused the backend tests to always render the template for the first module (which was the dashboard in this case).
Also, it's a constant less in Fork! And it was not that hard to replace.

I still parsed the variable to the template, so it can still be used in there (which is done a lot in the code base)