### PR TITLE
Fix revision page viewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 --
 Bugfixes:
 * Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
+* Pages: Fixes "Notice: Undefined index: parent_id" when viewing a page revision where the page is located in the root of the pages tree.
+* Pages: Fixes "Error: Call to a member function addMetaData() on null" when viewing an existing revision page.
 
 3.9.6 (2015-12-22)
 --

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -269,7 +269,7 @@ class Model extends \Common\Core\Model
 
         // get data
         $record = (array) $db->getRecord(
-            'SELECT p.id, p.revision_id, p.template_id, p.title, p.navigation_title, p.navigation_title_overwrite,
+            'SELECT p.id, p.parent_id, p.revision_id, p.template_id, p.title, p.navigation_title, p.navigation_title_overwrite,
                  p.data,
                  m.title AS meta_title, m.title_overwrite AS meta_title_overwrite,
                  m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -102,10 +102,17 @@ class Page extends FrontendBaseObject
         // set tracking cookie
         Model::getVisitorId();
 
+        // create header instance
+        $this->header = new Header($this->getKernel());
+
         // get page content from pageId of the requested URL
         $this->record = $this->getPageContent(
             Navigation::getPageId(implode('/', $this->URL->getPages()))
         );
+
+        if (empty($this->record)) {
+            $this->record = Model::getPage(404);
+        }
 
         // we need to set the correct id
         $this->pageId = (int) $this->record['id'];
@@ -121,9 +128,6 @@ class Page extends FrontendBaseObject
 
         // create breadcrumb instance
         $this->breadcrumb = new Breadcrumb($this->getKernel());
-
-        // create header instance
-        $this->header = new Header($this->getKernel());
 
         // new footer instance
         $this->footer = new Footer($this->getKernel());
@@ -239,6 +243,10 @@ class Page extends FrontendBaseObject
         } else {
             // get page record
             $record = (array) Model::getPage($pageId);
+        }
+
+        if (empty($record)) {
+            return array();
         }
 
         // init var


### PR DESCRIPTION
Fixes "Error: Call to a member function addMetaData() on null" when viewing an existing revision page.
How to reproduce the problem?
Goto: http://demo.fork-cms.com/en/?page_revision=1

Fixes "Notice: Undefined index: parent_id" when viewing a page revision where the page is located in the root of the pages tree.
How to reproduce the problem?
Goto: http://demo.fork-cms.com/en/?page_revision=9999
