### PR TITLE
Make "same language" installer checkbox not required

### DIFF
--- a/src/ForkCMS/Bundle/InstallerBundle/Form/Type/LanguagesType.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Form/Type/LanguagesType.php
@@ -49,6 +49,7 @@ class LanguagesType extends AbstractType
                 'checkbox',
                 array(
                     'label' => 'Use the same language(s) for the CMS interface.',
+                    'required' => false
                 )
             )
             ->add(


### PR DESCRIPTION
1. Go to the installer of Fork CMS 4.0.0
2. Uncheck "Use the same language(s) for the CMS interface."
3. Check 1 or more languages
4. Press "Next"
5. A html5 validation error shows that you have to check the "Use the same language(s) for the CMS interface.". This should not happen because it makes it impossible to use multiple cms languages.

Screencast of issue: http://d.pr/v/1auDg