### PR TITLE
Feature: Add CSS class to Formbuilder fields

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -77,6 +77,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addText('textbox_label');
         $this->frm->addText('textbox_value');
         $this->frm->addText('textbox_placeholder');
+        $this->frm->addText('textbox_classname');
         $this->frm->addCheckbox('textbox_required');
         $this->frm->addCheckbox('textbox_reply_to');
         $this->frm->addText('textbox_required_error_message');
@@ -96,6 +97,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addTextarea('textarea_value');
         $this->frm->getField('textarea_value')->setAttribute('cols', 30);
         $this->frm->addText('textarea_placeholder');
+        $this->frm->addText('textarea_classname');
         $this->frm->addCheckbox('textarea_required');
         $this->frm->addText('textarea_required_error_message');
         $this->frm->addDropdown('textarea_validation', array('' => ''));
@@ -149,7 +151,7 @@ class Edit extends BackendBaseActionEdit
                 'time' => BL::getLabel('Time')
             )
         );
-        //$this->frm->addText('datetime_validation_parameter');
+        $this->frm->addText('datetime_classname');
         $this->frm->addText('datetime_error_message');
 
         // dropdown dialog
@@ -158,6 +160,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('dropdown_default_value', array('' => ''))->setAttribute('rel', 'dropDownValues');
         $this->frm->addCheckbox('dropdown_required');
         $this->frm->addText('dropdown_required_error_message');
+        $this->frm->addText('dropdown_classname');
 
         // radiobutton dialog
         $this->frm->addText('radiobutton_label');
@@ -165,6 +168,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('radiobutton_default_value', array('' => ''))->setAttribute('rel', 'radioButtonValues');
         $this->frm->addCheckbox('radiobutton_required');
         $this->frm->addText('radiobutton_required_error_message');
+        $this->frm->addText('radiobutton_classname');
 
         // checkbox dialog
         $this->frm->addText('checkbox_label');
@@ -172,6 +176,7 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addDropdown('checkbox_default_value', array('' => ''))->setAttribute('rel', 'checkBoxValues');
         $this->frm->addCheckbox('checkbox_required');
         $this->frm->addText('checkbox_required_error_message');
+        $this->frm->addText('checkbox_classname');
 
         // heading dialog
         $this->frm->addText('heading');

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -46,6 +46,7 @@ class SaveField extends BackendBaseAJAXAction
 
         $defaultValues = trim(\SpoonFilter::getPostValue('default_values', null, '', 'string'));
         $placeholder = trim(\SpoonFilter::getPostValue('placeholder', null, '', 'string'));
+        $classname = trim(\SpoonFilter::getPostValue('classname', null, '', 'string'));
         $required = \SpoonFilter::getPostValue('required', array('Y','N'), 'N', 'string');
         $requiredErrorMessage = trim(\SpoonFilter::getPostValue('required_error_message', null, '', 'string'));
         $validation = \SpoonFilter::getPostValue('validation', array('email', 'numeric', 'time'), '', 'string');
@@ -208,8 +209,11 @@ class SaveField extends BackendBaseAJAXAction
                         if ($defaultValues != '') {
                             $settings['default_values'] = $defaultValues;
                         }
-                        if($placeholder != '') {
+                        if ($placeholder != '') {
                             $settings['placeholder'] = \SpoonFilter::htmlspecialchars($placeholder);
+                        }
+                        if ($classname != '') {
+                            $settings['classname'] = \SpoonFilter::htmlspecialchars($classname);
                         }
 
                         // reply-to, only for textboxes

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -393,6 +393,20 @@
         <translation language="sv"><![CDATA[platshållare]]></translation>
         <translation language="el"><![CDATA[κράτησης θέσης]]></translation>
       </item>
+      <item type="label" name="Classname">
+        <translation language="nl"><![CDATA[CSS-klasse]]></translation>
+        <translation language="en"><![CDATA[CSS class]]></translation>
+        <translation language="it"><![CDATA[Classe CSS]]></translation>
+        <translation language="ru"><![CDATA[CSS-класс]]></translation>
+        <translation language="zh"><![CDATA[CSS类]]></translation>
+        <translation language="fr"><![CDATA[Classe CSS]]></translation>
+        <translation language="hu"><![CDATA[CSS osztály]]></translation>
+        <translation language="de"><![CDATA[CSS-Klasse]]></translation>
+        <translation language="es"><![CDATA[Clases CSS]]></translation>
+        <translation language="uk"><![CDATA[CSS клас]]></translation>
+        <translation language="sv"><![CDATA[CSS-klass]]></translation>
+        <translation language="el"><![CDATA[CSS Class]]></translation>
+      </item>
       <item type="label" name="Preview">
         <translation language="nl"><![CDATA[preview]]></translation>
         <translation language="en"><![CDATA[preview]]></translation>

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -359,6 +359,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
                                 $('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+                                $('#textboxClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 if (data.data.field.settings.reply_to && data.data.field.settings.reply_to == true) $('#textboxReplyTo').prop('checked', true);
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
@@ -385,6 +386,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#textareaLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#textareaValue').val(utils.string.htmlDecode(data.data.field.settings.default_values));
                                 $('#textareaPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder));
+                                $('#textareaClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -411,6 +413,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#datetimeValueAmount').val(utils.string.htmlDecode(data.data.field.settings.value_amount));
                                 $('#datetimeValueType').val(utils.string.htmlDecode(data.data.field.settings.value_type));
                                 $('#datetimeType').val(utils.string.htmlDecode(data.data.field.settings.input_type));
+                                $('#datetimeClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -435,6 +438,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#dropdownId').val(data.data.field.id);
                                 $('#dropdownLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#dropdownValues').val(data.data.field.settings.values.join('|'));
+                                $('#dropdownClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -468,6 +472,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#radiobuttonId').val(data.data.field.id);
                                 $('#radiobuttonLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#radiobuttonValues').val(data.data.field.settings.values.join('|'));
+                                $('#radiobuttonClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -501,6 +506,7 @@ jsBackend.FormBuilder.Fields =
                                 $('#checkboxId').val(data.data.field.id);
                                 $('#checkboxLabel').val(utils.string.htmlDecode(data.data.field.settings.label));
                                 $('#checkboxValues').val(data.data.field.settings.values.join('|'));
+                                $('#checkboxClassname').val(utils.string.htmlDecode(data.data.field.settings.classname));
                                 $.each(data.data.field.validations, function (k, v) {
                                     // required checkbox
                                     if (k == 'required') {
@@ -689,6 +695,7 @@ jsBackend.FormBuilder.Fields =
         var defaultValue = $('#checkboxDefaultValue').val();
         var required = ($('#checkboxRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#checkboxRequiredErrorMessage').val();
+        var classname = $('#checkboxClassname').val();
 
         // make the call
         $.ajax({
@@ -700,7 +707,8 @@ jsBackend.FormBuilder.Fields =
                 values: values,
                 default_values: defaultValue,
                 required: required,
-                required_error_message: requiredErrorMessage
+                required_error_message: requiredErrorMessage,
+                classname: classname
             }),
             success: function (data, textStatus) {
                 // success
@@ -766,6 +774,7 @@ jsBackend.FormBuilder.Fields =
         var requiredErrorMessage = $('#datetimeRequiredErrorMessage').val();
         var validation = $('#datetimeValidation').val();
         var errorMessage = $('#datetimeErrorMessage').val();
+        var classname = $('#datetimeClassname').val();
 
         // make the call
         $.ajax(
@@ -781,7 +790,8 @@ jsBackend.FormBuilder.Fields =
                     required_error_message: requiredErrorMessage,
                     input_type: input_type,
                     validation: validation,
-                    error_message: errorMessage
+                    error_message: errorMessage,
+                    classname: classname
                 }),
                 success: function (data, textStatus) {
                     // success
@@ -843,6 +853,7 @@ jsBackend.FormBuilder.Fields =
         var defaultValue = $('#dropdownDefaultValue').val();
         var required = ($('#dropdownRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#dropdownRequiredErrorMessage').val();
+        var classname = $('#dropdownClassname').val();
 
         // make the call
         $.ajax({
@@ -854,7 +865,8 @@ jsBackend.FormBuilder.Fields =
                 values: values,
                 default_values: defaultValue,
                 required: required,
-                required_error_message: requiredErrorMessage
+                required_error_message: requiredErrorMessage,
+                classname: classname
             }),
             success: function (data, textStatus) {
                 // success
@@ -1023,6 +1035,7 @@ jsBackend.FormBuilder.Fields =
         var defaultValue = $('#radiobuttonDefaultValue').val();
         var required = ($('#radiobuttonRequired').is(':checked') ? 'Y' : 'N');
         var requiredErrorMessage = $('#radiobuttonRequiredErrorMessage').val();
+        var classname = $('#radiobuttonClassname').val();
 
         // make the call
         $.ajax({
@@ -1034,7 +1047,8 @@ jsBackend.FormBuilder.Fields =
                 values: values,
                 default_values: defaultValue,
                 required: required,
-                required_error_message: requiredErrorMessage
+                required_error_message: requiredErrorMessage,
+                classname: classname
             }),
             success: function (data, textStatus) {
                 // success
@@ -1147,6 +1161,7 @@ jsBackend.FormBuilder.Fields =
         var validation = $('#textareaValidation').val();
         var validationParameter = $('#textareaValidationParameter').val();
         var errorMessage = $('#textareaErrorMessage').val();
+        var classname = $('#textareaClassname').val();
 
         // make the call
         $.ajax({
@@ -1156,12 +1171,13 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
-                placeholder: placeholder,
                 required: required,
                 required_error_message: requiredErrorMessage,
                 validation: validation,
                 validation_parameter: validationParameter,
-                error_message: errorMessage
+                error_message: errorMessage,
+                placeholder: placeholder,
+                classname: classname
             }),
             success: function (data, textStatus) {
                 // success
@@ -1227,6 +1243,7 @@ jsBackend.FormBuilder.Fields =
         var validation = $('#textboxValidation').val();
         var validationParameter = $('#textboxValidationParameter').val();
         var errorMessage = $('#textboxErrorMessage').val();
+        var classname = $('#textboxClassname').val();
 
         // make the call
         $.ajax({
@@ -1236,13 +1253,14 @@ jsBackend.FormBuilder.Fields =
                 type: type,
                 label: label,
                 default_values: value,
-                placeholder: placeholder,
                 reply_to: replyTo,
                 required: required,
                 required_error_message: requiredErrorMessage,
                 validation: validation,
                 validation_parameter: validationParameter,
-                error_message: errorMessage
+                error_message: errorMessage,
+                placeholder: placeholder,
+                classname: classname
             }),
             success: function (data, textStatus) {
                 // success

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Dialogs.tpl
@@ -111,12 +111,12 @@
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="form-group">
-                                    <label for="textboxPlaceholder">
-                                        {$lblPlaceholder|ucfirst}
-                                        <abbr class="glyphicon glyphicon-asterisk" title="{$lblRequiredField|ucfirst}"></abbr>
-                                    </label>
-                                    <p id="textboxPlaceholderError" class="text-danger jsFieldError" style="display: none;"></p>
+                                    <label for="textboxPlaceholder">{$lblPlaceholder|ucfirst}</label>
                                     {$txtTextboxPlaceholder}
+                                </div>
+                                <div class="form-group">
+                                    <label for="textboxClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtTextboxClassname}
                                 </div>
                             </div>
                         </div>
@@ -233,12 +233,12 @@
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="form-group">
-                                    <label for="textareaPlaceholder">
-                                        {$lblPlaceholder|ucfirst}
-                                        <abbr class="glyphicon glyphicon-asterisk" title="{$lblRequiredField|ucfirst}"></abbr>
-                                    </label>
-                                    <p id="textareaPlaceholderError" class="text-danger jsFieldError" style="display: none;"></p>
+                                    <label for="textareaPlaceholder">{$lblPlaceholder|ucfirst}</label>
                                     {$txtTextareaPlaceholder}
+                                </div>
+                                <div class="form-group">
+                                    <label for="textareaClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtTextareaClassname}
                                 </div>
                             </div>
                         </div>
@@ -268,6 +268,9 @@
                     </li>
                     <li role="presentation">
                         <a href="#tabDatetimeProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#tabDatetimeAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -344,6 +347,21 @@
                             </div>
                         </div>
                     </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabDatetimeAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="datetimeClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtDatetimeClassname}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -369,6 +387,9 @@
                     </li>
                     <li role="presentation">
                         <a href="#tabDropdownProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#tabDropdownAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -428,6 +449,21 @@
                             </div>
                         </div>
                     </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabDropdownAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="dropdownClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtDropdownClassname}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -453,6 +489,9 @@
                     </li>
                     <li role="presentation">
                         <a href="#tabRadiobuttonProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#tabRadiobuttonAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -511,6 +550,21 @@
                             </div>
                         </div>
                     </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabRadiobuttonAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="radiobuttonClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtRadiobuttonClassname}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -536,6 +590,9 @@
                     </li>
                     <li role="presentation">
                         <a href="#tabCheckboxProperties" aria-controls="properties" role="tab" data-toggle="tab">{$lblProperties|ucfirst}</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#tabCheckboxAdvanced" aria-controls="advanced" role="tab" data-toggle="tab">{$lblAdvanced|ucfirst}</a>
                     </li>
                 </ul>
                 <div class="tab-content">
@@ -590,6 +647,21 @@
                                         <p id="checkboxRequiredErrorMessageError" class="text-danger jsFieldError" style="display: none;"></p>
                                         {$txtCheckboxRequiredErrorMessage}
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div role="tabpanel" class="tab-pane jsFieldTab" id="tabCheckboxAdvanced">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <h3>{$lblAdvanced|ucfirst}</h3>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-group">
+                                    <label for="checkboxClassname">{$lblClassname|ucfirst}</label>
+                                    {$txtCheckboxClassname}
                                 </div>
                             </div>
                         </div>

--- a/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.tpl
+++ b/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.tpl
@@ -24,7 +24,7 @@
 
 						{* Input fields, textareas and drop downs *}
 						{option:fields.simple}
-							<p{option:fields.error} class="errorArea"{/option:fields.error}>
+							<p class="{option:fields.error}errorArea {/option:fields.error}{option:fields.classname}{$fields.classname}{/option:fields.classname}">
 								<label for="{$fields.name}">
 									{$fields.label}{option:fields.required}<abbr title="{$lblRequiredField}">*</abbr>{/option:fields.required}
 								</label>
@@ -35,7 +35,7 @@
 
 						{* Radio buttons and checkboxes *}
 						{option:fields.multiple}
-							<div class="inputList{option:fields.error} errorArea{/option:fields.error}">
+							<div class="inputList {option:fields.error}errorArea {/option:fields.error}{option:fields.classname}{$fields.classname}{/option:fields.classname}">
 								<p class="label">
 									{$fields.label}{option:fields.required}<abbr title="{$lblRequiredField}">*</abbr>{/option:fields.required}
 								</p>

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -153,6 +153,7 @@ class Form extends FrontendBaseWidget
                 $item['type'] = $field['type'];
                 $item['label'] = (isset($field['settings']['label'])) ? $field['settings']['label'] : '';
                 $item['placeholder'] = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
+	            $item['classname'] = (isset($field['settings']['classname']) ? $field['settings']['classname'] : null);
                 $item['required'] = isset($field['validations']['required']);
                 $item['html'] = '';
 

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -153,7 +153,7 @@ class Form extends FrontendBaseWidget
                 $item['type'] = $field['type'];
                 $item['label'] = (isset($field['settings']['label'])) ? $field['settings']['label'] : '';
                 $item['placeholder'] = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
-	            $item['classname'] = (isset($field['settings']['classname']) ? $field['settings']['classname'] : null);
+                $item['classname'] = (isset($field['settings']['classname']) ? $field['settings']['classname'] : null);
                 $item['required'] = isset($field['validations']['required']);
                 $item['html'] = '';
 


### PR DESCRIPTION
Adds a classname inputfield to formbuilder fields in the bootstrap version of Fork CMS. I added all the CSS class translations too :wink: 

See #1218

### Preview:
![schermafbeelding 2015-06-04 om 04 21 52](https://cloud.githubusercontent.com/assets/1352979/7975691/4529c640-0a71-11e5-9e4e-1ecfd92ede55.png) 