### PR TITLE
Only load the installer route when Fork is not installed.

### DIFF
--- a/app/config/config_install.yml
+++ b/app/config/config_install.yml
@@ -4,7 +4,7 @@ imports:
 framework:
     secret:          %kernel.secret%
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.root_dir%/config/routing_install.yml"
         strict_requirements: ~
     form:            ~
     csrf_protection: ~

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -7,6 +7,8 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         collect: false
+    router:
+        resource: "%kernel.root_dir%/config/routing_install.yml"
 
 web_profiler:
     toolbar: false

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,6 +1,3 @@
-installer:
-    resource: "@ForkCMSInstallerBundle/Resources/config/routing.yml"
-
 backend:
     path: /private/{_locale}/{module}/{action}
     defaults:

--- a/app/config/routing_install.yml
+++ b/app/config/routing_install.yml
@@ -1,0 +1,6 @@
+installer:
+    resource: "@ForkCMSInstallerBundle/Resources/config/routing.yml"
+
+# default routes
+_main:
+    resource: routing.yml


### PR DESCRIPTION
This will make sure fork sites in production can't be reinstalled.