### PR TITLE
Bugfix in Add/Edit Groups - not-installed module widgets should not be executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Improvements:
 
 Bugfixes:
 
+* Groups: Fix (in add/edit) for executing widgets for which the module doesn't exists.
+
 
 3.9.1 (2015-03-12)
 --

--- a/src/Backend/Modules/Groups/Actions/Add.php
+++ b/src/Backend/Modules/Groups/Actions/Add.php
@@ -349,6 +349,10 @@ class Add extends BackendBaseActionAdd
     {
         // loop through all widgets
         foreach ($this->widgetInstances as $widget) {
+            if (!BackendModel::isModuleInstalled($widget['module'])) {
+                continue;
+            }
+
             // create instance
             $instance = new $widget['className']($this->getKernel());
 

--- a/src/Backend/Modules/Groups/Actions/Edit.php
+++ b/src/Backend/Modules/Groups/Actions/Edit.php
@@ -528,6 +528,10 @@ class Edit extends BackendBaseActionEdit
 
         // loop through all widgets
         foreach ($this->widgetInstances as $widget) {
+            if (!BackendModel::isModuleInstalled($widget['module'])) {
+                continue;
+            }
+
             // create instance
             $instance = new $widget['className']($this->getKernel());
 


### PR DESCRIPTION
## Problem
When adding/editing a Group and you try to add widgets for modules that aren't installed.
The widgets throw errors, because their database tables don't exist.

## Solution
I added a check so we first check if this module is installed. If not, skip this widget from executing.