### PR TITLE
Fixes for Frontend Analytics tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Bugfixes:
 
 * Analytics: frontend "ga" is a function, not an object.
 
+Improvements:
+* Analytics: internal "anchors" and "mailto"-links are now being tracked.
+
 
 3.9.6 (2015-12-22)
 --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.9.7 (xxxx-xx-xx)
+--
+Bugfixes:
+
+* Analytics: frontend "ga" is a function, not an object.
+
+
 3.9.6 (2015-12-22)
 --
 Improvements:

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -531,10 +531,6 @@ jsFrontend.statistics =
 			// bind on all links that don't have the class noTracking
 			$(document).on('click', 'a:external:not(.noTracking), a:internal:not(.noTracking)', function(e)
 			{
-				// only simulate direct links
-				var hasTarget = (typeof $(this).attr('target') != 'undefined');
-				if(!hasTarget) e.preventDefault();
-
 				var link = $(this).attr('href');
 				var currentUrl = window.location.pathname;
 
@@ -565,9 +561,6 @@ jsFrontend.statistics =
 				{
 					ga('send', 'event', type, pageView);
 				}
-
-				// set time out
-				if(!hasTarget) setTimeout(function() { document.location.href = link; }, 100);
 			});
 		}
 	}


### PR DESCRIPTION
**Fixes**
* ```ga``` is a function (not an object), fixes #1383 
* Tracking ```anchors``` is now working
* Tracking ```mailto``` is now working

**What I've added**
* An ':internal' check to track ```mailto``` and ```#```-links. So we can push these internal click events to Google Analytics (because :external does not do this).