### PR TITLE
Improve action authorization

### DIFF
--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -56,8 +56,8 @@ class Action extends Base\Object
     {
         $this->loadConfig();
 
-        // is the requested action possible? If not we redirect to the error page.
-        if (!$this->config->isActionPossible($this->action)) {
+        // is the requested action available? If not we redirect to the error page.
+        if (!$this->config->isActionAvailable($this->action)) {
             // build the url
             $errorUrl = '/' . NAMED_APPLICATION
                 . '/' . $this->get('request')->get('_locale')

--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -56,10 +56,15 @@ class Action extends Base\Object
     {
         $this->loadConfig();
 
-        // is the requested action possible? If not we throw an exception.
-        // We don't redirect because that could trigger a redirect loop
+        // is the requested action possible? If not we redirect to the error page.
         if (!$this->config->isActionPossible($this->action)) {
-            throw new Exception('This is an invalid action (' . $this->action . ').');
+            // build the url
+            $errorUrl = '/' . NAMED_APPLICATION
+                . '/' . $this->get('request')->get('_locale')
+                . '/error?type=action-not-allowed';
+
+            // redirect to the error page
+            return $this->redirect($errorUrl, 307);
         }
 
         // build action-class

--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -60,7 +60,7 @@ class Action extends Base\Object
         if (!$this->config->isActionAvailable($this->action)) {
             // build the url
             $errorUrl = '/' . NAMED_APPLICATION
-                . '/' . $this->get('request')->get('_locale')
+                . '/' . $this->get('request')->getLocale()
                 . '/error?type=action-not-allowed';
 
             // redirect to the error page

--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -58,8 +58,8 @@ class Action extends Base\Object
 
         // is the requested action possible? If not we throw an exception.
         // We don't redirect because that could trigger a redirect loop
-        if (!in_array($this->getAction(), $this->config->getPossibleActions())) {
-            throw new Exception('This is an invalid action (' . $this->getAction() . ').');
+        if (!$this->config->isActionPossible($this->action)) {
+            throw new Exception('This is an invalid action (' . $this->action . ').');
         }
 
         // build action-class

--- a/src/Backend/Core/Engine/Base/Config.php
+++ b/src/Backend/Core/Engine/Base/Config.php
@@ -168,7 +168,7 @@ class Config extends Object
                 continue;
             }
 
-            // The action is not disabled and the file is preset, this is an available action!
+            // The action is not disabled and the file is present, this is an available action!
             return true;
         }
 

--- a/src/Backend/Core/Engine/Base/Config.php
+++ b/src/Backend/Core/Engine/Base/Config.php
@@ -88,7 +88,7 @@ class Config extends Object
     {
         trigger_error(
             '$config->getPossibleActions() is deprecated.
-             Use $config->isActionPossible($action) to determine if an action is available',
+             Use $config->isActionAvailable($action) to determine if an action is available',
             E_USER_DEPRECATED
         );
 
@@ -104,7 +104,7 @@ class Config extends Object
     {
         trigger_error(
             '$config->getPossibleAJAXActions() is deprecated.
-             Use $config->isActionPossible($action) to determine if an action is available',
+             Use $config->isActionAvailable($action) to determine if an action is available',
             E_USER_DEPRECATED
         );
 
@@ -151,7 +151,7 @@ class Config extends Object
      * @param string $action
      * @return bool
      */
-    public function isActionPossible($action)
+    public function isActionAvailable($action)
     {
         // Save our action
         $this->action = $action;
@@ -168,11 +168,11 @@ class Config extends Object
                 continue;
             }
 
-            // The action is not disabled and the file is preset, this is a possible action!
+            // The action is not disabled and the file is preset, this is an available action!
             return true;
         }
 
-        // If no types contain a possible action, the action is impossible
+        // If no types contain an available action, the action is unavailable
         return false;
     }
 

--- a/src/Backend/Core/Engine/Base/Config.php
+++ b/src/Backend/Core/Engine/Base/Config.php
@@ -79,6 +79,39 @@ class Config extends Object
     }
 
     /**
+     * Get the possible actions
+     *
+     * @deprecated
+     * @return array
+     */
+    public function getPossibleActions()
+    {
+        trigger_error(
+            '$config->getPossibleActions() is deprecated.
+             Use $config->isActionPossible($action) to determine if an action is available',
+            E_USER_DEPRECATED
+        );
+
+        return $this->possibleActions;
+    }
+    /**
+     * Get the possible AJAX actions
+     *
+     * @deprecated
+     * @return array
+     */
+    public function getPossibleAJAXActions()
+    {
+        trigger_error(
+            '$config->getPossibleAJAXActions() is deprecated.
+             Use $config->isActionPossible($action) to determine if an action is available',
+            E_USER_DEPRECATED
+        );
+
+        return $this->possibleAJAXActions;
+    }
+
+    /**
      * Set the module
      *
      * We can't rely on the parent setModule function, because config could be


### PR DESCRIPTION
It is far more logical to check if everything is present and authorized for a single action than it is to check if an action is present among all authorized actions including ones we're not even requesting.
This also improves speed by around 30ms (rough estimate).

I also found it more logical to redirect to an error page when trying to access an unavailable action than it is to throw an exception which just results in a 500 error page on production anyway, often confusing end users.