### PR TITLE
Fixed add landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Improvements:
 
 Bugfixes:
+* Analytics: Fixed error when no page_list items were found.
 
 
 3.9.1 (2015-03-xx)

--- a/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
+++ b/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
@@ -113,7 +113,7 @@ class AddLandingPage extends BackendBaseActionAdd
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }
             if (!$this->frm->getField('page_path')->isFilled()
-                && !empty($this->linkList)
+                && $this->frm->existsField('page_list')
                 && !$this->frm->getfield('page_list')->isFilled()
             ) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));

--- a/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
+++ b/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
@@ -112,8 +112,9 @@ class AddLandingPage extends BackendBaseActionAdd
             if (!isset($page)) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }
-            if (!$this->frm->getField('page_path')->isFilled() &&
-                !$this->frm->hasField('page_list')->isFilled()
+            if (!$this->frm->getField('page_path')->isFilled()
+                && !empty($this->linkList)
+                && !$this->frm->getfield('page_list')->isFilled()
             ) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }

--- a/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
+++ b/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
@@ -91,6 +91,7 @@ class AddLandingPage extends BackendBaseActionAdd
 
             // shorten values
             $pagePath = $this->frm->getField('page_path')->getValue();
+            $pageList = null;
             if (count($this->linkList) > 1) {
                 $pageList = $this->frm->getField('page_list')->getSelected();
             }
@@ -111,7 +112,10 @@ class AddLandingPage extends BackendBaseActionAdd
             if (!isset($page)) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }
-            if (!$this->frm->getField('page_path')->isFilled() && !$this->frm->getfield('page_list')->isFilled()) {
+            if (!$this->frm->getField('page_path')->isFilled()
+                && !empty($this->linkList)
+                && !$this->frm->getfield('page_list')->isFilled()
+            ) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }
 

--- a/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
+++ b/src/Backend/Modules/Analytics/Actions/AddLandingPage.php
@@ -112,9 +112,8 @@ class AddLandingPage extends BackendBaseActionAdd
             if (!isset($page)) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }
-            if (!$this->frm->getField('page_path')->isFilled()
-                && !empty($this->linkList)
-                && !$this->frm->getfield('page_list')->isFilled()
+            if (!$this->frm->getField('page_path')->isFilled() &&
+                !$this->frm->hasField('page_list')->isFilled()
             ) {
                 $this->frm->getField('page_path')->addError(BL::err('FieldIsRequired'));
             }


### PR DESCRIPTION
## Problem
> This bug only occurs when no items are found for a dropdown 'page_list'.

Steps te reproduce
* Set up Analytics API key
* Click ```add landing page``` (you see no dropdown containing link items)
* When you now enter something and click "validate", you get an error in validateForm(), thats because the field 'page_list' does not exists.

## Solution

This solution solves two bugs
* ```$pageList``` was not set at rule 95-96
* field 'page_list' does not exists at rule 114