### PR TITLE
Use mod gzip on json files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -63,7 +63,7 @@ FileETag MTime Size
 
 # gzip on Apache 2
 <IfModule mod_deflate.c>
-	AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml text/javascript text/css application/x-javascript application/xhtml+xml application/javascript image/svg+xml
+	AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml text/javascript text/css application/x-javascript application/xhtml+xml application/javascript application/json image/svg+xml
 
 	# these browsers do not support deflate
 	BrowserMatch ^Mozilla/4 gzip-only-text/html
@@ -79,6 +79,7 @@ FileETag MTime Size
 
 	mod_gzip_item_include mime ^application/javascript$
 	mod_gzip_item_include mime ^application/x-javascript$
+	mod_gzip_item_include mime ^application/json$
 	mod_gzip_item_include mime ^application/xhtml+xml$
 	mod_gzip_item_include mime ^application/xml$
 	mod_gzip_item_include mime ^text/css$


### PR DESCRIPTION
Google PageSpeed insights gives adding compression on json files as a suggestion to improve the page speed score.