### PR TITLE
Capitalize cookie label

### DIFF
--- a/src/Backend/Modules/Settings/Layout/Templates/Index.tpl
+++ b/src/Backend/Modules/Settings/Layout/Templates/Index.tpl
@@ -231,7 +231,7 @@
 		<div class="options">
 			<p>{$msgHelpCookies}</p>
 			<ul class="inputList pb0">
-				<li>{$chkShowCookieBar} <label for="showCookieBar">{$msgShowCookieBar}</label></li>
+				<li>{$chkShowCookieBar} <label for="showCookieBar">{$msgShowCookieBar|ucfirst}</label></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
Something that bothered me for a long time :smiley: . Everywhere on the settings index page, there are capital letters except for this label