### PR TITLE
Add start-of-body-scripts functionality. Closes #1277

### DIFF
--- a/src/Backend/Core/Layout/Css/imports/core_modules.css
+++ b/src/Backend/Core/Layout/Css/imports/core_modules.css
@@ -458,13 +458,13 @@
 		/* Less important tabs go on the right side */
 
 		#pages.pagesAdd .ui-tabs-nav li,
-		#pages.pagesEdit .ui-tabs-nav li { 
-			float: right; 
+		#pages.pagesEdit .ui-tabs-nav li {
+			float: right;
 		}
 
 		#pages.pagesAdd .ui-tabs-nav li:first-child,
-		#pages.pagesEdit .ui-tabs-nav li:first-child { 
-			float: left; 
+		#pages.pagesEdit .ui-tabs-nav li:first-child {
+			float: left;
 		}
 
 		#pages.pagesAdd .ui-tabs-nav li:nth-child(2),
@@ -601,7 +601,8 @@
 	}
 
 	#settings.settingsIndex #siteHtmlFooter,
-	#settings.settingsIndex #siteHtmlHeader {
+	#settings.settingsIndex #siteHtmlHeader,
+	#settings.settingsIndex #siteStartOfBodyScripts {
 		width: 700px;
 		height: 200px;
 	}

--- a/src/Backend/Modules/Settings/Actions/Index.php
+++ b/src/Backend/Modules/Settings/Actions/Index.php
@@ -86,6 +86,13 @@ class Index extends BackendBaseActionIndex
             true
         );
         $this->frm->addTextarea(
+            'site_start_of_body_scripts',
+            $this->get('fork.settings')->get('Core', 'site_start_of_body_scripts', null),
+            'textarea code',
+            'textareaError code',
+            true
+        );
+        $this->frm->addTextarea(
             'site_html_footer',
             $this->get('fork.settings')->get('Core', 'site_html_footer', null),
             'textarea code',
@@ -360,6 +367,11 @@ class Index extends BackendBaseActionIndex
                     'Core',
                     'site_html_header',
                     $this->frm->getField('site_html_header')->getValue()
+                );
+                $this->get('fork.settings')->set(
+                    'Core',
+                    'site_start_of_body_scripts',
+                    $this->frm->getField('site_start_of_body_scripts')->getValue()
                 );
                 $this->get('fork.settings')->set(
                     'Core',

--- a/src/Backend/Modules/Settings/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Settings/Installer/Data/locale.xml
@@ -351,6 +351,14 @@
         <translation language="es"><![CDATA[<code>&lt;head&gt;</code> script(s)]]></translation>
         <translation language="el"><![CDATA[<code>&lt;head&gt;</code> σκριπτ.]]></translation>
       </item>
+      <item type="message" name="HelpScriptsStartOfBody">
+        <translation language="nl"><![CDATA[Plaats hier code die op elke pagina geladen moet worden na het openen van de <code>&lt;body&gt;</code>-tag.]]></translation>
+        <translation language="en"><![CDATA[Paste code that needs to be loaded right after the opening <code>&lt;body&gt;</code> tag here.]]></translation>
+      </item>
+      <item type="message" name="HelpScriptsStartOfBodyLabel">
+        <translation language="nl"><![CDATA[<code>Start van &lt;body&gt;</code> script(s)]]></translation>
+        <translation language="en"><![CDATA[<code>Start of &lt;body&gt;</code> script(s)]]></translation>
+      </item>
       <item type="message" name="HelpSendingEmails">
         <translation language="nl"><![CDATA[Je kan e-mails versturen op 2 manieren. Door de ingebouwd mail functie van PHP of via SMTP. We raden je aan om SMTP te gebruiken]]></translation>
         <translation language="en"><![CDATA[You can send emails in 2 ways. By using PHP's built-in mail method or via SMTP. We advise you to use SMTP]]></translation>

--- a/src/Backend/Modules/Settings/Layout/Templates/Index.tpl
+++ b/src/Backend/Modules/Settings/Layout/Templates/Index.tpl
@@ -34,14 +34,21 @@
 		</div>
 		<div class="options">
 			<div class="textareaHolder">
-				<p class="p0"><label for="siteHtmlHeader"><code>&lt;head&gt;</code> script(s)</label></p>
+				<p class="p0"><label for="siteHtmlHeader">{$msgHelpScriptsHeadLabel}</label></p>
 				{$txtSiteHtmlHeader} {$txtSiteHtmlHeaderError}
 				<span class="helpTxt">{$msgHelpScriptsHead}</span>
 			</div>
 		</div>
 		<div class="options">
 			<div class="textareaHolder">
-				<p class="p0"><label for="siteHtmlFooter">End of <code>&lt;body&gt;</code> script(s)</label></p>
+				<p class="p0"><label for="siteStartOfBodyScripts">{$msgHelpScriptsStartOfBodyLabel}</label></p>
+				{$txtSiteStartOfBodyScripts} {$txtSiteStartOfBodyScriptsError}
+				<span class="helpTxt">{$msgHelpScriptsStartOfBody}</span>
+			</div>
+		</div>
+		<div class="options">
+			<div class="textareaHolder">
+				<p class="p0"><label for="siteHtmlFooter">{$msgHelpScriptsFootLabel}</label></p>
 				{$txtSiteHtmlFooter} {$txtSiteHtmlFooterError}
 				<span class="helpTxt">{$msgHelpScriptsFoot}</span>
 			</div>

--- a/src/Frontend/Core/Engine/Template.php
+++ b/src/Frontend/Core/Engine/Template.php
@@ -335,6 +335,15 @@ class Template extends \SpoonTemplate
                 '/src/Frontend/Themes/' . Model::get('fork.settings')->get('Core', 'theme', 'default')
             );
         }
+
+        $this->assign(
+            'siteStartOfBodyScripts',
+            Model::get('fork.settings')->get(
+                'Core',
+                'site_start_of_body_scripts',
+                null
+            ) !== null ? Model::get('fork.settings')->get('Core', 'site_start_of_body_scripts', null) : ''
+        );
     }
 
     /**

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Default.tpl
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Default.tpl
@@ -1,6 +1,7 @@
 {include:Core/Layout/Templates/Head.tpl}
 
 <body class="{$LANGUAGE}" itemscope itemtype="http://schema.org/WebPage">
+	{$siteStartOfBodyScripts}
 	{include:Core/Layout/Templates/Cookies.tpl}
 
 	<div id="topWrapper">

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Home.tpl
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Home.tpl
@@ -1,6 +1,7 @@
 {include:Core/Layout/Templates/Head.tpl}
 
 <body class="{$LANGUAGE}" itemscope itemtype="http://schema.org/WebPage">
+	{$siteStartOfBodyScripts}
 	{include:Core/Layout/Templates/Cookies.tpl}
 
 	<div id="topWrapper">


### PR DESCRIPTION
This is equal the siteHTMLHeader and siteHTMLFooter functionality. You just add a snippet of code in the backend settings and it will be added right after the <body> tag in the template.