### PR TITLE
Only inject the modulesSettings in the configurator.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -61,7 +61,7 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
         arguments:
-            - @database
+            - @fork.settings
             - @service_container
     fork.settings_cache:
         class: Common\Cache\InMemoryCache

--- a/src/Common/Mailer/Configurator.php
+++ b/src/Common/Mailer/Configurator.php
@@ -3,13 +3,12 @@
 namespace Common\Mailer;
 
 use PDOException;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Common\ModulesSettings;
 
-class Configurator implements EventSubscriberInterface
+class Configurator
 {
     /**
      * @var ModulesSettings
@@ -45,12 +44,5 @@ class Configurator implements EventSubscriberInterface
         } catch (PDOException $e) {
             // we'll just use the mail transport thats pre-configured
         }
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST => array('onKernelRequest', 0)
-        );
     }
 }

--- a/src/Common/Mailer/TransportFactory.php
+++ b/src/Common/Mailer/TransportFactory.php
@@ -47,7 +47,7 @@ class TransportFactory
         ;
 
         if (in_array($encryption, array('ssl', 'tls'))) {
-            $transport->setEncryption('ssl');
+            $transport->setEncryption($encryption);
         }
 
         return $transport;

--- a/src/Common/Tests/Mailer/ConfiguratorTest.php
+++ b/src/Common/Tests/Mailer/ConfiguratorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Common\Tests\Mailer;
+
+use Common\Mailer\Configurator;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests for our module settings
+ *
+ * @author Wouter Sioen <wouter@sumocoders.be>
+ */
+class ConfiguratorTest extends PHPUnit_Framework_TestCase
+{
+    public function testConfiguratorSetsMailTransportByDefault()
+    {
+        $modulesSettingsMock = $this->getModulesSettingsMock();
+        $containerMock =
+            $this->getContainerMock();
+
+        $configurator = new Configurator(
+            $modulesSettingsMock,
+            $containerMock
+        );
+
+        // always return null: we have no modules settings set
+        $modulesSettingsMock
+            ->expects($this->exactly(6))
+            ->method('get')
+            ->will($this->returnValue(null))
+        ;
+
+        // we want our set method to be called with a Mail transport
+        $containerMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->equalTo('swiftmailer.mailer.default.transport'),
+                $this->isInstanceOf('\Swift_MailTransport')
+            )
+        ;
+
+        $configurator->onKernelRequest($this->getGetResponseEventMock());
+    }
+
+    public function testConfiguratorSetsSmtpTransport()
+    {
+        $modulesSettingsMock = $this->getModulesSettingsMock();
+        $containerMock =
+            $this->getContainerMock();
+
+        $configurator = new Configurator(
+            $modulesSettingsMock,
+            $containerMock
+        );
+
+        // always return null: we have modules settings set for smtp
+        $modulesSettingsMock
+            ->expects($this->exactly(6))
+            ->method('get')
+            ->will($this->onConsecutiveCalls(
+                'smtp',
+                'test.server.com',
+                25,
+                'test@server.com',
+                'testpass'
+            ))
+        ;
+
+        // we want our set method to be called with a Smtp transport
+        $containerMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->equalTo('swiftmailer.mailer.default.transport'),
+                $this->isInstanceOf('\Swift_SmtpTransport')
+            )
+        ;
+
+        $configurator->onKernelRequest($this->getGetResponseEventMock());
+    }
+
+    private function getModulesSettingsMock()
+    {
+        return $this->getMockBuilder('Common\ModulesSettings')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    private function getContainerMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    private function getGetResponseEventMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+}

--- a/src/Common/Tests/Mailer/TransportFactoryTest.php
+++ b/src/Common/Tests/Mailer/TransportFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Common\Tests\Mailer;
+
+use PHPUnit_Framework_TestCase;
+use Common\Mailer\TransportFactory;
+
+/**
+ * Tests for our module settings
+ *
+ * @author Wouter Sioen <wouter@sumocoders.be>
+ */
+class TransportFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreatesMailTransportByDefault()
+    {
+        $this->assertInstanceOf(
+            'Swift_MailTransport',
+            TransportFactory::create()
+        );
+    }
+
+    public function testCreatesSmtpTransportIfWanted()
+    {
+        $this->assertInstanceOf(
+            'Swift_SmtpTransport',
+            TransportFactory::create('smtp')
+        );
+    }
+
+    public function testEncryptionCanBeSet()
+    {
+        $transport = TransportFactory::create('smtp', null, null, null, null, 'ssl');
+        $this->assertEquals(
+            'ssl',
+            $transport->getEncryption()
+        );
+
+        $transport = TransportFactory::create('smtp', null, null, null, null, 'tls');
+        $this->assertEquals(
+            'tls',
+            $transport->getEncryption()
+        );
+    }
+}


### PR DESCRIPTION
This has two benifits:

* We have a database call less (modules settings are cached  in the fork.settings service after 1 call).
* Our Configurator class has a responsibility less, it does not know where and how  the moduleSettings are saved.

I've also added some tests, which enabled me to cleanup the code a little more.