### PR TITLE
Make the Profile::setId method private. Fixes #1237

### DIFF
--- a/src/Frontend/Modules/Profiles/Engine/Profile.php
+++ b/src/Frontend/Modules/Profiles/Engine/Profile.php
@@ -301,7 +301,7 @@ class Profile
      *
      * @param int $value Id of the profile.
      */
-    public function setId($value)
+    private function setId($value)
     {
         $this->id = (int) $value;
     }


### PR DESCRIPTION
It should not be possible to alter the id of an entity from outside this
entity.