### PR TITLE
Fixes view URL?page_revision=x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.9.7 (xxxx-xx-xx)
 --
 Bugfixes:
+* Pages: viewing ?page_revision=x was not possible.
 * Faq: fixes faq-category sequence reordering not being saved.
 * Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
 

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -269,7 +269,7 @@ class Model extends \Common\Core\Model
 
         // get data
         $record = (array) $db->getRecord(
-            'SELECT p.id, p.revision_id, p.template_id, p.title, p.navigation_title, p.navigation_title_overwrite,
+            'SELECT p.id, p.parent_id, p.revision_id, p.template_id, p.title, p.navigation_title, p.navigation_title_overwrite,
                  p.data,
                  m.title AS meta_title, m.title_overwrite AS meta_title_overwrite,
                  m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -102,6 +102,9 @@ class Page extends FrontendBaseObject
         // set tracking cookie
         Model::getVisitorId();
 
+        // create header instance
+        $this->header = new Header($this->getKernel());
+
         // get page content from pageId of the requested URL
         $this->record = $this->getPageContent(
             Navigation::getPageId(implode('/', $this->URL->getPages()))
@@ -121,9 +124,6 @@ class Page extends FrontendBaseObject
 
         // create breadcrumb instance
         $this->breadcrumb = new Breadcrumb($this->getKernel());
-
-        // create header instance
-        $this->header = new Header($this->getKernel());
 
         // new footer instance
         $this->footer = new Footer($this->getKernel());


### PR DESCRIPTION
### Problem

When viewing a ?page_revision=x you get an error because $this->header is not defined yet, so you can't execute ```->addMetaData```.
![schermafbeelding 2016-02-26 om 09 31 31](https://cloud.githubusercontent.com/assets/588616/13347114/c6ddbdaa-dc6b-11e5-9468-6569b3d0d8a8.png)

### Steps to reproduce

* Open /private
* Click on home and then click on "save as draft"
* Now click on the "preview page"-button
=> Error is shown when in dev modus

### Two fixes
* We need to define header first
* We need to fetch parent_id also, otherwise another error is thrown.