### PR TITLE
Formbuilder bootstrap fixes

### DIFF
--- a/src/Backend/Core/Layout/Css/extensions.css
+++ b/src/Backend/Core/Layout/Css/extensions.css
@@ -82,3 +82,8 @@ h3 + .btn-toolbar {
 .nav-tabs > li.danger > a:hover {
     color: #A94442;
 }
+
+/* Show click-to-edit message in center of editor */
+.form-group.optionsRTE {
+	position: relative;
+}

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -358,7 +358,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textboxId').val(data.data.field.id);
                                 $('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
-	                            $('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+                                $('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
                                 if (data.data.field.settings.reply_to && data.data.field.settings.reply_to == true) $('#textboxReplyTo').prop('checked', true);
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
@@ -384,7 +384,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textareaId').val(data.data.field.id);
                                 $('#textareaLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textareaValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
-	                            $('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+                                $('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -1141,7 +1141,7 @@ jsBackend.FormBuilder.Fields =
         var type = 'textarea';
         var label = $('#textareaLabel').val();
         var value = $('#textareaValue').val();
-	    var placeholder = $('#textareaPlaceholder').val();
+        var placeholder = $('#textareaPlaceholder').val();
         var required = ($('#textareaRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#textareaRequiredErrorMessage').val();
         var validation = $('#textareaValidation').val();
@@ -1156,7 +1156,7 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
-	            placeholder: placeholder,
+                placeholder: placeholder,
                 required: required,
                 required_error_message: requiredErrorMessage,
                 validation: validation,
@@ -1220,7 +1220,7 @@ jsBackend.FormBuilder.Fields =
         var type = 'textbox';
         var label = $('#textboxLabel').val();
         var value = $('#textboxValue').val();
-	    var placeholder = $('#textboxPlaceholder').val();
+        var placeholder = $('#textboxPlaceholder').val();
         var replyTo = ($('#textboxReplyTo').is(':checked') ? 'Y' : 'N');
         var required = ($('#textboxRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#textboxRequiredErrorMessage').val();
@@ -1236,7 +1236,7 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
-	            placeholder: placeholder,
+                placeholder: placeholder,
                 reply_to: replyTo,
                 required: required,
                 required_error_message: requiredErrorMessage,

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -1302,7 +1302,7 @@ jsBackend.FormBuilder.Fields =
         // new item
         else {
             // already field items so add after them
-            if ($('#fieldsHolder .field').length >= 1) $('#fieldsHolder .field:last').after(fieldHTML);
+            if ($('#fieldsHolder .jsField').length >= 1) $('#fieldsHolder .jsField:last').after(fieldHTML);
 
             // first field so add in beginning
             else $('#fieldsHolder').prepend(fieldHTML);

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -358,6 +358,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textboxId').val(data.data.field.id);
                                 $('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
+	                            $('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
                                 if (data.data.field.settings.reply_to && data.data.field.settings.reply_to == true) $('#textboxReplyTo').prop('checked', true);
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
@@ -383,6 +384,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textareaId').val(data.data.field.id);
                                 $('#textareaLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textareaValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
+	                            $('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -1139,6 +1141,7 @@ jsBackend.FormBuilder.Fields =
         var type = 'textarea';
         var label = $('#textareaLabel').val();
         var value = $('#textareaValue').val();
+	    var placeholder = $('#textareaPlaceholder').val();
         var required = ($('#textareaRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#textareaRequiredErrorMessage').val();
         var validation = $('#textareaValidation').val();
@@ -1153,6 +1156,7 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
+	            placeholder: placeholder,
                 required: required,
                 required_error_message: requiredErrorMessage,
                 validation: validation,
@@ -1216,6 +1220,7 @@ jsBackend.FormBuilder.Fields =
         var type = 'textbox';
         var label = $('#textboxLabel').val();
         var value = $('#textboxValue').val();
+	    var placeholder = $('#textboxPlaceholder').val();
         var replyTo = ($('#textboxReplyTo').is(':checked') ? 'Y' : 'N');
         var required = ($('#textboxRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#textboxRequiredErrorMessage').val();
@@ -1231,6 +1236,7 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
+	            placeholder: placeholder,
                 reply_to: replyTo,
                 required: required,
                 required_error_message: requiredErrorMessage,

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -660,7 +660,7 @@ jsBackend.FormBuilder.Fields =
      */
     resetDialog: function (id) {
         // clear all form fields
-        $('#' + id).find(':input').val('').removeAttr('checked').removeAttr('selected');
+        $('#' + id).find(':input').removeAttr('checked').removeAttr('selected').val('');
 
         // bind validation
         jsBackend.FormBuilder.Fields.handleValidation('#' + id + ' .jsValidation');
@@ -672,7 +672,7 @@ jsBackend.FormBuilder.Fields =
         $('#datetimeDialog').find('.defaultValue').show();
 
         // select first tab
-        $('#' + id + ' .tabs').tabs('select', 0);
+        $('#' + id + ' .nav-tabs a:first').tab('show');
     },
 
     /**

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
@@ -74,7 +74,7 @@
                                         {$txtTextboxRequiredErrorMessage}
                                     </div>
                                 </div>
-                                <div class="jsValidation" style="display: none;">
+                                <div class="jsValidation">
                                     <div class="form-group">
                                         <label for="textboxValidation">{$lblValidation|ucfirst}</label>
                                         {$ddmTextboxValidation}

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
@@ -14,6 +14,9 @@
                     <li role="presentation">
                         <a href="#tabTextboxProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
                     </li>
+                    <li role="presentation">
+                        <a href="#tabTextboxAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
+                    </li>
                 </ul>
                 <div class="tab-content">
                     <div role="tabpanel" class="tab-pane jsFieldTab active" id="tabTextboxBasic">
@@ -99,6 +102,25 @@
                             </div>
                         </div>
                     </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabTextboxAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="textboxPlaceholder">
+                                        {$lblPlaceholder|ucfirst}
+                                        <abbr class="glyphicon glyphicon-asterisk" title="{$lblRequiredField|ucfirst}"></abbr>
+                                    </label>
+                                    <p id="textboxPlaceholderError" class="text-danger jsFieldError" style="display: none;"></p>
+                                    {$txtTextboxPlaceholder}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -124,6 +146,9 @@
                     </li>
                     <li role="presentation">
                         <a href="#tabTextareaProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#tabTextareaAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -195,6 +220,25 @@
                                         <p id="textareaErrorMessageError" class="text-danger jsFieldError" style="display: none;"></p>
                                         {$txtTextareaErrorMessage}
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabTextareaAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="textareaPlaceholder">
+                                        {$lblPlaceholder|ucfirst}
+                                        <abbr class="glyphicon glyphicon-asterisk" title="{$lblRequiredField|ucfirst}"></abbr>
+                                    </label>
+                                    <p id="textareaPlaceholderError" class="text-danger jsFieldError" style="display: none;"></p>
+                                    {$txtTextareaPlaceholder}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Some fixes to the bootstrap Formbuilder module that I promised 😬

* [x] Fixed an error that caused newly added fields to prepend to the form instead of append like earlier
* [x] Fixed showing validation options (validate message etc). They were hidden with display: none; 
* [x] Fixes to the removeDialog script (select the first tab using bootstrap code, fix removeAttr error)
* [x] Center the click-to-edit message in the paragraph ckeditor. The click-to-edit message was positioned at top overlaying on the buttons (like [this](http://cl.ly/image/203u0X2G0y0r)). This problem occurred on all editor blocks in fork cms.
* [x] Add some missing placeholder code to show placeholders input fields in Formbuilder etc.

I noticed that some tpl files use 2 space indentation, while some others use tabs. Shouldn't they all be set in 4-space indentation? Or wait until the conversion to twig? 