### PR TITLE
Save log files separately for each environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Improvements:
 
 * Core: Moved startProcessingHooks from Backend/Frontend to Common/Core/Model.php
+* Core: Save logs in an environment specific log file.
 
 
 3.9.3 (2015-06-10)

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -31,7 +31,7 @@ monolog:
     handlers:
         main:
             type:  stream
-            path:  %site.path_www%/app/logs/logs.log
+            path:  %site.path_www%/app/logs/%kernel.environment%.log
             level: debug
         # swift:
         #     type:       swift_mailer


### PR DESCRIPTION
This makes it a lot easier to debug issues in our test environment without having to go trough all the logs of our dev environment.