### PR TITLE
Location: Added zoom-level 1 and 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 3.9.7 (xxxx-xx-xx)
 --
+Improvements:
+* Location: added zoom-level 1 and 2.
+
 Bugfixes:
 * Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
 

--- a/src/Backend/Modules/Location/Actions/Edit.php
+++ b/src/Backend/Modules/Location/Actions/Edit.php
@@ -132,8 +132,8 @@ class Edit extends BackendBaseActionEdit
         );
 
         $zoomLevels = array_combine(
-            array_merge(array('auto'), range(3, 18)),
-            array_merge(array(BL::lbl('Auto', $this->getModule())), range(3, 18))
+            array_merge(array('auto'), range(1, 18)),
+            array_merge(array(BL::lbl('Auto', $this->getModule())), range(1, 18))
         );
 
         $this->settingsForm = new BackendForm('settings');

--- a/src/Backend/Modules/Location/Actions/Index.php
+++ b/src/Backend/Modules/Location/Actions/Index.php
@@ -127,8 +127,8 @@ class Index extends BackendBaseActionIndex
         );
 
         $zoomLevels = array_combine(
-            array_merge(array('auto'), range(3, 18)),
-            array_merge(array(BL::lbl('Auto', $this->getModule())), range(3, 18))
+            array_merge(array('auto'), range(1, 18)),
+            array_merge(array(BL::lbl('Auto', $this->getModule())), range(1, 18))
         );
 
         $this->form = new BackendForm('settings');


### PR DESCRIPTION
**Problem**
I have client that has locations all over the world but the zoom-level only starts from 3.

**Solution**
You can now select 1 and 2 from the zoom-level.