### PR TITLE
DataGrid hasColumn was not working

### DIFF
--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -292,14 +292,14 @@ class DataGrid extends \SpoonDataGrid
     }
 
     /**
-     * Checks wether a column is present in the datagrid
+     * Checks whether a column is present in the datagrid
      *
      * @param string $column
      * @return bool
      */
     public function hasColumn($column)
     {
-        return in_array($column, $this->columns);
+        return array_key_exists($column, $this->columns);
     }
 
     /**


### PR DESCRIPTION
I found a bug regarding the hasColumn function. It was not working when using the sequence option. After further investigation I noticed that function was checking the wrong values.