### PR TITLE
Keep the leading slash in getQueryString.

### DIFF
--- a/src/Frontend/Core/Engine/Form.php
+++ b/src/Frontend/Core/Engine/Form.php
@@ -46,7 +46,7 @@ class Form extends \Common\Core\Form
         }
 
         $useToken = (bool) $useToken;
-        $action = ($action === null) ? '/' . $this->URL->getQueryString() : (string) $action;
+        $action = ($action === null) ? $this->URL->getQueryString() : (string) $action;
 
         // call the real form-class
         parent::__construct((string) $name, $action . $hash, $method, (bool) $useToken);

--- a/src/Frontend/Core/Engine/Url.php
+++ b/src/Frontend/Core/Engine/Url.php
@@ -179,7 +179,7 @@ class Url extends \KernelLoader
      */
     public function getQueryString()
     {
-        return trim((string) $this->request->getRequestUri(), '/');
+        return rtrim((string) $this->request->getRequestUri(), '/');
     }
 
     /**

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -518,7 +518,7 @@ class Form extends FrontendBaseWidget
                 \SpoonSession::set('formbuilder_' . $this->item['id'], time());
 
                 // redirect
-                $redirect = SITE_URL . '/' . $this->URL->getQueryString();
+                $redirect = SITE_URL . $this->URL->getQueryString();
                 $redirect .= (stripos($redirect, '?') === false) ? '?' : '&';
                 $redirect .= 'identifier=' . $this->item['identifier'];
 

--- a/src/Frontend/Modules/Profiles/Actions/ForgotPassword.php
+++ b/src/Frontend/Modules/Profiles/Actions/ForgotPassword.php
@@ -137,7 +137,7 @@ class ForgotPassword extends FrontendBaseBlock
                 $this->get('mailer')->send($message);
 
                 // redirect
-                $this->redirect(SITE_URL . '/' . $this->URL->getQueryString() . '?sent=true');
+                $this->redirect(SITE_URL . $this->URL->getQueryString() . '?sent=true');
             } else {
                 $this->tpl->assign('forgotPasswordHasError', true);
             }

--- a/src/Frontend/Modules/Profiles/Actions/Register.php
+++ b/src/Frontend/Modules/Profiles/Actions/Register.php
@@ -185,7 +185,7 @@ class Register extends FrontendBaseBlock
                     $this->get('mailer')->send($message);
 
                     // redirect
-                    $this->redirect(SITE_URL . '/' . $this->URL->getQueryString() . '?sent=true');
+                    $this->redirect(SITE_URL . $this->URL->getQueryString() . '?sent=true');
                 } catch (\Exception $e) {
                     // make sure RedirectExceptions get thrown
                     if ($e instanceof RedirectException) {

--- a/src/Frontend/Modules/Profiles/Actions/ResendActivation.php
+++ b/src/Frontend/Modules/Profiles/Actions/ResendActivation.php
@@ -136,7 +136,7 @@ class ResendActivation extends FrontendBaseBlock
                 $this->get('mailer')->send($message);
 
                 // redirect
-                $this->redirect(SITE_URL . '/' . $this->URL->getQueryString() . '?sent=true');
+                $this->redirect(SITE_URL . $this->URL->getQueryString() . '?sent=true');
             } else {
                 $this->tpl->assign('resendActivationHasError', true);
             }


### PR DESCRIPTION
In almost all cases, we readd it after calling this method. This is
inefficient as stated in issue #1260