### PR TITLE
Fixed saving blog articles as draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 3.9.7 (xxxx-xx-xx)
 --
 Bugfixes:
+* Blog: Fixed saving Blog articles as draft.
 * Core: Fix incorrect path for theme OpenGraphImage.
 * Core: Fixed when deploying, that /src/Frontend/Cache/Navigation/editor_link_list_x.js is now created if not exists.
 * Faq: fixes faq-category sequence reordering not being saved.

--- a/src/Backend/Modules/Blog/Engine/Model.php
+++ b/src/Backend/Modules/Blog/Engine/Model.php
@@ -1054,16 +1054,16 @@ class Model
             array($item['id'], $archiveType, BL::getWorkingLanguage(), $rowsToKeep)
         );
         
-        // get meta-ids that will be deleted
-        $metasIdsToRemove = (array) $db->getColumn(
-            'SELECT i.meta_id
-             FROM blog_posts AS i
-             WHERE i.id = ? AND revision_id NOT IN (' . implode(', ', $revisionIdsToKeep) . ')',
-            array($item['id'])
-        );
-        
         // delete other revisions
         if (!empty($revisionIdsToKeep)) {
+            // get meta-ids that will be deleted
+            $metasIdsToRemove = (array) $db->getColumn(
+                'SELECT i.meta_id
+                 FROM blog_posts AS i
+                 WHERE i.id = ? AND revision_id NOT IN (' . implode(', ', $revisionIdsToKeep) . ')',
+                array($item['id'])
+            );
+
             // get all the images of the revisions that will NOT be deleted
             $imagesToKeep = $db->getColumn(
                 'SELECT image FROM blog_posts


### PR DESCRIPTION
**Problem**

When saving a blog post, without other versions, an SQL error is thrown if you wish to save as draft.

**Solution**
Moved the method in the if statement.
=> When we don't have revisionIdsToKeep, we don't have metasIdsToRemove

