### PR TITLE
Make our container available statically

### DIFF
--- a/app/console
+++ b/app/console
@@ -14,6 +14,7 @@ require_once __DIR__ . '/BaseModel.php';
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
+use Backend\Init as BackendInit;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
@@ -33,7 +34,12 @@ $kernel = new AppKernel($env, $debug);
 
 // make our container available statically. This is needed to make our static models work
 $kernel->boot();
+$kernel->defineForkConstants();
 BaseModel::setContainer($kernel->getContainer());
+
+define('APPLICATION', 'Console');
+$backend = new BackendInit($kernel);
+$backend->initialize('BackendCronjob');
 
 $application = new Application($kernel);
 $application->run($input);

--- a/app/console
+++ b/app/console
@@ -8,7 +8,7 @@
 set_time_limit(0);
 
 require_once __DIR__ . '/../autoload.php';
-require_once __DIR__.'/AppKernel.php';
+require_once __DIR__ . '/AppKernel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;

--- a/app/console
+++ b/app/console
@@ -13,6 +13,8 @@ require_once __DIR__.'/AppKernel.php';
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
+use Backend\Core\Engine\Model as BackendModel;
+use Frontend\Core\Engine\Model as FrontendModel;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
@@ -29,5 +31,11 @@ if ($debug) {
 }
 
 $kernel = new AppKernel($env, $debug);
+
+// make our container available statically. This is needed to make our static models work
+$kernel->boot();
+FrontendModel::setContainer($kernel->getContainer());
+BackendModel::setContainer($kernel->getContainer());
+
 $application = new Application($kernel);
 $application->run($input);

--- a/app/console
+++ b/app/console
@@ -39,7 +39,7 @@ BaseModel::setContainer($kernel->getContainer());
 
 define('APPLICATION', 'Console');
 $backend = new BackendInit($kernel);
-$backend->initialize('BackendCronjob');
+$backend->initialize('Console');
 
 $application = new Application($kernel);
 $application->run($input);

--- a/app/console
+++ b/app/console
@@ -9,12 +9,11 @@ set_time_limit(0);
 
 require_once __DIR__ . '/../autoload.php';
 require_once __DIR__ . '/AppKernel.php';
+require_once __DIR__ . '/BaseModel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Debug\Debug;
-use Backend\Core\Engine\Model as BackendModel;
-use Frontend\Core\Engine\Model as FrontendModel;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
@@ -34,8 +33,7 @@ $kernel = new AppKernel($env, $debug);
 
 // make our container available statically. This is needed to make our static models work
 $kernel->boot();
-FrontendModel::setContainer($kernel->getContainer());
-BackendModel::setContainer($kernel->getContainer());
+BaseModel::setContainer($kernel->getContainer());
 
 $application = new Application($kernel);
 $application->run($input);


### PR DESCRIPTION
If we want to use our static model classes in our code, we need the container to be available.