### PR TITLE
Add ucfirst twigfilter

### DIFF
--- a/src/Common/Core/Twig/Extensions/TwigFilters.php
+++ b/src/Common/Core/Twig/Extensions/TwigFilters.php
@@ -58,6 +58,7 @@ class TwigFilters
             'sprintf',
             array('is_safe' => array('html'))
         ));
+        $twig->addFilter(new Twig_SimpleFilter('ucfirst', 'ucfirst'));
 
         // Functions navigation
         $twig->addFunction(new Twig_SimpleFunction(


### PR DESCRIPTION
Twig doesn't support `ucfirst` ([see here](https://github.com/twigphp/Twig/issues/1652)). They have the capitalize filter but that doesn't work quite the same way. I'm upgrading my old module(s) and I have this label: "link with TinyPNG". 

Original label: `link with TinyPNG`
Capitalize filter: `Link with tinypng` --> Everything gets lowercased except the first capital letter.
Ucfirst filter: `Link with TinyPNG` --> Capitalizes the first letter.
