### PR TITLE
FormBuilder EventListener: Integrated ModulesSettings in constructor

### DIFF
--- a/src/Backend/Modules/FormBuilder/Resources/config/services.yml
+++ b/src/Backend/Modules/FormBuilder/Resources/config/services.yml
@@ -3,6 +3,7 @@ services:
         class: Frontend\Modules\FormBuilder\EventListener\FormBuilderSubmittedMailSubscriber
         arguments:
             - "@mailer"
+            - "@fork.settings"
         tags:
             - { name: kernel.event_listener, event: form.submitted, method: onFormSubmitted }
     formbuilder.submitted.notifier:

--- a/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
+++ b/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
@@ -3,8 +3,8 @@
 namespace Frontend\Modules\FormBuilder\EventListener;
 
 use Swift_Mailer;
-use Frontend\Core\Engine\Language as FL;
-use Frontend\Core\Engine\Model as FrontendModel;
+use Common\ModulesSettings;
+use Frontend\Core\Engine\Language;
 use Frontend\Modules\FormBuilder\Event\FormBuilderSubmittedEvent;
 
 /**
@@ -14,14 +14,26 @@ use Frontend\Modules\FormBuilder\Event\FormBuilderSubmittedEvent;
  */
 final class FormBuilderSubmittedMailSubscriber
 {
+    /**
+     * @var ModulesSettings
+     */
+    protected $modulesSettings;
+
+    /**
+     * @var Swift_Mailer
+     */
     protected $mailer;
 
     /**
      * @param Swift_Mailer $mailer
+     * @param ModulesSettings $modulesSettings
      */
-    public function __construct(Swift_Mailer $mailer)
-    {
+    public function __construct(
+        Swift_Mailer $mailer,
+        ModulesSettings $modulesSettings
+    ) {
         $this->mailer = $mailer;
+        $this->modulesSettings = $modulesSettings;
     }
 
     /**
@@ -34,10 +46,10 @@ final class FormBuilderSubmittedMailSubscriber
         // need to send mail
         if ($form['method'] == 'database_email') {
             // build our message
-            $from = FrontendModel::get('fork.settings')->get('Core', 'mailer_from');
+            $from = $this->modulesSettings->get('Core', 'mailer_from');
             $fieldData = $this->getEmailFields($event->getData());
             $message = \Common\Mailer\Message::newInstance(sprintf(
-                    FL::getMessage('FormBuilderSubject'),
+                    Language::getMessage('FormBuilderSubject'),
                     $form['name']
                 ))
                 ->parseHtml(
@@ -63,7 +75,7 @@ final class FormBuilderSubmittedMailSubscriber
                 }
             }
             if ($message->getReplyTo() === null) {
-                $replyTo = FrontendModel::get('fork.settings')->get('Core', 'mailer_reply_to');
+                $replyTo = $this->modulesSettings->get('Core', 'mailer_reply_to');
                 $message->setReplyTo(array($replyTo['email'] => $replyTo['name']));
             }
 


### PR DESCRIPTION
It is better practice to use constructor arguments when integrating a class.