### PR TITLE
Remove unneeded require statements.

### DIFF
--- a/src/Api/V1/Init.php
+++ b/src/Api/V1/Init.php
@@ -44,9 +44,6 @@ class Init extends \Common\Core\Init
         $this->definePaths();
         $this->setDebugging();
 
-        // get spoon
-        require_once 'spoon/spoon.php';
-
         \SpoonFilter::disableMagicQuotes();
         $this->initSession();
     }

--- a/src/Common/Core/Init.php
+++ b/src/Common/Core/Init.php
@@ -62,9 +62,6 @@ abstract class Init extends \KernelLoader
         $this->definePaths();
         $this->defineURLs();
         $this->setDebugging();
-
-        // require spoon
-        require_once 'spoon/spoon.php';
     }
 
     /**

--- a/src/Frontend/Init.php
+++ b/src/Frontend/Init.php
@@ -30,7 +30,6 @@ class Init extends \Common\Core\Init
     {
         parent::initialize($type);
 
-        $this->requireFrontendClasses();
         \SpoonFilter::disableMagicQuotes();
     }
 
@@ -55,19 +54,5 @@ class Init extends \Common\Core\Init
         defined('FRONTEND_CORE_URL') || define('FRONTEND_CORE_URL', '/src/' . APPLICATION . '/Core');
         defined('FRONTEND_CACHE_URL') || define('FRONTEND_CACHE_URL', '/src/' . APPLICATION . '/Cache');
         defined('FRONTEND_FILES_URL') || define('FRONTEND_FILES_URL', '/src/' . APPLICATION . '/Files');
-    }
-
-    /**
-     * Require all needed classes
-     */
-    private function requireFrontendClasses()
-    {
-        switch ($this->type) {
-            case 'Frontend':
-            case 'FrontendAjax':
-                require_once FRONTEND_CORE_PATH . '/Engine/TemplateCustom.php';
-                require_once FRONTEND_PATH . '/Modules/Tags/Engine/Model.php';
-                break;
-        }
     }
 }


### PR DESCRIPTION
We user the autoloader generated by composer, which means we don't need
to add those require statements anymore.