### PR TITLE
Fix "Illegal offset type" error on setReplyTo method

### DIFF
--- a/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
+++ b/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
@@ -58,7 +58,7 @@ final class FormBuilderSubmittedMailSubscriber
                 if (array_key_exists('reply_to', $field['settings']) &&
                     $field['settings']['reply_to'] === true
                 ) {
-                    $email = $fieldData[$field['id']];
+                    $email = $fieldData[$field['id']]['value'];
                     $message->setReplyTo(array($email => $email));
                 }
             }


### PR DESCRIPTION
The setReplyTo method uses an array with $email as key and value. The variable $email is however an array containing: 'id' and 'value'. 

Because of this, the error "Illegal offset type" is thrown on line 62. We need a string here, so make sure to fetch the value from $email

After fixing this, my form works again perfectly.

Did it work properly in #1182 ? 