### PR TITLE
Avoid catching RedirectExceptions.

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
@@ -10,6 +10,7 @@ use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Modules\Mailmotor\Engine\Model as FrontendMailmotorModel;
 use Frontend\Modules\Mailmotor\Engine\CMHelper as FrontendMailmotorCMHelper;
+use Common\Exception\RedirectException as RedirectException;
 
 /**
  * This is the subscribe-action
@@ -104,6 +105,11 @@ class Subscribe extends FrontendBaseBlock
                         FrontendNavigation::getURLForBlock('Mailmotor', 'Subscribe') . '?sent=true#subscribeForm'
                     );
                 } catch (\Exception $e) {
+                    // make sure RedirectExceptions get thrown
+                    if ($e instanceof RedirectException) {
+                        throw $e;
+                    }
+
                     // when debugging we need to see the exceptions
                     if ($this->getContainer()->getParameter('kernel.debug')) {
                         throw $e;


### PR DESCRIPTION
RedirectExceptions are caught. This makes it look like the redirect is
not taking place.

resolves #1297