### PR TITLE
Fix dutch analysis translation

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -4002,7 +4002,7 @@
         <translation language="tr"><![CDATA[analiz]]></translation>
       </item>
       <item type="label" name="Analysis">
-        <translation language="nl"><![CDATA[analysi]]></translation>
+        <translation language="nl"><![CDATA[analyse]]></translation>
         <translation language="en"><![CDATA[analysis]]></translation>
         <translation language="hu"><![CDATA[analízis]]></translation>
         <translation language="it"><![CDATA[analisi]]></translation>


### PR DESCRIPTION
It's "analyse" (http://www.vandale.nl/opzoeken?pattern=analyse&lang=nn) in dutch instead of "analysi". 

Appears when you see the Fork CMS dashboard widget with title "analysi"