### PR TITLE
INI directive 'safe_mode' is not used anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ before_script:
 after_success:
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+
+sudo: false

--- a/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step1.html.twig
+++ b/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step1.html.twig
@@ -111,9 +111,6 @@
           </p>
 
           <h3>PHP ini-settings</h3>
-          <h4><span class="{{ checker.errors.settingsSafeMode }}">{{ checker.errors.settingsSafeMode }}</span> Safe Mode</h4>
-          <p><strong>As of PHP 5.3.0 Safe Mode is deprecated.</strong> For forward compatibility we highly recommend you to disable Safe Mode.</p>
-
           <h4><span class="{{ checker.errors.settingsOpenBasedir }}">{{ checker.errors.settingsOpenBasedir }}</span> Open Basedir</h4>
           <p>For forward compatibility we highly recommend you not to use open_basedir.</p>
 

--- a/src/ForkCMS/Bundle/InstallerBundle/Service/RequirementsChecker.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Service/RequirementsChecker.php
@@ -158,7 +158,6 @@ class RequirementsChecker
      */
     protected function checkPhpIniSettings()
     {
-        $this->checkRequirement('settingsSafeMode', ini_get('safe_mode') == '', self::STATUS_WARNING);
         $this->checkRequirement('settingsOpenBasedir', ini_get('open_basedir') == '', self::STATUS_WARNING);
         $this->checkRequirement(
             'settingsDateTimezone',


### PR DESCRIPTION
It was deprecated in 5.3 and forbidden in 5.4. Since our minimum version
is 5.4 now, there is no need to check this directive anymore.