### PR TITLE
Bugfix analytics module when using deployment

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,6 +26,7 @@ FileETag MTime Size
 	RewriteRule src/Frontend/Cache/Logs - [F]
 	RewriteRule src/Frontend/Cache/Navigation/.*\.php - [F]
 	RewriteRule src/Frontend/Cache/Search - [F]
+	RewriteRule src/Frontend/Files/Analytics - [F]
 	RewriteRule src/Backend/Cache/CompiledTemplates - [F]
 	RewriteRule src/Backend/Cache/Config - [F]
 	RewriteRule src/Backend/Cache/Cronjobs - [F]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 
 Bugfixes:
 
+* Analytics: changed storage path for secret file.
 
 3.9.2 (2015-05-12)
 --

--- a/src/Backend/Modules/Analytics/Actions/Settings.php
+++ b/src/Backend/Modules/Analytics/Actions/Settings.php
@@ -161,7 +161,7 @@ final class Settings extends ActionIndex
 
         if ($this->form->isCorrect()) {
             $fileField->moveFile(
-                BACKEND_CACHE_PATH . '/' . $this->getModule() . '/'
+                FRONTEND_FILES_PATH . '/' . $this->getModule() . '/'
                 . $fileField->getFileName()
             );
             $this->get('fork.settings')->set(

--- a/src/Backend/Modules/Analytics/GoogleClient/ClientFactory.php
+++ b/src/Backend/Modules/Analytics/GoogleClient/ClientFactory.php
@@ -34,7 +34,7 @@ class ClientFactory
         // create the instance
         $client = new Google_Client();
         $client->setAuthConfigFile(
-            BACKEND_CACHE_PATH . '/Analytics/'
+            FRONTEND_FILES_PATH . '/Analytics/'
             . $this->settings->get('Analytics', 'secret_file')
         );
         $client->setRedirectUri(


### PR DESCRIPTION
BACKEND_CACHE_PATH worked. But when using capistrano deployment, every
time you deploy the cache (= secret json file) was deleted. So the file couldn't be
found and a Google Client Secret File error was thrown.