### PR TITLE
Fix exception handlers by using "self" instead "this"

### DIFF
--- a/src/Api/V1/Init.php
+++ b/src/Api/V1/Init.php
@@ -128,7 +128,7 @@ class Init extends \KernelLoader
     public static function exceptionHandler($exception, $output)
     {
         $output = (string) $output;
-        $debugMail = $this->getContainer()->getParameter('fork.debug_email');
+        $debugMail = self::getContainer()->getParameter('fork.debug_email');
 
         // mail it?
         if ($debugMail != '') {

--- a/src/Backend/Init.php
+++ b/src/Backend/Init.php
@@ -142,7 +142,7 @@ class Init extends \KernelLoader
     public static function exceptionHandler($exception, $output)
     {
         $output = (string) $output;
-        $debugEmail = $this->getContainer()->getParameter('fork.debug_email');
+        $debugEmail = self::getContainer()->getParameter('fork.debug_email');
 
         // mail it?
         if ($debugEmail != '') {

--- a/src/Frontend/Init.php
+++ b/src/Frontend/Init.php
@@ -142,7 +142,7 @@ class Init extends \KernelLoader
     public static function exceptionHandler($exception, $output)
     {
         $output = (string) $output;
-        $debugEmail = $this->getContainer()->getParameter('fork.debug_email');
+        $debugEmail = self::getContainer()->getParameter('fork.debug_email');
 
         // mail it?
         if ($debugEmail != '') {


### PR DESCRIPTION
Fix exception handlers by using "self" instead "this" because the method are in the class scope not in its instance scope.