### PR TITLE
Initialize the container and fork constants when creating a kernel

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -35,8 +35,6 @@ abstract class Kernel extends BaseKernel implements KernelInterface
     {
         parent::__construct($environment, $debug);
         $this->boot();
-        // define Fork constants
-        $this->defineForkConstants();
     }
 
     /**
@@ -46,7 +44,25 @@ abstract class Kernel extends BaseKernel implements KernelInterface
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        // boot if it hasn't booted yet
+        $this->boot();
+
         return $this->getHttpKernel()->handle($request, $type, $catch);
+    }
+
+    /**
+     * Boot and define the Fork Constants.
+     */
+    public function boot()
+    {
+        if ($this->booted) {
+            return;
+        }
+
+        parent::boot();
+
+        // define Fork constants
+        $this->defineForkConstants();
     }
 
     /**

--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -24,19 +24,28 @@ use Symfony\Component\HttpKernel\KernelInterface;
 abstract class Kernel extends BaseKernel implements KernelInterface
 {
     /**
+     * Constructor.
+     *
+     * @param string $environment The environment
+     * @param bool   $debug       Whether to enable debugging or not
+     *
+     * @api
+     */
+    public function __construct($environment, $debug)
+    {
+        parent::__construct($environment, $debug);
+        $this->boot();
+        // define Fork constants
+        $this->defineForkConstants();
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        if (false === $this->booted) {
-            $this->boot();
-
-            // define Fork constants
-            $this->defineForkConstants();
-        }
-
         return $this->getHttpKernel()->handle($request, $type, $catch);
     }
 

--- a/app/console
+++ b/app/console
@@ -33,8 +33,6 @@ if ($debug) {
 $kernel = new AppKernel($env, $debug);
 
 // make our container available statically. This is needed to make our static models work
-$kernel->boot();
-$kernel->defineForkConstants();
 BaseModel::setContainer($kernel->getContainer());
 
 define('APPLICATION', 'Console');

--- a/src/Backend/Core/Js/ckfinder/config.php
+++ b/src/Backend/Core/Js/ckfinder/config.php
@@ -25,7 +25,6 @@ $debug = getenv('FORK_DEBUG') === '1';
 
 $kernel = new AppKernel($env, $debug);
 $loader = new KernelLoader($kernel);
-$kernel->boot();
 $kernel->getContainer()->get('session.handler');
 $loader->passContainerToModels();
 

--- a/src/Common/WebTestCase.php
+++ b/src/Common/WebTestCase.php
@@ -63,8 +63,6 @@ abstract class WebTestCase extends BaseWebTestCase
         }
 
         static::$kernel = static::createKernel($options);
-        static::$kernel->boot();
-        static::$kernel->defineForkConstants();
 
         $client = static::$kernel->getContainer()->get('test.client');
         $client->setServerParameters($server);

--- a/tools/install_locale.php
+++ b/tools/install_locale.php
@@ -48,8 +48,7 @@ else {
 // bootstrap Fork
 define('APPLICATION', 'Backend');
 $kernel = new AppKernel('prod', false);
-$kernel->boot();
-$kernel->defineForkConstants();
+
 if (!defined('PATH_WWW')) {
     define('PATH_WWW', __DIR__ . '/..');
 }


### PR DESCRIPTION
Initialize the container and fork constants when creating a kernel instead of initializing it when handling the request.