### PR TITLE
Make sure our bad request header is formatted correctly.

### DIFF
--- a/src/Backend/Modules/Authentication/Actions/Index.php
+++ b/src/Backend/Modules/Authentication/Actions/Index.php
@@ -109,9 +109,7 @@ class Index extends BackendBaseActionIndex
             // invalid form-token?
             if ($this->frm->getToken() != $this->frm->getField('form_token')->getValue()) {
                 // set a correct header, so bots understand they can't mess with us.
-                if (!headers_sent()) {
-                    throw new BadRequestHttpException();
-                }
+                throw new BadRequestHttpException();
             }
 
             // get the user's id
@@ -158,9 +156,7 @@ class Index extends BackendBaseActionIndex
                     sleep($timeout);
 
                     // set a correct header, so bots understand they can't mess with us.
-                    if (!headers_sent()) {
-                        throw new ServiceUnavailableHttpException();
-                    }
+                    throw new ServiceUnavailableHttpException();
                 } else {
                     // increment and store
                     \SpoonSession::set('backend_last_attempt', time());

--- a/src/Backend/Modules/Authentication/Actions/Index.php
+++ b/src/Backend/Modules/Authentication/Actions/Index.php
@@ -10,6 +10,8 @@ namespace Backend\Modules\Authentication\Actions;
  */
 
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Backend\Core\Engine\Base\ActionIndex as BackendBaseActionIndex;
 use Backend\Core\Engine\Authentication as BackendAuthentication;
 use Backend\Core\Engine\Form as BackendForm;
@@ -108,7 +110,7 @@ class Index extends BackendBaseActionIndex
             if ($this->frm->getToken() != $this->frm->getField('form_token')->getValue()) {
                 // set a correct header, so bots understand they can't mess with us.
                 if (!headers_sent()) {
-                    header('400 Bad Request', true, 400);
+                    throw new BadRequestHttpException();
                 }
             }
 
@@ -157,7 +159,7 @@ class Index extends BackendBaseActionIndex
 
                     // set a correct header, so bots understand they can't mess with us.
                     if (!headers_sent()) {
-                        header('503 Service Unavailable', true, 503);
+                        throw new ServiceUnavailableHttpException();
                     }
                 } else {
                     // increment and store


### PR DESCRIPTION
This changes in a 500 because of the malformed header.