### PR TITLE
Encode the external redirect URL for pages

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             <exclude>src/Frontend/Modules/Search/Tests/Actions</exclude>
             <exclude>src/Backend/Modules/Authentication/Tests/Actions</exclude>
             <exclude>src/Backend/Modules/Blog/Tests/Actions</exclude>
+            <exclude>src/Backend/Modules/Pages/Tests/Actions</exclude>
             <exclude>src/Api/*/Tests/Actions</exclude>
             <exclude>src/Frontend/Core/Tests/AjaxTest.php</exclude>
         </testsuite>

--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -367,7 +367,9 @@ class Add extends BackendBaseActionAdd
                 }
                 if ($redirectValue == 'external') {
                     $data['external_redirect'] = array(
-                        'url' => $this->frm->getField('external_redirect')->getValue(),
+                        'url' => BackendPagesModel::getEncodedRedirectURL(
+                            $this->frm->getField('external_redirect')->getValue()
+                        ),
                         'code' => '301'
                     );
                 }

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -402,7 +402,7 @@ class Edit extends BackendBaseActionEdit
         );
         $this->frm->addText(
             'external_redirect',
-            ($redirectValue == 'external') ? $this->record['data']['external_redirect']['url'] : null,
+            ($redirectValue == 'external') ? urldecode($this->record['data']['external_redirect']['url']) : null,
             null,
             null,
             null,
@@ -611,7 +611,9 @@ class Edit extends BackendBaseActionEdit
                 }
                 if ($redirectValue == 'external') {
                     $data['external_redirect'] = array(
-                        'url' => $this->frm->getField('external_redirect')->getValue(),
+                        'url' => BackendPagesModel::getEncodedRedirectURL(
+                            $this->frm->getField('external_redirect')->getValue()
+                        ),
                         'code' => '301'
                     );
                 }

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1503,4 +1503,25 @@ class Model
             self::insertBlocks($blocksContent);
         }
     }
+
+    /**
+     * Get encoded redirect URL
+     *
+     * @param string $redirectURL
+     *
+     * @return string
+     */
+    public static function getEncodedRedirectURL($redirectURL)
+    {
+        preg_match('!(http[s]?)://(.*)!i', $redirectURL, $matches);
+        $URLChunks = explode('/', $matches[2]);
+        if (!empty($URLChunks)) {
+            foreach ($URLChunks as &$URLChunk) {
+                $URLChunk = urlencode($URLChunk);
+            }
+            $redirectURL = $matches[1] . '://' . implode('/', $URLChunks);
+        }
+
+        return $redirectURL;
+    }
 }

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1516,10 +1516,12 @@ class Model
         preg_match('!(http[s]?)://(.*)!i', $redirectURL, $matches);
         $URLChunks = explode('/', $matches[2]);
         if (!empty($URLChunks)) {
+            // skip domain name
+            $domain = array_shift($URLChunks);
             foreach ($URLChunks as &$URLChunk) {
                 $URLChunk = urlencode($URLChunk);
             }
-            $redirectURL = $matches[1] . '://' . implode('/', $URLChunks);
+            $redirectURL = $matches[1] . '://' . $domain . '/' . implode('/', $URLChunks);
         }
 
         return $redirectURL;

--- a/src/Backend/Modules/Pages/Tests/Model/ModelTest.php
+++ b/src/Backend/Modules/Pages/Tests/Model/ModelTest.php
@@ -20,5 +20,9 @@ class ModelTest extends \PHPUnit_Framework_TestCase
             'http://www.google.be/Quote%27HelloWorld%27',
             Model::getEncodedRedirectURL("http://www.google.be/Quote'HelloWorld'")
         );
+        $this->assertEquals(
+            'http://cédé.be/Quote%22HelloWorld%22',
+            Model::getEncodedRedirectURL('http://cédé.be/Quote"HelloWorld"')
+        );
     }
 }

--- a/src/Backend/Modules/Pages/Tests/Model/ModelTest.php
+++ b/src/Backend/Modules/Pages/Tests/Model/ModelTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Backend\Modules\Pages\Tests\Model;
+
+use Backend\Modules\Pages\Engine\Model;
+
+class ModelTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUrlIsEncoded()
+    {
+        $this->assertEquals(
+            'http://www.google.be/Quote',
+            Model::getEncodedRedirectURL('http://www.google.be/Quote')
+        );
+        $this->assertEquals(
+            'http://www.google.be/Quote%22HelloWorld%22',
+            Model::getEncodedRedirectURL('http://www.google.be/Quote"HelloWorld"')
+        );
+        $this->assertEquals(
+            'http://www.google.be/Quote%27HelloWorld%27',
+            Model::getEncodedRedirectURL("http://www.google.be/Quote'HelloWorld'")
+        );
+    }
+}


### PR DESCRIPTION
When a redirect URL has a double quote in it (not the best practice, but it
happens), it gives unexcepting results with the cache (because the cache is
JSON and the URL will be surrounded by double quotes. Adding the encoding for
the external redirect URL fixes wrong redirect URLs in navigation. Only add
encoding for the URL segments, because otherwise the whole URL (including ://)
will be encoded.

For example:
Redirect URL: http://www.google.be/Quote"HelloWorld"
Becomes: http://www.google.be/Quote in navigation