### PR TITLE
Fixes bug in utils.string.stripTags for Windows 7 + IE10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.9.7 (xxxx-xx-xx)
 --
 Bugfixes:
+* Core: fixes utils.string.stripTags which throws errors in Windows 7 + IE10.
 * Faq: fixes faq-category sequence reordering not being saved.
 * Pages: removed single quotes converter in CacheBuilder. This fixes page titles with single quotes.
 * Pages: Fixes "Notice: Undefined index: parent_id" when viewing a page revision where the page is located in the root of the pages tree.

--- a/src/Backend/Core/Js/utils.js
+++ b/src/Backend/Core/Js/utils.js
@@ -166,6 +166,7 @@ utils.form =
  * @author	Tijs Verkoyen <tijs@sumocoders.be>
  * @author	Dieter Vanden Eynde <dieter@netlash.com>
  * @author	Matthias Mullie <forkcms@mullie.eu>
+ * @author	Jeroen Desloovere <info@jeroendesloovere.be>
  */
 utils.string =
 {
@@ -303,7 +304,13 @@ utils.string =
 	 */
 	stripTags: function(value)
 	{
-		return value.replace(/<[^>]*>/ig, '');
+		if(typeof value === 'undefined') return '';
+		else
+		{
+			value = value.replace(/<[^>]*>/ig, '');
+		}
+
+		return value;
 	},
 
 	/**

--- a/src/Backend/Core/Js/utils.js
+++ b/src/Backend/Core/Js/utils.js
@@ -304,13 +304,11 @@ utils.string =
 	 */
 	stripTags: function(value)
 	{
-		if(typeof value === 'undefined') return '';
-		else
-		{
-			value = value.replace(/<[^>]*>/ig, '');
+		if (typeof value === 'undefined') {
+		    return '';
 		}
 
-		return value;
+		return value.replace(/<[^>]*>/ig, '');
 	},
 
 	/**

--- a/src/Frontend/Core/Js/utils.js
+++ b/src/Frontend/Core/Js/utils.js
@@ -166,6 +166,8 @@ utils.form =
  * @author	Tijs Verkoyen <tijs@sumocoders.be>
  * @author	Dieter Vanden Eynde <dieter@netlash.com>
  * @author	Matthias Mullie <forkcms@mullie.eu>
+ * @author	Jeroen Desloovere <info@jeroendesloovere.be>
+ */
  */
 utils.string =
 {
@@ -287,7 +289,13 @@ utils.string =
 	 */
 	stripTags: function(value)
 	{
-		return value.replace(/<[^>]*>/ig, '');
+		if(typeof value === 'undefined') return '';
+		else
+		{
+			value = value.replace(/<[^>]*>/ig, '');
+		}
+
+		return value;
 	},
 
 	/**

--- a/src/Frontend/Core/Js/utils.js
+++ b/src/Frontend/Core/Js/utils.js
@@ -289,13 +289,11 @@ utils.string =
 	 */
 	stripTags: function(value)
 	{
-		if(typeof value === 'undefined') return '';
-		else
-		{
-			value = value.replace(/<[^>]*>/ig, '');
+		if (typeof value === 'undefined') {
+		    return '';
 		}
 
-		return value;
+		return value.replace(/<[^>]*>/ig, '');
 	},
 
 	/**


### PR DESCRIPTION
When trying to add new "editor" block in Pages module then you'll previously got error.