### PR TITLE
Rename blockIsHTML to blockIsEditor.

### DIFF
--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -369,9 +369,12 @@ class Page extends FrontendBaseObject
                         // parse extra
                         $positions[$position][$i] = array(
                             'variables' => $block['extra']->getTemplate()->getAssignedVariables(),
-                            'blockIsHTML' => false,
+                            'blockIsEditor' => false,
                             'blockContent' => $block['extra']->getContent()
                         );
+
+                        // Maintain backwards compatibility
+                        $positions[$position][$i]['blockIsHTML'] = $positions[$position][$i]['blockIsEditor'];
 
                         if (empty($positions[$position][$i]['blockContent'])) {
                             unset($positions[$position][$i]);
@@ -498,9 +501,12 @@ class Page extends FrontendBaseObject
                 } else {
                     // the block only contains HTML
                     $block = array(
-                        'blockIsHTML' => true,
+                        'blockIsEditor' => true,
                         'blockContent' => $block['html']
                     );
+
+                    // Maintain backwards compatibility
+                    $block['blockIsHTML'] = $block['blockIsEditor'];
                 }
             }
         }

--- a/src/Frontend/Core/Layout/Templates/Default.tpl
+++ b/src/Frontend/Core/Layout/Templates/Default.tpl
@@ -34,7 +34,7 @@
 
 			{* Main position *}
 			{iteration:positionMain}
-				{option:positionMain.blockIsHTML}
+				{option:positionMain.blockIsEditor}
 					<section class="mod">
 						<div class="inner">
 							<div class="bd content">
@@ -42,10 +42,10 @@
 							</div>
 						</div>
 					</section>
-				{/option:positionMain.blockIsHTML}
-				{option:!positionMain.blockIsHTML}
+				{/option:positionMain.blockIsEditor}
+				{option:!positionMain.blockIsEditor}
 					{$positionMain.blockContent}
-				{/option:!positionMain.blockIsHTML}
+				{/option:!positionMain.blockIsEditor}
 			{/iteration:positionMain}
 		</section>
 

--- a/src/Frontend/Core/Layout/Templates/Home.tpl
+++ b/src/Frontend/Core/Layout/Templates/Home.tpl
@@ -34,7 +34,7 @@
 
 			{* Main position *}
 			{iteration:positionMain}
-				{option:positionMain.blockIsHTML}
+				{option:positionMain.blockIsEditor}
 					<section class="mod">
 						<div class="inner">
 							<div class="bd content">
@@ -42,10 +42,10 @@
 							</div>
 						</div>
 					</section>
-				{/option:positionMain.blockIsHTML}
-				{option:!positionMain.blockIsHTML}
+				{/option:positionMain.blockIsEditor}
+				{option:!positionMain.blockIsEditor}
 					{$positionMain.blockContent}
-				{/option:!positionMain.blockIsHTML}
+				{/option:!positionMain.blockIsEditor}
 			{/iteration:positionMain}
 		</section>
 

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Default.tpl
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Default.tpl
@@ -42,14 +42,14 @@
 
 				{* Advertisement position *}
 				{iteration:positionAdvertisement}
-					{option:positionAdvertisement.blockIsHTML}
+					{option:positionAdvertisement.blockIsEditor}
 						<div id="headerAd">
 							{$positionAdvertisement.blockContent}
 						</div>
-					{/option:positionAdvertisement.blockIsHTML}
-					{option:!positionAdvertisement.blockIsHTML}
+					{/option:positionAdvertisement.blockIsEditor}
+					{option:!positionAdvertisement.blockIsEditor}
 						{$positionAdvertisement.blockContent}
-					{/option:!positionAdvertisement.blockIsHTML}
+					{/option:!positionAdvertisement.blockIsEditor}
 				{/iteration:positionAdvertisement}
 			</div>
 
@@ -68,7 +68,7 @@
 
 					{* Left position *}
 					{iteration:positionLeft}
-						{option:positionLeft.blockIsHTML}
+						{option:positionLeft.blockIsEditor}
 							<section class="mod">
 								<div class="inner">
 									<div class="bd content">
@@ -76,10 +76,10 @@
 									</div>
 								</div>
 							</section>
-						{/option:positionLeft.blockIsHTML}
-						{option:!positionLeft.blockIsHTML}
+						{/option:positionLeft.blockIsEditor}
+						{option:!positionLeft.blockIsEditor}
 							{$positionLeft.blockContent}
-						{/option:!positionLeft.blockIsHTML}
+						{/option:!positionLeft.blockIsEditor}
 					{/iteration:positionLeft}
 
 				</div>
@@ -96,7 +96,7 @@
 
 					{* Main position *}
 					{iteration:positionMain}
-						{option:positionMain.blockIsHTML}
+						{option:positionMain.blockIsEditor}
 							<section class="mod">
 								<div class="inner">
 									<div class="bd content">
@@ -104,10 +104,10 @@
 									</div>
 								</div>
 							</section>
-						{/option:positionMain.blockIsHTML}
-						{option:!positionMain.blockIsHTML}
+						{/option:positionMain.blockIsEditor}
+						{option:!positionMain.blockIsEditor}
 							{$positionMain.blockContent}
-						{/option:!positionMain.blockIsHTML}
+						{/option:!positionMain.blockIsEditor}
 					{/iteration:positionMain}
 
 				</div>

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Home.tpl
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Home.tpl
@@ -42,14 +42,14 @@
 
 				{* Advertisement position *}
 				{iteration:positionAdvertisement}
-					{option:positionAdvertisement.blockIsHTML}
+					{option:positionAdvertisement.blockIsEditor}
 						<div id="headerAd">
 							{$positionAdvertisement.blockContent}
 						</div>
-					{/option:positionAdvertisement.blockIsHTML}
-					{option:!positionAdvertisement.blockIsHTML}
+					{/option:positionAdvertisement.blockIsEditor}
+					{option:!positionAdvertisement.blockIsEditor}
 						{$positionAdvertisement.blockContent}
-					{/option:!positionAdvertisement.blockIsHTML}
+					{/option:!positionAdvertisement.blockIsEditor}
 				{/iteration:positionAdvertisement}
 
 			</div>
@@ -70,7 +70,7 @@
 
 					{* Main position *}
 					{iteration:positionMain}
-						{option:positionMain.blockIsHTML}
+						{option:positionMain.blockIsEditor}
 							<section class="mod">
 								<div class="inner">
 									<div class="bd content">
@@ -78,10 +78,10 @@
 									</div>
 								</div>
 							</section>
-						{/option:positionMain.blockIsHTML}
-						{option:!positionMain.blockIsHTML}
+						{/option:positionMain.blockIsEditor}
+						{option:!positionMain.blockIsEditor}
 							{$positionMain.blockContent}
-						{/option:!positionMain.blockIsHTML}
+						{/option:!positionMain.blockIsEditor}
 					{/iteration:positionMain}
 
 				</div>
@@ -91,7 +91,7 @@
 
 				{* Left position *}
 				{iteration:positionLeft}
-					{option:positionLeft.blockIsHTML}
+					{option:positionLeft.blockIsEditor}
 						<section class="mod">
 							<div class="inner">
 								<div class="bd content">
@@ -99,10 +99,10 @@
 								</div>
 							</div>
 						</section>
-					{/option:positionLeft.blockIsHTML}
-					{option:!positionLeft.blockIsHTML}
+					{/option:positionLeft.blockIsEditor}
+					{option:!positionLeft.blockIsEditor}
 						{$positionLeft.blockContent}
-					{/option:!positionLeft.blockIsHTML}
+					{/option:!positionLeft.blockIsEditor}
 				{/iteration:positionLeft}
 
 				</div>
@@ -112,7 +112,7 @@
 
 				{* Right position *}
 				{iteration:positionRight}
-					{option:positionRight.blockIsHTML}
+					{option:positionRight.blockIsEditor}
 						<section class="mod">
 							<div class="inner">
 								<div class="bd content">
@@ -120,10 +120,10 @@
 								</div>
 							</div>
 						</section>
-					{/option:positionRight.blockIsHTML}
-					{option:!positionRight.blockIsHTML}
+					{/option:positionRight.blockIsEditor}
+					{option:!positionRight.blockIsEditor}
 						{$positionRight.blockContent}
-					{/option:!positionRight.blockIsHTML}
+					{/option:!positionRight.blockIsEditor}
 				{/iteration:positionRight}
 
 				</div>


### PR DESCRIPTION
blockIsEditor is better naming.
Backwards compatibility is preserved by equaling blockIsHTML to the
value of blockIsEditor.

Closes #1147.