### PR TITLE
Add placeholder to textbox and textarea elements

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -76,6 +76,7 @@ class Edit extends BackendBaseActionEdit
         // textfield dialog
         $this->frm->addText('textbox_label');
         $this->frm->addText('textbox_value');
+        $this->frm->addText('textbox_placeholder');
         $this->frm->addCheckbox('textbox_required');
         $this->frm->addCheckbox('textbox_reply_to');
         $this->frm->addText('textbox_required_error_message');
@@ -94,6 +95,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addText('textarea_label');
         $this->frm->addTextarea('textarea_value');
         $this->frm->getField('textarea_value')->setAttribute('cols', 30);
+        $this->frm->addText('textarea_placeholder');
         $this->frm->addCheckbox('textarea_required');
         $this->frm->addText('textarea_required_error_message');
         $this->frm->addDropdown('textarea_validation', array('' => ''));

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -45,6 +45,7 @@ class SaveField extends BackendBaseAJAXAction
         $values = \SpoonFilter::htmlspecialcharsDecode($values);
 
         $defaultValues = trim(\SpoonFilter::getPostValue('default_values', null, '', 'string'));
+        $placeholder = trim(\SpoonFilter::getPostValue('placeholder', null, '', 'string'));
         $required = \SpoonFilter::getPostValue('required', array('Y','N'), 'N', 'string');
         $requiredErrorMessage = trim(\SpoonFilter::getPostValue('required_error_message', null, '', 'string'));
         $validation = \SpoonFilter::getPostValue('validation', array('email', 'numeric', 'time'), '', 'string');
@@ -206,6 +207,9 @@ class SaveField extends BackendBaseAJAXAction
                         }
                         if ($defaultValues != '') {
                             $settings['default_values'] = $defaultValues;
+                        }
+                        if($placeholder != '') {
+                            $settings['placeholder'] = \SpoonFilter::htmlspecialchars($placeholder);
                         }
 
                         // reply-to, only for textboxes

--- a/src/Backend/Modules/FormBuilder/Engine/Helper.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Helper.php
@@ -44,6 +44,7 @@ class Helper
                 $field['settings']['default_values'] :
                 null
             );
+            $placeholder = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
 
             /**
              * Create form and parse to HTML
@@ -117,6 +118,7 @@ class Helper
                 // create element
                 $txt = $frm->addText($fieldName, $defaultValues);
                 $txt->setAttribute('disabled', 'disabled');
+                $txt->setAttribute('placeholder', $placeholder);
 
                 // get content
                 $fieldHTML = $txt->parse();
@@ -125,6 +127,7 @@ class Helper
                 $txt = $frm->addTextarea($fieldName, $defaultValues);
                 $txt->setAttribute('cols', 30);
                 $txt->setAttribute('disabled', 'disabled');
+                $txt->setAttribute('placeholder', $placeholder);
 
                 // get content
                 $fieldHTML = $txt->parse();

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -379,6 +379,20 @@
         <translation language="sv"><![CDATA[parameter]]></translation>
         <translation language="el"><![CDATA[Παράμετρος]]></translation>
       </item>
+      <item type="label" name="Placeholder">
+        <translation language="nl"><![CDATA[placeholder]]></translation>
+        <translation language="en"><![CDATA[placeholder]]></translation>
+        <translation language="it"><![CDATA[segnaposto]]></translation>
+        <translation language="ru"><![CDATA[заполнитель]]></translation>
+        <translation language="zh"><![CDATA[占位符]]></translation>
+        <translation language="fr"><![CDATA[espace réservé]]></translation>
+        <translation language="hu"><![CDATA[helyőrző]]></translation>
+        <translation language="de"><![CDATA[Platzhalter]]></translation>
+        <translation language="es"><![CDATA[marcador de posición]]></translation>
+        <translation language="uk"><![CDATA[заповнювач]]></translation>
+        <translation language="sv"><![CDATA[platshållare]]></translation>
+        <translation language="el"><![CDATA[κράτησης θέσης]]></translation>
+      </item>
       <item type="label" name="Preview">
         <translation language="nl"><![CDATA[preview]]></translation>
         <translation language="en"><![CDATA[preview]]></translation>

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -413,6 +413,7 @@ jsBackend.formBuilder.fields =
 								$('#textboxId').val(data.data.field.id);
 								$('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
+								$('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
 								if(data.data.field.settings.reply_to && data.data.field.settings.reply_to == true) $('#textboxReplyTo').prop('checked', true);
 								$.each(data.data.field.validations, function(k, v)
 								{
@@ -442,6 +443,7 @@ jsBackend.formBuilder.fields =
 								$('#textareaId').val(data.data.field.id);
 								$('#textareaLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#textareaValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
+								$('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -1261,6 +1263,7 @@ jsBackend.formBuilder.fields =
 		var type = 'textarea';
 		var label = $('#textareaLabel').val();
 		var value = $('#textareaValue').val();
+		var placeholder = $('#textareaPlaceholder').val();
 		var required = ($('#textareaRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#textareaRequiredErrorMessage').val();
 		var validation = $('#textareaValidation').val();
@@ -1277,6 +1280,7 @@ jsBackend.formBuilder.fields =
 				type: type,
 				label: label,
 				default_values: value,
+				placeholder: placeholder,
 				required: required,
 				required_error_message: requiredErrorMessage,
 				validation: validation,
@@ -1342,6 +1346,7 @@ jsBackend.formBuilder.fields =
 		var type = 'textbox';
 		var label = $('#textboxLabel').val();
 		var value = $('#textboxValue').val();
+		var placeholder = $('#textboxPlaceholder').val();
 		var replyTo = ($('#textboxReplyTo').is(':checked') ? 'Y' : 'N');
 		var required = ($('#textboxRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#textboxRequiredErrorMessage').val();
@@ -1359,6 +1364,7 @@ jsBackend.formBuilder.fields =
 				type: type,
 				label: label,
 				default_values: value,
+				placeholder: placeholder,
 				reply_to: replyTo,
 				required: required,
 				required_error_message: requiredErrorMessage,

--- a/src/Backend/Modules/FormBuilder/Layout/Css/FormBuilder.css
+++ b/src/Backend/Modules/FormBuilder/Layout/Css/FormBuilder.css
@@ -218,7 +218,7 @@
 
 	/* Pop-ups */
 
-	#tabTextboxBasic, #tabTextboxProperties, #tabTextareaBasic, #tabTextareaProperties, #tabDropdownBasic, #tabDropdownProperties, #tabRadiobuttonBasic, #tabRadiobuttonProperties, #tabCheckboxBasic, #tabCheckboxProperties, #tabDatetimeBasic, #tabDatetimeProperties {
+	#tabTextboxBasic, #tabTextboxProperties, #tabTextboxAdvanced, #tabTextareaBasic, #tabTextareaProperties, #tabTextareaAdvanced, #tabDropdownBasic, #tabDropdownProperties, #tabRadiobuttonBasic, #tabRadiobuttonProperties, #tabCheckboxBasic, #tabCheckboxProperties, #tabDatetimeBasic, #tabDatetimeProperties {
 		padding: 0;
 		border-left: 0;
 		border-right: 0;

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
@@ -87,8 +87,8 @@
 								</p>
 								<p class="floatRight buttonHolderRight p0">
 									<a href="#edit-{$submitId}" class="button iconOnly icon iconEdit editField floatRight" rel="{$submitId}">
-                                        <span>{$lblEdit}</span>
-                                    </a>
+										<span>{$lblEdit}</span>
+									</a>
 								</p>
 							</div>
 						</div>
@@ -161,7 +161,7 @@
 			<ul>
 				<li><a href="#tabTextboxBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabTextboxProperties">{$lblProperties|ucfirst}</a></li>
-                <li><a href="#tabTextboxAdvanced">{$lblAdvanced|ucfirst}</a></li>
+				<li><a href="#tabTextboxAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabTextboxBasic" class="box">
@@ -222,16 +222,16 @@
 
 			</div>
 
-            <div id="tabTextboxAdvanced" class="box">
-                <div class="horizontal">
-                    <div class="options">
-                        <p>
-                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
-                            {$txtTextboxPlaceholder}
-                        </p>
-                    </div>
-                </div>
-            </div>
+			<div id="tabTextboxAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+							{$txtTextboxPlaceholder}
+						</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
 
@@ -243,7 +243,7 @@
 			<ul>
 				<li><a href="#tabTextareaBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabTextareaProperties">{$lblProperties|ucfirst}</a></li>
-                <li><a href="#tabTextareaAdvanced">{$lblAdvanced|ucfirst}</a></li>
+				<li><a href="#tabTextareaAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabTextareaBasic" class="box">
@@ -295,86 +295,86 @@
 				</div>
 			</div>
 
-            <div id="tabTextareaAdvanced" class="box">
-                <div class="horizontal">
-                    <div class="options">
-                        <p>
-                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
-                            {$txtTextareaPlaceholder}
-                        </p>
-                    </div>
-                </div>
-            </div>
+			<div id="tabTextareaAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+							{$txtTextareaPlaceholder}
+						</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
 
-    {* Dialog for a datetime *}
-    <div id="datetimeDialog" title="{$lblDatetime|ucfirst}" class="dialog" style="display: none;">
-        <input type="hidden" name="datetime_id" id="datetimeId" value="" />
+	{* Dialog for a datetime *}
+	<div id="datetimeDialog" title="{$lblDatetime|ucfirst}" class="dialog" style="display: none;">
+		<input type="hidden" name="datetime_id" id="datetimeId" value="" />
 
-        <div class="tabs forkForms">
-            <ul>
-                <li><a href="#tabDatetimeBasic">{$lblBasic|ucfirst}</a></li>
-                <li><a href="#tabDatetimeProperties">{$lblProperties|ucfirst}</a></li>
-            </ul>
+		<div class="tabs forkForms">
+			<ul>
+				<li><a href="#tabDatetimeBasic">{$lblBasic|ucfirst}</a></li>
+				<li><a href="#tabDatetimeProperties">{$lblProperties|ucfirst}</a></li>
+			</ul>
 
-            <div id="tabDatetimeBasic" class="box">
-                <div class="horizontal">
-                    <div class="options">
-                        <p>
-                            <label for="datetimeLabel">{$lblLabel|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
-                            {$txtDatetimeLabel}
-                            <span id="datetimeLabelError" class="formError" style="display: none;"></span>
-                        </p>
-                    </div>
-                </div>
-            </div>
-            <div id="tabDatetimeProperties" class="box">
-                <div class="horizontal">
-                    <div class="defaultValue options">
-                        <p>
-                            <label for="datetimeValue">{$lblDefaultValue|ucfirst}</label>
-                            {$ddmDatetimeValueAmount} {$ddmDatetimeValueType}
-                            <span id="datetimeDefaultValueErrorMessageError" class="formError" style="display: none;"></span>
-                        </p>
-                    </div>
-                    <div class="validation options">
-                        <p class="p0">
-                            <label for="datetimeRequired">{$lblRequiredField|ucfirst}</label>
-                            {$chkDatetimeRequired}
-                        </p>
-                        <p class="validationRequiredErrorMessage hidden">
-                            <label for="datetimeRequiredErrorMessage">{$lblErrorMessage|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
-                            {$txtDatetimeRequiredErrorMessage}
-                            <span id="datetimeRequiredErrorMessageError" class="formError" style="display: none;"></span>
-                        </p>
-                    </div>
-                    <div class="type options">
-                        <p class="p0">
-                            <label for="datetimeType">{$lblType|ucfirst}</label>
-                            {$ddmDatetimeType}
-                        </p>
-                        <p class="typeParameter" style="display: none;">
-                            <label for="datetimeTypeParameter">{$lblParameter|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
-                            {$txtDatetimeTypeParameter}
-                        </p>
-                    </div>
-                    <div class="validation options">
-                        <p class="p0">
-                            <label for="datetimeValidation">{$lblValidation|ucfirst}</label>
-                            {$ddmDatetimeValidation}
-                        </p>
-                        <p class="validationErrorMessage" style="display: none;">
-                            <label for="datetimeErrorMessage">{$lblErrorMessage|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
-                            {$txtDatetimeErrorMessage}
-                            <span id="datetimeErrorMessageError" class="formError" style="display: none;"></span>
-                        </p>
-                    </div>
-                </div>
+			<div id="tabDatetimeBasic" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="datetimeLabel">{$lblLabel|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
+							{$txtDatetimeLabel}
+							<span id="datetimeLabelError" class="formError" style="display: none;"></span>
+						</p>
+					</div>
+				</div>
+			</div>
+			<div id="tabDatetimeProperties" class="box">
+				<div class="horizontal">
+					<div class="defaultValue options">
+						<p>
+							<label for="datetimeValue">{$lblDefaultValue|ucfirst}</label>
+							{$ddmDatetimeValueAmount} {$ddmDatetimeValueType}
+							<span id="datetimeDefaultValueErrorMessageError" class="formError" style="display: none;"></span>
+						</p>
+					</div>
+					<div class="validation options">
+						<p class="p0">
+							<label for="datetimeRequired">{$lblRequiredField|ucfirst}</label>
+							{$chkDatetimeRequired}
+						</p>
+						<p class="validationRequiredErrorMessage hidden">
+							<label for="datetimeRequiredErrorMessage">{$lblErrorMessage|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
+							{$txtDatetimeRequiredErrorMessage}
+							<span id="datetimeRequiredErrorMessageError" class="formError" style="display: none;"></span>
+						</p>
+					</div>
+					<div class="type options">
+						<p class="p0">
+							<label for="datetimeType">{$lblType|ucfirst}</label>
+							{$ddmDatetimeType}
+						</p>
+						<p class="typeParameter" style="display: none;">
+							<label for="datetimeTypeParameter">{$lblParameter|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
+							{$txtDatetimeTypeParameter}
+						</p>
+					</div>
+					<div class="validation options">
+						<p class="p0">
+							<label for="datetimeValidation">{$lblValidation|ucfirst}</label>
+							{$ddmDatetimeValidation}
+						</p>
+						<p class="validationErrorMessage" style="display: none;">
+							<label for="datetimeErrorMessage">{$lblErrorMessage|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
+							{$txtDatetimeErrorMessage}
+							<span id="datetimeErrorMessageError" class="formError" style="display: none;"></span>
+						</p>
+					</div>
+				</div>
 
-            </div>
-        </div>
-    </div>
+			</div>
+		</div>
+	</div>
 
 	{* Dialog for a dropdown *}
 	<div id="dropdownDialog" title="{$lblDropdown|ucfirst}" class="dialog" style="display: none;">

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
@@ -181,6 +181,10 @@
 							<label for="textboxValue">{$lblDefaultValue|ucfirst}</label>
 							{$txtTextboxValue}
 						</p>
+                        <p>
+                            <label for="textboxPlaceholder">{$lblPlaceholder|ucfirst}</label>
+                            {$txtTextboxPlaceholder}
+                        </p>
 					</div>
 					<div class="options">
 						<p class="p0">
@@ -252,6 +256,10 @@
 							<label for="textareaValue">{$lblDefaultValue|ucfirst}</label>
 							{$txtTextareaValue}
 						</p>
+                        <p>
+                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+                            {$txtTextareaPlaceholder}
+                        </p>
 					</div>
 					<div class="validation options">
 						<p class="p0">

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
@@ -161,6 +161,7 @@
 			<ul>
 				<li><a href="#tabTextboxBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabTextboxProperties">{$lblProperties|ucfirst}</a></li>
+                <li><a href="#tabTextboxAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabTextboxBasic" class="box">
@@ -181,10 +182,6 @@
 							<label for="textboxValue">{$lblDefaultValue|ucfirst}</label>
 							{$txtTextboxValue}
 						</p>
-                        <p>
-                            <label for="textboxPlaceholder">{$lblPlaceholder|ucfirst}</label>
-                            {$txtTextboxPlaceholder}
-                        </p>
 					</div>
 					<div class="options">
 						<p class="p0">
@@ -224,6 +221,17 @@
 				</div>
 
 			</div>
+
+            <div id="tabTextboxAdvanced" class="box">
+                <div class="horizontal">
+                    <div class="options">
+                        <p>
+                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+                            {$txtTextboxPlaceholder}
+                        </p>
+                    </div>
+                </div>
+            </div>
 		</div>
 	</div>
 
@@ -235,6 +243,7 @@
 			<ul>
 				<li><a href="#tabTextareaBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabTextareaProperties">{$lblProperties|ucfirst}</a></li>
+                <li><a href="#tabTextareaAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabTextareaBasic" class="box">
@@ -256,10 +265,6 @@
 							<label for="textareaValue">{$lblDefaultValue|ucfirst}</label>
 							{$txtTextareaValue}
 						</p>
-                        <p>
-                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
-                            {$txtTextareaPlaceholder}
-                        </p>
 					</div>
 					<div class="validation options">
 						<p class="p0">
@@ -289,6 +294,17 @@
 					</div>
 				</div>
 			</div>
+
+            <div id="tabTextareaAdvanced" class="box">
+                <div class="horizontal">
+                    <div class="options">
+                        <p>
+                            <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+                            {$txtTextareaPlaceholder}
+                        </p>
+                    </div>
+                </div>
+            </div>
 		</div>
 	</div>
 

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -150,6 +150,7 @@ class Form extends FrontendBaseWidget
                 $item['name'] = 'field' . $field['id'];
                 $item['type'] = $field['type'];
                 $item['label'] = (isset($field['settings']['label'])) ? $field['settings']['label'] : '';
+                $item['placeholder'] = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
                 $item['required'] = isset($field['validations']['required']);
                 $item['html'] = '';
 
@@ -206,6 +207,7 @@ class Form extends FrontendBaseWidget
                 } elseif ($field['type'] == 'textbox') {
                     // create element
                     $txt = $this->frm->addText($item['name'], $defaultValues);
+                    $txt->setAttribute('placeholder', $item['placeholder']);
 
                     // add required attribute
                     if ($item['required']) {
@@ -264,6 +266,7 @@ class Form extends FrontendBaseWidget
                     // create element
                     $txt = $this->frm->addTextarea($item['name'], $defaultValues);
                     $txt->setAttribute('cols', 30);
+                    $txt->setAttribute('placeholder', $item['placeholder']);
 
                     // add required attribute
                     if ($item['required']) {


### PR DESCRIPTION
Adds a "placeholder" input field to the Formbuilder when you create a textbox or textarea element. This gives you the possibility to add placeholder text to the input field if you want.

Example: 
![image](https://cloud.githubusercontent.com/assets/1352979/6496352/1e77c956-c2d3-11e4-961e-1c49320ae013.png)

Or should I put a line between the "default value" and the "placeholder" input field?


Frontend:

![image](https://cloud.githubusercontent.com/assets/1352979/6496379/60ae462e-c2d3-11e4-81ff-514905a03c49.png)



This fixes #1083 