### PR TITLE
FormBuilder: Anchor added to Form.php widget

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  * @author Dieter Vanden Eynde <dieter.vandeneynde@netlash.com>
  * @author Tijs Verkoyen <tijs@sumocoders.be>
  * @author Wouter Sioen <wouter.sioen@wijs.be>
+ * @author Jeroen Desloovere <jeroen@siesqo.be>
  */
 class Form extends FrontendBaseWidget
 {
@@ -34,6 +35,13 @@ class Form extends FrontendBaseWidget
      * @var FrontendForm
      */
     private $frm;
+
+    /**
+     * Form name
+     *
+     * @var string
+     */
+    private $formName;
 
     /**
      * The form item.
@@ -134,6 +142,9 @@ class Form extends FrontendBaseWidget
     {
         // fetch the item
         $this->item = FrontendFormBuilderModel::get((int) $this->data['id']);
+
+        // define form name
+        $this->formName = 'form' . $this->item['id'];
     }
 
     /**
@@ -298,9 +309,8 @@ class Form extends FrontendBaseWidget
     private function parse()
     {
         // form name
-        $formName = 'form' . $this->item['id'];
-        $this->tpl->assign('formName', $formName);
-        $this->tpl->assign('formAction', $this->createAction() . '#' . $formName);
+        $this->tpl->assign('formName', $this->formName);
+        $this->tpl->assign('formAction', $this->createAction() . '#' . $this->formName);
 
         // got fields
         if (!empty($this->fieldsHTML)) {
@@ -358,8 +368,7 @@ class Form extends FrontendBaseWidget
     private function parseSuccessMessage()
     {
         // form name
-        $formName = 'form' . $this->item['id'];
-        $this->tpl->assign('formName', $formName);
+        $this->tpl->assign('formName', $this->formName);
         $this->tpl->assign('successMessage', $this->item['success_message']);
     }
 
@@ -502,6 +511,7 @@ class Form extends FrontendBaseWidget
                 $redirect = SITE_URL . $this->URL->getQueryString();
                 $redirect .= (stripos($redirect, '?') === false) ? '?' : '&';
                 $redirect .= 'identifier=' . $this->item['identifier'];
+                $redirect .= '#' . $this->formName;
 
                 throw new RedirectException(
                     'Redirect',


### PR DESCRIPTION
Closes #1381 

Two things have changed:
- Created a $this->formName variable (instead of defining two times the same)
- Added $this->formName to the redirect action