### PR TITLE
Zipped modules scanned more reliably for module location.

### DIFF
--- a/src/Backend/Modules/Extensions/Actions/UploadModule.php
+++ b/src/Backend/Modules/Extensions/Actions/UploadModule.php
@@ -228,10 +228,9 @@ class UploadModule extends BackendBaseActionAdd
             }
         }
 
-        // If we ever get here, something odd has likely happened, so
-        // just return an empty prefix.  At least a correctly formatted
-        // zip would then work...
-        return "";
+        // If the zip has a top-level single directory, eg
+        // /myModuleName/, then we should just assume that is the prefix.
+        return $file['name'];
     }
 
     /**

--- a/src/Backend/Modules/Extensions/Actions/UploadModule.php
+++ b/src/Backend/Modules/Extensions/Actions/UploadModule.php
@@ -105,8 +105,8 @@ class UploadModule extends BackendBaseActionAdd
             $file = $zip->statIndex($i);
             $fileName = $file['name'];
 
-            if ($i === 0 && $fileName !== 'src/' && $fileName !== 'library/') {
-                $prefix = $fileName;
+            if ($i === 0) {
+                $prefix = $this->extractPrefix($file);
             }
 
             // check if the file is in one of the valid directories
@@ -207,6 +207,31 @@ class UploadModule extends BackendBaseActionAdd
 
         // return the files
         return $moduleName;
+    }
+
+    /**
+     * Try to extract a prefix if a module has been zipped with unexpected
+     * paths.
+     *
+     * @param $file
+     * @return string
+     */
+    private function extractPrefix($file) {
+        $name = explode(PATH_SEPARATOR, $file['name']);
+        $prefix = array();
+
+        foreach($name as $element) {
+            if ($element == 'src' || $element == 'library') {
+                return join(PATH_SEPARATOR, $prefix);
+            } else {
+                $prefix[] = $element;
+            }
+        }
+
+        // If we ever get here, something odd has likely happened, so
+        // just return an empty prefix.  At least a correctly formatted
+        // zip would then work...
+        return "";
     }
 
     /**


### PR DESCRIPTION
Running the legit command:

    zip -r MyModule.zip src/Frontend/Modules/MyModule/ src/Backend/Modules/MyModule/

Does not include the `src/` folder as a "dangling folder" entry, as was previously expected by the module zip uploader.

This new method of extracting a prefix is more reliable under differing zip formats.

It also now functions if a module is uploaded into a single top level directory, eg

    /myModuleName/src/....


