### PR TITLE
Use php's default session handler. Fixes #1343

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,9 +10,7 @@ framework:
     csrf_protection: ~
     templating:
         engines: ['twig']
-    session:
-        handler_id: session.handler.native_file
-        save_path: "%kernel.root_dir%/sessions"
+    session: ~
 
 # Assetic Configuration
 assetic:

--- a/app/sessions/.gitignore
+++ b/app/sessions/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This will fix two issues:

* rights will always be correct on the sessions directory
* our sessions will be autocleaned up (not overflowing inodes on servers)

This introduces some other issues. On shared servers, this sessions
directory could be shared with other projects. This could theoretically
allow them to read/write our sessions and do malicious stuff with it.

We've discussed this and people who find this an issue can still change
their session handler. They can save them in the database, a folder they
choose, memcached,...
This way, advanced users can configure it completely customized.

We thus chose the native session handler. This one just works on every
server and does require no additional setup (like database tables).