### PR TITLE
Fix blog file names

### DIFF
--- a/src/Backend/Modules/Blog/Actions/Edit.php
+++ b/src/Backend/Modules/Blog/Actions/Edit.php
@@ -381,12 +381,7 @@ class Edit extends BackendBaseActionEdit
 
                     // create folders if needed
                     $fs = new Filesystem();
-                    if (!$fs->exists($imagePath . '/source')) {
-                        $fs->mkdir($imagePath . '/source');
-                    }
-                    if (!$fs->exists($imagePath . '/128x128')) {
-                        $fs->mkdir($imagePath . '/128x128');
-                    }
+                    $fs->mkdir(array($imagePath . '/source', $imagePath . '/128x128'));
 
                     // If the image should be deleted, only the database entry is refreshed.
                     // The revision should keep it's file.
@@ -413,10 +408,15 @@ class Edit extends BackendBaseActionEdit
                         $image = new File($imagePath . '/source/' . $item['image']);
                         $newName = $this->meta->getURL() .
                                             '-' . BL::getWorkingLanguage() .
+                                            '-' . $item['revision_id'] .
                                             '.' . $image->getExtension();
 
+                        // extract the filenames excluding …-[language]-[revision-id].jpg
+                        // to properly compare them to eachother
+                        $regex = '/(.*)-[a-z]{2}-[0-9]+\.(.*)/';
+
                         // only copy if the new name differs from the old filename
-                        if ($newName != $item['image']) {
+                        if (preg_replace($regex, '$1', $newName) != preg_replace($regex, '$1', $item['image'])) {
                             // loop folders
                             foreach (BackendModel::getThumbnailFolders($imagePath, true) as $folder) {
                                 $fs->copy($folder['path'] . '/' . $item['image'], $folder['path'] . '/' . $newName);

--- a/src/Backend/Modules/Blog/Engine/Model.php
+++ b/src/Backend/Modules/Blog/Engine/Model.php
@@ -1195,4 +1195,18 @@ class Model
             }
         }
     }
+
+    /**
+     * Update a page revision without generating a new revision.
+     * Needed to add an image to a page.
+     */
+    public static function updateRevision($revision_id, $item)
+    {
+        BackendModel::getContainer()->get('database')->update(
+            'blog_posts',
+            $item,
+            'revision_id = ?',
+            array($revision_id)
+        );
+    }
 }


### PR DESCRIPTION
A previous commit (54b434725394c3fa50367c85b921dc6e1891b584) exposed an issue with filenames/revisions and partially fixed in.
Action edit checks the name of the file and compares it to the previous image.
Because it now incorporates the revision id, this check was redundant since the result will always be true.

Comparing an excerpt of the name should, in most cases, return false.