### PR TITLE
fix pagination not working with querystring

### DIFF
--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -319,7 +319,7 @@ class Block extends Object
         }
 
         // should we use a questionmark or an ampersand
-        if (mb_strpos($this->pagination['url'], '?') > 0) {
+        if (mb_strpos($this->pagination['url'], '?') !== false) {
             $useQuestionMark = false;
         }
 

--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -278,7 +278,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         }
 
         // should we use a questionmark or an ampersand
-        if (mb_strpos($this->pagination['url'], '?') > 0) {
+        if (mb_strpos($this->pagination['url'], '?') !== false) {
             $useQuestionMark = false;
         }
 


### PR DESCRIPTION
If the url only contains of a querystring the character 0 will be the ? so it won't be detected and the paging url won't work with the querystring (like a form to filter)