### PR TITLE
Fix datagrid sequence missing column

### DIFF
--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -251,6 +251,17 @@ class DataGrid extends \SpoonDataGrid
     }
 
     /**
+     * Checks wether a column is present in the datagrid
+     *
+     * @param string $column
+     * @return bool
+     */
+    public function hasColumn($column)
+    {
+        return in_array($column, $this->columns);
+    }
+
+    /**
      * Retrieve the parsed output.
      *
      * @return string

--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -234,8 +234,10 @@ class DataGrid extends \SpoonDataGrid
         // disable paging
         $this->setPaging(false);
 
-        // hide the sequence column
-        $this->setColumnHidden('sequence');
+        // hide the sequence column if present
+        if ($this->hasColumn('sequence')) {
+            $this->setColumnHidden('sequence');
+        }
 
         // add a column for the handle, so users have something to hold while dragging
         $this->addColumn('dragAndDropHandle', null, '<span>' . Language::lbl('Move') . '</span>');


### PR DESCRIPTION
The enableSequenceByDragAndDrop() method sets the 'sequence' column to hidden but there's no reason to actually fetch the sequence in most cases. Therefor I made a method to check wether a column is present and used that method to only hide the sequence column if it's present.