### PR TITLE
Add asterisk for required fields in frontend

### DIFF
--- a/src/Frontend/Modules/Faq/Layout/Templates/Detail.html.twig
+++ b/src/Frontend/Modules/Faq/Layout/Templates/Detail.html.twig
@@ -108,7 +108,7 @@
 
 						<div id="feedbackNoInfo"{% if hideFeedbackNoInfo %} style="display: none;"{% endif %}>
 							<p class="bigInput{% if txtMessageError %} errorArea{% endif %}">
-								<label for="message">{{ 'msg.HowToImprove'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+								<label for="message">{{ 'msg.HowToImprove'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 								{% form_field_error Message %} {% form_field Message %}
 							</p>
 							<p>

--- a/src/Frontend/Modules/Faq/Layout/Widgets/AskOwnQuestion.html.twig
+++ b/src/Frontend/Modules/Faq/Layout/Widgets/AskOwnQuestion.html.twig
@@ -15,15 +15,15 @@
 
 			{% form own_question %}
 				<p{% if txtNameError %} class="errorArea"{% endif %}>
-					<label for="name">{{ 'lbl.YourName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="name">{{ 'lbl.YourName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field_error Name %} {% form_field Name %}
 				</p>
 				<p{% if txtEmailError %} class="errorArea"{% endif %}>
-					<label for="email">{{ 'lbl.YourEmail'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="email">{{ 'lbl.YourEmail'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field_error Email %} {% form_field Email %}
 				</p>
 				<p class="bigInput{% if txtMessageError %} errorArea{% endif %}">
-					<label for="message">{{ 'lbl.YourQuestion'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="message">{{ 'lbl.YourQuestion'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field_error Message %} {% form_field Message %}
 				</p>
 				<p>

--- a/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
+++ b/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
@@ -26,7 +26,7 @@
 						{% if field.simple %}
 							<p{% if field.error %} class="errorArea"{% endif %}>
 								<label for="{{ field.name }}">
-									{{ field.label }}{% if field.required %}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr>{% endif %}
+									{{ field.label }}{% if field.required %}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr>{% endif %}
 								</label>
 								{{ field.html|raw }}
 								{% if field.error %}<span class="formError inlineError">{{ field.error }}</span>{% endif %}
@@ -37,7 +37,7 @@
 						{% if field.multiple %}
 							<div class="inputList{% if field.error %} errorArea{% endif %}">
 								<p class="label">
-									{{ field.label }}{% if field.required %}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr>{% endif %}
+									{{ field.label }}{% if field.required %}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr>{% endif %}
 								</p>
 								<ul>
 									{% for html in field.html %}

--- a/src/Frontend/Modules/Location/Layout/Widgets/Location.html.twig
+++ b/src/Frontend/Modules/Location/Layout/Widgets/Location.html.twig
@@ -12,7 +12,7 @@
 		<aside id="locationSearch{{ widgetLocationItem.id }}" class="locationSearch">
 			<form method="get" action="#">
 				<p>
-					<label for="locationSearchAddress{{ widgetLocationItem.id }}">{{ 'lbl.Start'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="locationSearchAddress{{ widgetLocationItem.id }}">{{ 'lbl.Start'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					<input type="text" id="locationSearchAddress{{ widgetLocationItem.id }}" name="locationSearchAddress" class="inputText" />
 					<span id="locationSearchError{{ widgetLocationItem.id }}" class="formError inlineError" style="display: none;">{{ 'err.FieldIsRequired'|trans|capitalize }}</span>
 				</p>

--- a/src/Frontend/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
+++ b/src/Frontend/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
@@ -8,7 +8,7 @@
 			{% if not subscribeHideForm %}
 				{% form subscribe %}
 					<p{% if txtEmailError %} class="errorArea"{% endif %}>
-						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Email %} {% form_field Email %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
+++ b/src/Frontend/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
@@ -8,7 +8,7 @@
 			{% if not unsubscribeHideForm %}
 				{% form unsubscribe %}
 					<p{% if txtEmailError %} class="errorArea"{% endif %}>
-						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Email %} {% form_field Email %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Mailmotor/Layout/Widgets/Subscribe.html.twig
+++ b/src/Frontend/Modules/Mailmotor/Layout/Widgets/Subscribe.html.twig
@@ -4,7 +4,7 @@
 			{% form subscribe %}
 				<input type="hidden" name="form_token" id="formToken" value="{{ formToken }}" />
 				<p>
-					<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field_error email %} {% form_field email %}
 				</p>
 				<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/ChangeEmail.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/ChangeEmail.html.twig
@@ -14,11 +14,11 @@
 			{% form updateEmail %}
 				<fieldset>
 					<p{% if txtPasswordError %} class="errorArea"{% endif %}>
-						<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Password %}{% form_field Password %}
 					</p>
 					<p{% if txtEmailError %} class="errorArea"{% endif %}>
-						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Email %}{% form_field Email %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/ChangePassword.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/ChangePassword.html.twig
@@ -14,15 +14,15 @@
 			{% form updatePassword %}
 				<fieldset>
 					<p{% if txtOldPasswordError %} class="errorArea"{% endif %}>
-						<label for="oldPassword">{{ 'lbl.OldPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="oldPassword">{{ 'lbl.OldPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error OldPassword %}{% form_field OldPassword %}
 					</p>
 					<p{% if txtNewPasswordError %} class="errorArea"{% endif %}>
-						<label for="newPassword">{{ 'lbl.NewPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="newPassword">{{ 'lbl.NewPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error NewPassword %}{% form_field NewPassword %}
 					</p>
 					<p{% if txtVerifyNewPasswordError %} class="errorArea"{% endif %}>
-						<label for="verifyNewPassword">{{ 'lbl.VerifyNewPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="verifyNewPassword">{{ 'lbl.VerifyNewPassword'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error VerifyNewPassword %}{% form_field VerifyNewPassword %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/ForgotPassword.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/ForgotPassword.html.twig
@@ -15,7 +15,7 @@
 				{% form forgotPassword %}
 					<fieldset>
 						<p{% if txtEmailError %} class="errorArea"{% endif %}>
-							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Email %}{% form_field Email %}
 						</p>
 						<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Login.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Login.html.twig
@@ -17,11 +17,11 @@
 			{% form login %}
 				<fieldset>
 					<p{% if txtEmailError %} class="errorArea"{% endif %}>
-						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Email %}{% form_field Email %}
 					</p>
 					<p{% if txtPasswordError %} class="errorArea"{% endif %}>
-						<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Password %}{% form_field Password %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Register.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Register.html.twig
@@ -15,15 +15,15 @@
 				<div class="bd">
 					<fieldset>
 						<p{% if txtDisplayNameError %} class="errorArea"{% endif %}>
-							<label for="displayName">{{ 'lbl.DisplayName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="displayName">{{ 'lbl.DisplayName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error DisplayName %}{% form_field DisplayName %}
 						</p>
 						<p{% if txtEmailError %} class="errorArea"{% endif %}>
-							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Email %}{% form_field Email %}
 						</p>
 						<p{% if txtPasswordError %} class="errorArea"{% endif %}>
-							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Password %}{% form_field Password %}
 						</p>
 						<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/ResendActivation.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/ResendActivation.html.twig
@@ -15,7 +15,7 @@
 				{% form resendActivation %}
 					<fieldset>
 						<p {% if txtEmailError %} class="errorArea"{% endif %}>
-							<label for="email">{{ 'lbl.Email'|trans|capitalize }} <abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="email">{{ 'lbl.Email'|trans|capitalize }} <abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Email %} {% form_field Email %}
 						</p>
 						<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/ResetPassword.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/ResetPassword.html.twig
@@ -15,7 +15,7 @@
 				{% form resetPassword %}
 					<fieldset>
 						<p{% if txtPasswordError %} class="errorArea"{% endif %}>
-							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Password %}{% form_field Password %}
 						</p>
 						<p>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
@@ -16,12 +16,12 @@
 					<legend>{{ 'lbl.YourData'|trans|capitalize }}</legend>
 
 					<p{% if txtDisplayNameError %} class="errorArea"{% endif %}>
-						<label for="displayName">{{ 'lbl.DisplayName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="displayName">{{ 'lbl.DisplayName'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error DisplayName %}{% form_field DisplayName %}
 						<small class="helpTxt">{{ 'msg.HelpDisplayNameChanges'|trans|sprintf({$maxDisplayNameChanges }}:{{ displayNameChangesLeft }}})</small>
 					</p>
 					<p{% if txtEmailError %} class="errorArea"{% endif %}>
-						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+						<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 						{% form_field_error Email %}{% form_field Email %}
 					</p>
 					<p>

--- a/src/Frontend/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
@@ -21,11 +21,11 @@
 				{% form login %}
 					<fieldset>
 						<p{% if txtEmailError %} class="errorArea"{% endif %}>
-							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="email">{{ 'lbl.Email'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Email %}{% form_field Email %}
 						</p>
 						<p{% if txtPasswordError %} class="errorArea"{% endif %}>
-							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+							<label for="password">{{ 'lbl.Password'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 							{% form_field_error Password %}{% form_field Password %}
 						</p>
 						<p>

--- a/src/Frontend/Modules/Search/Layout/Templates/Index.html.twig
+++ b/src/Frontend/Modules/Search/Layout/Templates/Index.html.twig
@@ -12,7 +12,7 @@
 		<div class="bd">
 			{% form search %}
 				<p{% if form_field_error %} class="errorArea"{% endif %}>
-					<label for="q">{{ 'lbl.SearchTerm'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="q">{{ 'lbl.SearchTerm'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field_error q %} {% form_field q %}
 				</p>
 				<p>

--- a/src/Frontend/Modules/Search/Layout/Widgets/Form.html.twig
+++ b/src/Frontend/Modules/Search/Layout/Widgets/Form.html.twig
@@ -6,7 +6,7 @@
 		<div class="bd">
 			{% form search %}
 				<p>
-					<label for="q_widget">{{ 'lbl.SearchTerm'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">#</abbr></label>
+					<label for="q_widget">{{ 'lbl.SearchTerm'|trans|capitalize }}<abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr></label>
 					{% form_field q_widget %}
 				</p>
 				<p>


### PR DESCRIPTION
Check the frontend of the forkcms demo: http://demo.fork-cms.com/en/contact
You see a `Name#` instead of `Name*` ?

For some reason unknown, required fields in the frontend use a "#" instead of the typically used asterisk "*". I fixed those. 