### PR TITLE
Bugfix: datagrid sequence "extra-params" to have valid json object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 3.9.7 (xxxx-xx-xx)
 --
 Bugfixes:
-* Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
 * Backend: Core fix when using extra-params in a datagrid sequence reorder ajax call.
+* Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
 
 3.9.6 (2015-12-22)
 --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 --
 Bugfixes:
 * Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
+* Backend: Core fix when using extra-params in a datagrid sequence reorder ajax call.
 
 3.9.6 (2015-12-22)
 --

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -2023,8 +2023,18 @@ jsBackend.tableSequenceByDragAndDrop =
 					var module = (typeof $table.parents('table.dataGrid').data('module') == 'undefined') ? jsBackend.current.module : $table.parents('table.dataGrid').data('module').toString();
 
 					// fetch extra params
-					if(typeof $table.parents('table.dataGrid').data('extra-params') != 'undefined') extraParams = $table.parents('table.dataGrid').data('extra-params');
-					else extraParams = {};
+					if(typeof $table.parents('table.dataGrid').data('extra-params') != 'undefined') {
+						// we define extra params
+						extraParams = $table.parents('table.dataGrid').data('extra-params');
+
+						// we convert the unvalid {'key':'value'} to the valid {"key":"value"}
+						extraParams = extraParams.replace(/'/g, '"');
+
+						// we parse it as an object
+						extraParams = $.parseJSON(extraParams);
+					} else {
+						extraParams = {};
+					}
 
 					// init var
 					$rows = $(this).find('tr');


### PR DESCRIPTION
For example:

You have the following in your Backend Action:
```php
// enable sorting
$this->dgPosts->enableSequenceByDragAndDrop();
$this->dgPosts->setAttributes(
    array(
        'class' => 'dataGrid sequenceByDragAndDrop',
        'data-extra-params' => "{'module':'Products', 'type':'" . $this->category['type'] . "', 'category_id':'" . $this->categoryId . "'}",
        'data-module' => 'Categories',
        'data-action' => 'SequenceForItems'
    )
);
```
> You can not use ", because this breaks the html. So you must use `.

In older jQuery versions this wasn't any problem.
But in the newer jQuery version I noticed that the json validation has become stricter.

**So we must convert ` to " in our javascript.** (=> which is exactly what this PR does).

===
SCREENSHOTS
**Before fix**
![schermafbeelding 2016-02-18 om 10 20 41](https://cloud.githubusercontent.com/assets/588616/13138774/4f9530ae-d629-11e5-8eff-a5aaa6af2f58.png)

**After fix**
![schermafbeelding 2016-02-18 om 10 20 26](https://cloud.githubusercontent.com/assets/588616/13138779/54fbecb8-d629-11e5-852e-d08ca5067fa3.png)