### PR TITLE
Add classname inputfield to formbuilder fields

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -77,6 +77,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addText('textbox_label');
         $this->frm->addText('textbox_value');
         $this->frm->addText('textbox_placeholder');
+        $this->frm->addText('textbox_classname');
         $this->frm->addCheckbox('textbox_required');
         $this->frm->addCheckbox('textbox_reply_to');
         $this->frm->addText('textbox_required_error_message');
@@ -96,6 +97,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addTextarea('textarea_value');
         $this->frm->getField('textarea_value')->setAttribute('cols', 30);
         $this->frm->addText('textarea_placeholder');
+        $this->frm->addText('textarea_classname');
         $this->frm->addCheckbox('textarea_required');
         $this->frm->addText('textarea_required_error_message');
         $this->frm->addDropdown('textarea_validation', array('' => ''));
@@ -149,7 +151,7 @@ class Edit extends BackendBaseActionEdit
                 'time' => BL::getLabel('Time')
             )
         );
-        //$this->frm->addText('datetime_validation_parameter');
+        $this->frm->addText('datetime_classname');
         $this->frm->addText('datetime_error_message');
 
         // dropdown dialog
@@ -158,6 +160,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('dropdown_default_value', array('' => ''))->setAttribute('rel', 'dropDownValues');
         $this->frm->addCheckbox('dropdown_required');
         $this->frm->addText('dropdown_required_error_message');
+        $this->frm->addText('dropdown_classname');
 
         // radiobutton dialog
         $this->frm->addText('radiobutton_label');
@@ -165,6 +168,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('radiobutton_default_value', array('' => ''))->setAttribute('rel', 'radioButtonValues');
         $this->frm->addCheckbox('radiobutton_required');
         $this->frm->addText('radiobutton_required_error_message');
+        $this->frm->addText('radiobutton_classname');
 
         // checkbox dialog
         $this->frm->addText('checkbox_label');
@@ -172,6 +176,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('checkbox_default_value', array('' => ''))->setAttribute('rel', 'checkBoxValues');
         $this->frm->addCheckbox('checkbox_required');
         $this->frm->addText('checkbox_required_error_message');
+        $this->frm->addText('checkbox_classname');
 
         // heading dialog
         $this->frm->addText('heading');

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -46,6 +46,7 @@ class SaveField extends BackendBaseAJAXAction
 
         $defaultValues = trim(\SpoonFilter::getPostValue('default_values', null, '', 'string'));
         $placeholder = trim(\SpoonFilter::getPostValue('placeholder', null, '', 'string'));
+        $classname = trim(\SpoonFilter::getPostValue('classname', null, '', 'string'));
         $required = \SpoonFilter::getPostValue('required', array('Y','N'), 'N', 'string');
         $requiredErrorMessage = trim(\SpoonFilter::getPostValue('required_error_message', null, '', 'string'));
         $validation = \SpoonFilter::getPostValue('validation', array('email', 'numeric', 'time'), '', 'string');
@@ -208,8 +209,12 @@ class SaveField extends BackendBaseAJAXAction
                         if ($defaultValues != '') {
                             $settings['default_values'] = $defaultValues;
                         }
-                        if($placeholder != '') {
+                        if ($placeholder != '') {
                             $settings['placeholder'] = \SpoonFilter::htmlspecialchars($placeholder);
+                        }
+
+                        if ($classname != '') {
+                            $settings['classname'] = \SpoonFilter::htmlspecialchars($classname);
                         }
 
                         // reply-to, only for textboxes

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -393,6 +393,11 @@
         <translation language="sv"><![CDATA[platshållare]]></translation>
         <translation language="el"><![CDATA[κράτησης θέσης]]></translation>
       </item>
+      <item type="label" name="Classname">
+        <translation language="nl"><![CDATA[CSS klasse]]></translation>
+        <translation language="en"><![CDATA[CSS classname]]></translation>
+        <translation language="de"><![CDATA[CSS Klasse]]></translation>
+      </item>
       <item type="label" name="Preview">
         <translation language="nl"><![CDATA[preview]]></translation>
         <translation language="en"><![CDATA[preview]]></translation>

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -414,6 +414,7 @@ jsBackend.formBuilder.fields =
 								$('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
 								$('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+								$('#textboxClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								if(data.data.field.settings.reply_to && data.data.field.settings.reply_to == true) $('#textboxReplyTo').prop('checked', true);
 								$.each(data.data.field.validations, function(k, v)
 								{
@@ -444,6 +445,7 @@ jsBackend.formBuilder.fields =
 								$('#textareaLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#textareaValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
 								$('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+								$('#textareaClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -474,6 +476,7 @@ jsBackend.formBuilder.fields =
 								$('#datetimeValueAmount').val(utils.string.htmlDecode(data.data.field.settings.value_amount));
 								$('#datetimeValueType').val(utils.string.htmlDecode(data.data.field.settings.value_type));
 								$('#datetimeType').val(utils.string.htmlDecode(data.data.field.settings.input_type));
+								$('#datetimeClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -502,6 +505,7 @@ jsBackend.formBuilder.fields =
 								$('#dropdownId').val(data.data.field.id);
 								$('#dropdownLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#dropdownValues').val(data.data.field.settings.values.join('|'));
+								$('#dropdownClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -540,6 +544,7 @@ jsBackend.formBuilder.fields =
 								$('#radiobuttonId').val(data.data.field.id);
 								$('#radiobuttonLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#radiobuttonValues').val(data.data.field.settings.values.join('|'));
+								$('#radiobuttonClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -578,6 +583,7 @@ jsBackend.formBuilder.fields =
 								$('#checkboxId').val(data.data.field.id);
 								$('#checkboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
 								$('#checkboxValues').val(data.data.field.settings.values.join('|'));
+								$('#checkboxClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
 								$.each(data.data.field.validations, function(k, v)
 								{
 									// required checkbox
@@ -776,6 +782,7 @@ jsBackend.formBuilder.fields =
 		var defaultValue = $('#checkboxDefaultValue').val();
 		var required = ($('#checkboxRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#checkboxRequiredErrorMessage').val();
+		var classname = $('#checkboxClassname').val();
 
 		// make the call
 		$.ajax(
@@ -789,7 +796,8 @@ jsBackend.formBuilder.fields =
 				values: values,
 				default_values: defaultValue,
 				required: required,
-				required_error_message: requiredErrorMessage
+				required_error_message: requiredErrorMessage,
+				classname: classname
 			}),
 			success: function(data, textStatus)
 			{
@@ -855,8 +863,8 @@ jsBackend.formBuilder.fields =
 		var required = ($('#datetimeRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#datetimeRequiredErrorMessage').val();
 		var validation = $('#datetimeValidation').val();
-		//var validationParameter = $('#datetimeValidationParameter').val();
 		var errorMessage = $('#datetimeErrorMessage').val();
+		var classname = $('#datetimeClassname').val();
 
 		// make the call
 		$.ajax(
@@ -873,8 +881,8 @@ jsBackend.formBuilder.fields =
 						required_error_message: requiredErrorMessage,
 						input_type: input_type,
 						validation: validation,
-						//validation_parameter: validationParameter,
-						error_message: errorMessage
+						error_message: errorMessage,
+						classname: classname
 					}),
 				success: function(data, textStatus)
 				{
@@ -938,6 +946,7 @@ jsBackend.formBuilder.fields =
 		var defaultValue = $('#dropdownDefaultValue').val();
 		var required = ($('#dropdownRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#dropdownRequiredErrorMessage').val();
+		var classname = $('#dropdownClassname').val();
 
 		// make the call
 		$.ajax(
@@ -951,7 +960,8 @@ jsBackend.formBuilder.fields =
 				values: values,
 				default_values: defaultValue,
 				required: required,
-				required_error_message: requiredErrorMessage
+				required_error_message: requiredErrorMessage,
+				classname: classname
 			}),
 			success: function(data, textStatus)
 			{
@@ -1131,6 +1141,7 @@ jsBackend.formBuilder.fields =
 		var defaultValue = $('#radiobuttonDefaultValue').val();
 		var required = ($('#radiobuttonRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#radiobuttonRequiredErrorMessage').val();
+		var classname = $('#radiobuttonClassname').val();
 
 		// make the call
 		$.ajax(
@@ -1144,7 +1155,8 @@ jsBackend.formBuilder.fields =
 				values: values,
 				default_values: defaultValue,
 				required: required,
-				required_error_message: requiredErrorMessage
+				required_error_message: requiredErrorMessage,
+				classname: classname
 			}),
 			success: function(data, textStatus)
 			{
@@ -1263,12 +1275,13 @@ jsBackend.formBuilder.fields =
 		var type = 'textarea';
 		var label = $('#textareaLabel').val();
 		var value = $('#textareaValue').val();
-		var placeholder = $('#textareaPlaceholder').val();
 		var required = ($('#textareaRequired').is(':checked') ? 'Y' : 'N');
 		var requiredErrorMessage = $('#textareaRequiredErrorMessage').val();
 		var validation = $('#textareaValidation').val();
 		var validationParameter = $('#textareaValidationParameter').val();
 		var errorMessage = $('#textareaErrorMessage').val();
+		var placeholder = $('#textareaPlaceholder').val();
+		var classname = $('#textareaClassname').val();
 
 		// make the call
 		$.ajax(
@@ -1280,12 +1293,13 @@ jsBackend.formBuilder.fields =
 				type: type,
 				label: label,
 				default_values: value,
-				placeholder: placeholder,
 				required: required,
 				required_error_message: requiredErrorMessage,
 				validation: validation,
 				validation_parameter: validationParameter,
-				error_message: errorMessage
+				error_message: errorMessage,
+				placeholder: placeholder,
+				classname: classname
 			}),
 			success: function(data, textStatus)
 			{
@@ -1353,6 +1367,7 @@ jsBackend.formBuilder.fields =
 		var validation = $('#textboxValidation').val();
 		var validationParameter = $('#textboxValidationParameter').val();
 		var errorMessage = $('#textboxErrorMessage').val();
+		var classname = $('#textboxClassname').val();
 
 		// make the call
 		$.ajax(
@@ -1370,7 +1385,8 @@ jsBackend.formBuilder.fields =
 				required_error_message: requiredErrorMessage,
 				validation: validation,
 				validation_parameter: validationParameter,
-				error_message: errorMessage
+				error_message: errorMessage,
+				classname: classname,
 			}),
 			success: function(data, textStatus)
 			{

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.tpl
@@ -226,8 +226,12 @@
 				<div class="horizontal">
 					<div class="options">
 						<p>
-							<label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
+							<label for="textboxPlaceholder">{$lblPlaceholder|ucfirst}</label>
 							{$txtTextboxPlaceholder}
+						</p>
+						<p>
+							<label for="textboxClassname">{$lblClassname|ucfirst}</label>
+							{$txtTextboxClassname}
 						</p>
 					</div>
 				</div>
@@ -302,6 +306,10 @@
 							<label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
 							{$txtTextareaPlaceholder}
 						</p>
+						<p>
+							<label for="textareaClassname">{$lblClassname|ucfirst}</label>
+							{$txtTextareaClassname}
+						</p>
 					</div>
 				</div>
 			</div>
@@ -316,6 +324,7 @@
 			<ul>
 				<li><a href="#tabDatetimeBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabDatetimeProperties">{$lblProperties|ucfirst}</a></li>
+				<li><a href="#tabDatetimeAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabDatetimeBasic" class="box">
@@ -371,7 +380,16 @@
 						</p>
 					</div>
 				</div>
-
+			</div>
+			<div id="tabDatetimeAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="datetimeClassname">{$lblClassname|ucfirst}</label>
+							{$txtDatetimeClassname}
+						</p>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -384,6 +402,7 @@
 			<ul>
 				<li><a href="#tabDropdownBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabDropdownProperties">{$lblProperties|ucfirst}</a></li>
+				<li><a href="#tabDropdownAdvanced">{$lblProperties|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabDropdownBasic" class="box">
@@ -424,6 +443,16 @@
 					</div>
 				</div>
 			</div>
+			<div id="tabDropdownAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="dropdownClassname">{$lblClassname|ucfirst}</label>
+							{$txtDropdownClassname}
+						</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
 
@@ -435,6 +464,7 @@
 			<ul>
 				<li><a href="#tabRadiobuttonBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabRadiobuttonProperties">{$lblProperties|ucfirst}</a></li>
+				<li><a href="#tabRadiobuttonAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabRadiobuttonBasic" class="box">
@@ -475,6 +505,16 @@
 					</div>
 				</div>
 			</div>
+			<div id="tabRadiobuttonAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="radiobuttonClassname">{$lblClassname|ucfirst}</label>
+							{$txtRadiobuttonClassname}
+						</p>
+					</div>
+				</div>
+			</div>
 		</div>
 	</div>
 
@@ -486,6 +526,7 @@
 			<ul>
 				<li><a href="#tabCheckboxBasic">{$lblBasic|ucfirst}</a></li>
 				<li><a href="#tabCheckboxProperties">{$lblProperties|ucfirst}</a></li>
+				<li><a href="#tabCheckboxAdvanced">{$lblAdvanced|ucfirst}</a></li>
 			</ul>
 
 			<div id="tabCheckboxBasic" class="box">
@@ -521,6 +562,17 @@
 							<label for="checkboxRequiredErrorMessage">{$lblErrorMessage|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
 							{$txtCheckboxRequiredErrorMessage}
 							<span id="checkboxRequiredErrorMessageError" class="formError" style="display: none;"></span>
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div id="tabCheckboxAdvanced" class="box">
+				<div class="horizontal">
+					<div class="options">
+						<p>
+							<label for="checkboxClassname">{$lblClassname|ucfirst}</label>
+							{$txtCheckboxClassname}
 						</p>
 					</div>
 				</div>

--- a/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.tpl
+++ b/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.tpl
@@ -24,7 +24,7 @@
 
 						{* Input fields, textareas and drop downs *}
 						{option:fields.simple}
-							<p{option:fields.error} class="errorArea"{/option:fields.error}>
+							<p class="{option:fields.error}errorArea {/option:fields.error}{option:fields.classname}{$fields.classname}{/option:fields.classname}">
 								<label for="{$fields.name}">
 									{$fields.label}{option:fields.required}<abbr title="{$lblRequiredField}">*</abbr>{/option:fields.required}
 								</label>
@@ -35,7 +35,7 @@
 
 						{* Radio buttons and checkboxes *}
 						{option:fields.multiple}
-							<div class="inputList{option:fields.error} errorArea{/option:fields.error}">
+							<div class="inputList {option:fields.error}errorArea {/option:fields.error}{option:fields.classname}{$fields.classname}{/option:fields.classname}">
 								<p class="label">
 									{$fields.label}{option:fields.required}<abbr title="{$lblRequiredField}">*</abbr>{/option:fields.required}
 								</p>

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -153,6 +153,7 @@ class Form extends FrontendBaseWidget
                 $item['type'] = $field['type'];
                 $item['label'] = (isset($field['settings']['label'])) ? $field['settings']['label'] : '';
                 $item['placeholder'] = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
+                $item['classname'] = (isset($field['settings']['classname']) ? $field['settings']['classname'] : null);
                 $item['required'] = isset($field['validations']['required']);
                 $item['html'] = '';
 


### PR DESCRIPTION
Adds a CSS classname field to the advanced panel of each formbuilder field. A small formbuilder feature that allows you to do more with form fields in the frontend. Use the CSS class field to resize fields using a grid classname, float fields next to each other, target fields with javascript selectors, hide a field label, etc.

I didn't add the css class to the header and paragraph elements in formbuilder, because those are too basic. 

Example:
Note that, of course, you can write multiple css classnames such as `.col-md-4 .field-email .js-email`
![schermafbeelding 2015-05-30 om 02 41 23](https://cloud.githubusercontent.com/assets/1352979/7894925/673d9860-0675-11e5-8328-e2e12d1c439c.png)
