### PR TITLE
Add the new Composer exclude-from-classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
     "autoload": {
         "psr-0": {
             "": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "**/Tests/",
+            "**/tests/",
+            "**/Test/"
+        ]
     }
 }


### PR DESCRIPTION
When you run composer dump-autoload -o to get an optimized autoloader, Composer scans all files and builds a huge classmap, even for packages that define autoload rules as psr-0 or psr-4. This is great but in some cases you have some classes in the psr-0 path that you actually don't want to be included in this optimized map. Obviously in production we don't want to include those test classes in the optimized class map as it is just a waste.
Last year, composer got a new feature called "exclude-from-classpath". It uses a regex that can both exclude our own tests ànd the vendor tests to reduce the autoloader file located in /vendor/composer/autoload_classmap.php

More info: https://carlosbuenosvinos.com/saved-500-kbytes-of-autoload-classmap-with-autoload-dev-at-atrapaloeng/
More info: http://www.slideshare.net/javier.eguiluz/new-symfony-tips-tricks-symfonycon-paris-2015#61


This doesn't shave off many KB's for fork cms' autoloader but lets add it though? :)