### PR TITLE
Fixes loading in duplicate JS & CSS files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Improvements:
 
 Bugfixes:
+* Frontend: no more duplicate JS-files.
 
 
 3.9.4 (2015-07-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Improvements:
 
 Bugfixes:
+
 * Frontend: no more duplicate JS-files.
 
 

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -158,7 +158,7 @@ class Header extends FrontendBaseObject
 
         // only add when not already in array
         if (!isset($this->cssFiles[$file])) {
-            $this->cssFiles[] = $cssFile;
+            $this->cssFiles[$file] = $cssFile;
         }
     }
 

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -199,9 +199,9 @@ class Header extends FrontendBaseObject
             'priority_group' => $priorityGroup
         );
 
-        // already in array?
-        if (!in_array($jsFile, $this->jsFiles)) {
-            $this->jsFiles[] = $jsFile;
+        // only add when not already in array
+        if (!isset($this->jsFiles[$file])) {
+            $this->jsFiles[$file] = $jsFile;
         }
     }
 

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -151,18 +151,14 @@ class Header extends FrontendBaseObject
             $file = $this->minifyCSS($file);
         }
 
-        $inArray = false;
-        foreach ($this->cssFiles as $row) {
-            if ($row['file'] == $file) {
-                $inArray = true;
-            }
-        }
+        $cssFile = array(
+            'file' => $file,
+            'add_timestamp' => $addTimestamp
+        );
 
-        // add to array if it isn't there already
-        if (!$inArray) {
-            $temp['file'] = (string) $file;
-            $temp['add_timestamp'] = $addTimestamp;
-            $this->cssFiles[] = $temp;
+        // only add when not already in array
+        if (!isset($this->cssFiles[$file])) {
+            $this->cssFiles[] = $cssFile;
         }
     }
 

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -153,7 +153,7 @@ class Header extends FrontendBaseObject
 
         $cssFile = array(
             'file' => $file,
-            'add_timestamp' => $addTimestamp
+            'add_timestamp' => $addTimestamp,
         );
 
         // only add when not already in array
@@ -192,7 +192,7 @@ class Header extends FrontendBaseObject
         $jsFile = array(
             'file' => $file,
             'add_timestamp' => $addTimestamp,
-            'priority_group' => $priorityGroup
+            'priority_group' => $priorityGroup,
         );
 
         // only add when not already in array


### PR DESCRIPTION
**Problem**

JS and CSS files should only be loaded in one time.

**Solution**

We added a check to see if the JS or CSS file is already added or not, so we don't load in duplicate files.