### PR TITLE
Use Flysystem as cache backend

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,10 +64,18 @@ services:
             - @fork.settings
             - @service_container
 
-    cache.adapter:
-        class: MatthiasMullie\Scrapbook\Adapters\Filesystem
+    cache.filesystem.adapter:
+        class: League\Flysystem\Adapter\Local
         arguments:
             - %kernel.cache_dir%
+    cache.filesystem.filesystem:
+        class: League\Flysystem\Filesystem
+        arguments:
+            - @cache.filesystem.adapter
+    cache.adapter:
+        class: MatthiasMullie\Scrapbook\Adapters\Flysystem
+        arguments:
+            - @cache.filesystem.filesystem
     cache.buffer:
         class: MatthiasMullie\Scrapbook\Buffered\BufferedStore
         arguments:

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,15 @@
         "tijsverkoyen/akismet": "1.1.*",
         "tijsverkoyen/css-to-inline-styles": "1.5.*",
         "matthiasmullie/minify": "~1.3",
-        "matthiasmullie/scrapbook": "~1.0",
+        "matthiasmullie/scrapbook": "~1.0.3",
         "symfony/symfony": "2.3.*",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "2.3.*",
         "spoon/library": "~2.0.0",
         "behat/transliterator": "~1.0",
-        "google/apiclient": "~1.1.2"
+        "google/apiclient": "~1.1.2",
+        "league/flysystem": "~1.0"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "41419b6fafba7e1b738d1c0487cb1909",
-    "content-hash": "b963d7346b9f435d6ab8ab1e0c209e15",
+    "hash": "038faec072c8f464b0c827195264e707",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -569,6 +568,90 @@
             "time": "2014-12-12 05:04:05"
         },
         {
+            "name": "league/flysystem",
+            "version": "1.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "31525caf9e8772683672fefd8a1ca0c0736020f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/31525caf9e8772683672fefd8a1ca0c0736020f4",
+                "reference": "31525caf9e8772683672fefd8a1ca0c0736020f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "mockery/mockery": "~0.9",
+                "phpspec/phpspec": "^2.2",
+                "phpspec/prophecy-phpunit": "~1.0",
+                "phpunit/phpunit": "~4.1"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-copy": "Allows you to use Copy.com storage",
+                "league/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2015-09-30 22:26:59"
+        },
+        {
             "name": "matthiasmullie/minify",
             "version": "1.3.26",
             "source": {
@@ -677,16 +760,16 @@
         },
         {
             "name": "matthiasmullie/scrapbook",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasmullie/scrapbook.git",
-                "reference": "02de8d10c11a4963b3381b4c8eb5c4fc52c7a608"
+                "reference": "210df14d0321a0c759d7a3be98148d0833c33d5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/scrapbook/zipball/02de8d10c11a4963b3381b4c8eb5c4fc52c7a608",
-                "reference": "02de8d10c11a4963b3381b4c8eb5c4fc52c7a608",
+                "url": "https://api.github.com/repos/matthiasmullie/scrapbook/zipball/210df14d0321a0c759d7a3be98148d0833c33d5f",
+                "reference": "210df14d0321a0c759d7a3be98148d0833c33d5f",
                 "shasum": ""
             },
             "require": {
@@ -704,7 +787,8 @@
                 "ext-couchbase": ">=2.0.0",
                 "ext-memcached": ">=2.0.0",
                 "ext-pdo": ">=0.1.0",
-                "ext-redis": ">=2.2.0 || 0.0.0.0"
+                "ext-redis": ">=2.2.0 || 0.0.0.0",
+                "league/flysystem": "~1.0"
             },
             "type": "library",
             "autoload": {
@@ -730,6 +814,7 @@
             "homepage": "http://scrapbook.cash",
             "keywords": [
                 "Buffer",
+                "Flysystem",
                 "apc",
                 "buffered",
                 "cache",
@@ -753,7 +838,7 @@
                 "transactional",
                 "value"
             ],
-            "time": "2015-09-04 07:31:20"
+            "time": "2015-10-21 08:36:38"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
Scrapbook now supports Flysystem (a filesystem abstraction) as a
cache adapter. The original Filesystem backend is still around,
but has been deprecated in favor of Flysystem, which is a popular
and proven filesystem library. It likely handles edgecases better
than Scrapbook's original Filesystem adapter did, and allows for
more versatility in filesystem backends (e.g. FTP, AWS, ...)