### PR TITLE
Fix hidden items getUrlForBlock. Closes #1278

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -704,7 +704,7 @@ class Model extends \Common\Core\Model
             foreach ($level as $pages) {
                 foreach ($pages as $pageId => $properties) {
                     // only process pages with extra_blocks
-                    if (!isset($properties['extra_blocks'])) {
+                    if (!isset($properties['extra_blocks']) || $properties['hidden']) {
                         continue;
                     }
 

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -862,10 +862,10 @@ class Model
              LEFT OUTER JOIN pages AS p ON p.parent_id = i.id AND p.status = "active" AND p.hidden = "N"
              AND p.language = i.language
              WHERE i.parent_id IN (' . implode(', ', $ids) . ')
-                 AND i.status = ? AND i.language = ?
+                 AND i.status = ? AND i.language = ? AND b.visible = ?
              GROUP BY i.revision_id
              ORDER BY i.sequence ASC',
-            array('block', 'active', $language),
+            array('block', 'active', $language, 'Y'),
             'id'
         );
 

--- a/src/Frontend/Core/Engine/Navigation.php
+++ b/src/Frontend/Core/Engine/Navigation.php
@@ -548,8 +548,8 @@ class Navigation extends FrontendBaseObject
             foreach ($level as $pages) {
                 // loop pages
                 foreach ($pages as $pageId => $properties) {
-                    // only process pages with extra_blocks
-                    if (!isset($properties['extra_blocks'])) {
+                    // only process pages with extra_blocks that are visible
+                    if (!isset($properties['extra_blocks']) || $properties['hidden']) {
                         continue;
                     }
 


### PR DESCRIPTION
Makes sure an url returned by getUrlForBlock is only returned when
- The page is visible
- The given block is visible