### PR TITLE
Increasing security in API when user is "God"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Improvements:
 Bugfixes:
 
 * Analytics: Auth config content saved in databse, because capistrano deployments didn't work with BACKEND_CACHE_PATH.
+* Api: increasing security when user is GOD.
+
 
 3.9.2 (2015-05-12)
 --

--- a/src/Api/V1/Engine/Api.php
+++ b/src/Api/V1/Engine/Api.php
@@ -327,11 +327,6 @@ class Api extends \KernelLoader implements \ApplicationInterface
             return self::output(self::FORBIDDEN, array('message' => 'This account does not exist.'));
         }
 
-        // user is god!
-        if ($user->isGod()) {
-            return true;
-        }
-
         // get settings
         $apiAccess = $user->getSetting('api_access', false);
         $apiKey = $user->getSetting('api_key');


### PR DESCRIPTION
Even for "God" we have to verify the access_token.

**Problem**
When a "God" user connects for the first time with his email address, he will be given an "api_key" in the database. But on the next calls which require authentication, that api key will never be checked in the API, because we return true before even checking it.

So if any other person knows the email address of "God", no matter what API key he fills in, he can be able to access anything in the API.

**Solution**
Remove the "God" check. So every authenticated call needs to check the given api_key.