### PR TITLE
Backend: Core fix when using extra-params in a datagrid sequence reorder ajax call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 Bugfixes:
 
+* Backend: Core fix when using extra-params in a datagrid sequence reorder ajax call.
 * Core: Fixes date field with empty date.
 * Core: Fix lost ucfirst template modifier.
 * Installer: Make "same language" not required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 
 Bugfixes:
 
-* Backend: Core fix when using extra-params in a datagrid sequence reorder ajax call.
 * Core: Fixes date field with empty date.
 * Core: Fix lost ucfirst template modifier.
 * Installer: Make "same language" not required.

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -1974,8 +1974,18 @@ jsBackend.tableSequenceByDragAndDrop =
                         var module = (typeof $table.parents('table.jsDataGrid').data('module') == 'undefined') ? jsBackend.current.module : $table.parents('table.jsDataGrid').data('module').toString();
 
                         // fetch extra params
-                        if (typeof $table.parents('table.jsDataGrid').data('extra-params') != 'undefined') extraParams = $table.parents('table.jsDataGrid').data('extra-params');
-                        else extraParams = {};
+                        if (typeof $table.parents('table.jsDataGrid').data('extra-params') != 'undefined') {
+                            // we define extra params
+                            extraParams = $table.parents('table.jsDataGrid').data('extra-params');
+
+                            // we convert the unvalid {'key':'value'} to the valid {"key":"value"}
+                            extraParams = extraParams.replace(/'/g, '"');
+
+                            // we parse it as an object
+                            extraParams = $.parseJSON(extraParams);
+                        } else {
+                            extraParams = {};
+                        }
 
                         // init var
                         $rows = $(this).find('tr');


### PR DESCRIPTION
Closes #1403, because has merging conflicts