### PR TITLE
Update the install_locale script + Symfony command

### DIFF
--- a/app/console
+++ b/app/console
@@ -30,4 +30,5 @@ if ($debug) {
 
 $kernel = new AppKernel($env, $debug);
 $application = new Application($kernel);
+$application->add(new \Common\Command\ImportLocaleCommand());
 $application->run($input);

--- a/src/Common/Command/ImportLocaleCommand.php
+++ b/src/Common/Command/ImportLocaleCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Common\Command;
+
+use AppKernel;
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Backend\Modules\Locale\Engine\Model as BackendLocaleModel;
+use Backend\Init as BackendInit;
+
+/**
+ * This is a simple command to install a locale file
+ * @package Common\Command
+ *
+ * @author Jesse Dobbelaere <jesse@dobbelaere-ae.be>
+ */
+class ImportLocaleCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName('locale:install')
+             ->setDescription('Install locale translations')
+             ->addOption('overwrite', 'o', InputOption::VALUE_OPTIONAL, 'Overwrite the existing locale', true)
+             ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Path to the locale file')
+             ->addOption('module', 'm', InputOption::VALUE_OPTIONAL, 'Name of the module that contains the locale');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Bootstrap fork
+        $this->bootstrapFork();
+
+        // Get input values
+        $fileOption = $input->getOption('file');
+        $moduleOption = $input->getOption('module');
+        $overwriteOption = $input->hasOption('overwrite') ? true : false;
+
+        if (!isset($fileOption) && !isset($moduleOption)) {
+            throw new Exception('Please specify a modulename or path to a locale file');
+        }
+
+        // Get path to locale file
+        $localePath = $this->getLocalePath($fileOption, $moduleOption);
+
+        // Verify existence file
+        if (!file_exists($localePath)) {
+            throw new Exception('The given locale file (' . $localePath . ') does not exist.');
+        }
+
+        // Import locale
+        $output->writeln('<info>Importing locale....</info>');
+        $this->installLocale($localePath, $overwriteOption, $output);
+    }
+
+    /**
+     * Bootstrap the app
+     */
+    private function bootstrapFork()
+    {
+        define('APPLICATION', 'Backend');
+        $kernel = new AppKernel('prod', false);
+        $kernel->boot();
+        $kernel->defineForkConstants();
+        if (!defined('PATH_WWW')) {
+            define('PATH_WWW', __DIR__ . '/..');
+        }
+        $loader = new BackendInit($kernel);
+        $loader->initialize('Backend');
+        $loader->passContainerToModels();
+    }
+
+    /**
+     * @param string $localePath
+     * @param bool $overwrite
+     * @param OutputInterFace $output
+     * @throws Exception
+     */
+    private function installLocale($localePath, $overwrite, OutputInterface $output)
+    {
+        // Load the xml from the file
+        $xmlData = @simplexml_load_file($localePath);
+
+        // This is an invalid xml file
+        if ($xmlData === false) {
+            throw new Exception('Invalid locale.xml file.');
+        }
+
+        // Everything ok, let's install the locale
+        $results = BackendLocaleModel::importXML($xmlData, $overwrite, null, null, 1);
+
+        if (!$results['total'] > 0) {
+            $output->writeln('<error>Something went wrong during import.</error>');
+            return;
+        }
+
+        if ($results['imported'] > 0) {
+            $output->writeln('<comment>Imported ' . $results['imported'] . ' translations succesfully!</comment>');
+            return;
+        }
+
+        if ($results['imported'] == 0) {
+            $output->writeln('<info>No locale was imported. Try adding the overwrite (-o) option.</info>');
+            return;
+        }
+    }
+
+    /**
+     * Get the file or module path according to the input options
+     *
+     * @param string $fileOption
+     * @param string $moduleOption
+     * @return string
+     */
+    private function getLocalePath($fileOption, $moduleOption)
+    {
+        if (isset($fileOption)) {
+            return $fileOption;
+        }
+
+        return __DIR__ . '/../../..' . '/src/Backend/Modules/' . ucfirst($moduleOption) . '/Installer/Data/locale.xml';
+    }
+}

--- a/src/Common/Command/ImportLocaleCommand.php
+++ b/src/Common/Command/ImportLocaleCommand.php
@@ -26,8 +26,8 @@ class ImportLocaleCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('locale:install')
-             ->setDescription('Install locale translations')
+        $this->setName('locale:import')
+             ->setDescription('Import locale translations')
              ->addOption('overwrite', 'o', InputOption::VALUE_OPTIONAL, 'Overwrite the existing locale', true)
              ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Path to the locale file')
              ->addOption('module', 'm', InputOption::VALUE_OPTIONAL, 'Name of the module that contains the locale');
@@ -65,7 +65,7 @@ class ImportLocaleCommand extends Command
 
         // Import locale
         $output->writeln('<info>Importing locale....</info>');
-        $this->installLocale($localePath, $overwriteOption, $output);
+        $this->importLocale($localePath, $overwriteOption, $output);
     }
 
     /**
@@ -91,7 +91,7 @@ class ImportLocaleCommand extends Command
      * @param OutputInterFace $output
      * @throws Exception
      */
-    private function installLocale($localePath, $overwrite, OutputInterface $output)
+    private function importLocale($localePath, $overwrite, OutputInterface $output)
     {
         // Load the xml from the file
         $xmlData = @simplexml_load_file($localePath);
@@ -101,7 +101,7 @@ class ImportLocaleCommand extends Command
             throw new Exception('Invalid locale.xml file.');
         }
 
-        // Everything ok, let's install the locale
+        // Everything ok, let's import the locale
         $results = BackendLocaleModel::importXML($xmlData, $overwrite, null, null, 1);
 
         if (!$results['total'] > 0) {

--- a/src/Common/Command/ImportLocaleCommand.php
+++ b/src/Common/Command/ImportLocaleCommand.php
@@ -104,7 +104,7 @@ class ImportLocaleCommand extends Command
         // Everything ok, let's import the locale
         $results = BackendLocaleModel::importXML($xmlData, $overwrite, null, null, 1);
 
-        if (!$results['total'] > 0) {
+        if ($results['total'] < 0) {
             $output->writeln('<error>Something went wrong during import.</error>');
             return;
         }


### PR DESCRIPTION
I was using the install_locale command but it's only possible to add the full path to a locale.xml file.  **Ideally, we could just use the modulename to import locale** and say `php install_locale.php -o -m blog` to install the blog module locale.xml. I quickly added this option...



#### Some remarks:
* Why are Exceptions used in this script? This doesn't make sense to me as they are not printed in the CLI. I first ran the script with errors but no output was given so I had no clue.
* **Is there already a possibility in Fork CMS to add Symfony commands?** I would like to refactor this script to an `app/console locale:install` command or something like that. Any input on how to achieve this in forkcms? What folder would Fork cms use for commands? `/src/Backend/Command` or `/src/ForkCMS/Command`? There's not a real backend bundle yet