### PR TITLE
Use https for google maps by default

### DIFF
--- a/src/Frontend/Modules/Location/Widgets/Location.php
+++ b/src/Frontend/Modules/Location/Widgets/Location.php
@@ -37,7 +37,7 @@ class Location extends FrontendBaseWidget
      */
     public function execute()
     {
-        $this->addJS('http://maps.google.com/maps/api/js?sensor=true', true, false);
+        $this->addJS('https://maps.google.com/maps/api/js?sensor=true', true, false);
 
         parent::execute();
 


### PR DESCRIPTION
Use https by default for google maps library, otherwise maps won't load (mixed-content warnings in Chrome).