### PR TITLE
Page Template: {option:isPageXChild} added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.9.2 (2015-xx-xx)
 --
 Improvements:
+* Core: every template can now check if it has a certain parent id with {option:isPage1Child}
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 3.9.2 (2015-xx-xx)
 --
 Improvements:
-* Core: every template can now check if it has a certain parent id with {option:isPage1Child}
+* Core: every template can now check if it has a certain parent id with {option:isChildOfPage1}
 
 Bugfixes:
 

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -172,7 +172,7 @@ class Page extends FrontendBaseObject
 
         // assign the id so we can use it as an option
         $this->tpl->assign('isPage' . $this->pageId, true);
-        $this->tpl->assign('isPage' . $this->record['parent_id'] . 'Child', true);
+        $this->tpl->assign('isChildOfPage' . $this->record['parent_id'], true);
 
         // hide the cookiebar from within the code to prevent flickering
         $this->tpl->assign(

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -172,6 +172,7 @@ class Page extends FrontendBaseObject
 
         // assign the id so we can use it as an option
         $this->tpl->assign('isPage' . $this->pageId, true);
+        $this->tpl->assign('isPage' . $this->record['parent_id'] . 'Child', true);
 
         // hide the cookiebar from within the code to prevent flickering
         $this->tpl->assign(


### PR DESCRIPTION
## Problem

When having a page tree structure with parents containing children.
You sometimes need to add extra elements for pages for a certain parent.

## Solution

You can now use the following if you want pages with a parent_id == 30 to have an extra paragraph:
```html
{option:isPage30Child}
<p>I'm a child for the parent page with ID = 30</p>
{/option:isPage30Child}
```