### PR TITLE
Small layout fixes

### DIFF
--- a/src/Backend/Modules/Extensions/Js/ThemeTemplate.js
+++ b/src/Backend/Modules/Extensions/Js/ThemeTemplate.js
@@ -39,7 +39,7 @@ jsBackend.template =
 
 		// fetch position & block index
 		var positionIndex = $(this).closest('.jsPosition').find('input[id^=position]').attr('id').replace('position', '');
-		var blockIndex = $(this).prevAll('.jsBlock').length;
+		var blockIndex = $(this).closest('.jsBlocks').find('.jsBlock').length;
 
 		// update for id & name
 		$('#type00', blockContainer).attr('id', 'type' + positionIndex + blockIndex).attr('name', 'type_' + positionIndex + '_' + blockIndex);
@@ -51,7 +51,7 @@ jsBackend.template =
 		}
 
 		// add to dom
-		blockContainer.insertAfter($(this).prevAll('.jsBlock').last());
+		blockContainer.insertAfter($(this).closest('.jsBlocks').find('.jsBlock').last());
 	},
 
 	/**

--- a/src/Backend/Modules/Extensions/Layout/Templates/AddThemeTemplate.html.twig
+++ b/src/Backend/Modules/Extensions/Layout/Templates/AddThemeTemplate.html.twig
@@ -125,8 +125,8 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div>
-                {{ 'msg.HelpPositionsLayout'|trans }}
+              <div class="help-block">
+                {{ 'msg.HelpPositionsLayoutText'|trans|raw }}
               </div>
             </div>
           </div>

--- a/src/Backend/Modules/Extensions/Layout/Templates/EditThemeTemplate.html.twig
+++ b/src/Backend/Modules/Extensions/Layout/Templates/EditThemeTemplate.html.twig
@@ -21,8 +21,11 @@
             <label for="file" class="control-label">{{ 'msg.PathToTemplate'|trans|capitalize }}</label>
             <label for="theme" class="hide">{{ 'lbl.Theme'|trans|capitalize }}</label>
             {% form_field_error theme %}
-            <small><code>/Core/Layout/Templates/</code>
-            </small>{% form_field file %} {% form_field theme %} {% form_field_error file %}
+            {% form_field theme %}
+            <small>
+              <code>/Core/Layout/Templates/</code>
+            </small>
+            {% form_field file %} {% form_field_error file %}
           </div>
           <div class="form-group">
             <label for="label" class="control-label">{{ 'lbl.Label'|trans|capitalize }}</label>

--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -271,7 +271,8 @@ class Add extends BackendBaseActionAdd
         $this->frm->addCheckbox('is_action', false);
 
         // extra
-        $this->frm->addDropdown('extra_type', BackendPagesModel::getTypes());
+        $blockTypes = BackendPagesModel::getTypes();
+        $this->frm->addDropdown('extra_type', $blockTypes, key($blockTypes));
 
         // meta
         $this->meta = new BackendMeta($this->frm, null, 'title', true);

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -424,7 +424,8 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addCheckbox('is_action', $isAction);
 
         // extra
-        $this->frm->addDropdown('extra_type', BackendPagesModel::getTypes());
+        $blockTypes = BackendPagesModel::getTypes();
+        $this->frm->addDropdown('extra_type', $blockTypes, key($blockTypes));
 
         // meta
         $this->meta = new BackendMeta($this->frm, $this->record['meta_id'], 'title', true);

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -395,7 +395,7 @@ jsBackend.pages.extras =
 		$('#extraType option[value=block]').attr('disabled', !enabled);
 
 		// set type
-		$('#extraType').val('html');
+		$('#extraType').val($('#extraType').val());
 		$('#extraExtraId').val(0);
 
 		// populate the modules

--- a/src/Frontend/Modules/Blog/Layout/Widgets/RecentComments.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Widgets/RecentComments.html.twig
@@ -13,9 +13,11 @@
         <ul>
           {% for comment in widgetBlogRecentComments %}
             <li>
-              {% if comment.website %}<a href="{{ comment.website }}" rel="nofollow">{% endif %}
+              {% if comment.website %}
+                <a href="{{ comment.website }}" rel="nofollow">{{ comment.author }}</a>
+              {% else %}
                 {{ comment.author }}
-                {% if comment.website %}</a>{% endif %}
+              {% endif %}
               {{ 'lbl.CommentedOn'|trans }} <a href="{{ comment.full_url }}">{{ comment.post_title }}</a>
             </li>
           {% endfor %}

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Login.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Login.html.twig
@@ -38,7 +38,7 @@
     </div>
     <footer class="ft">
       <p>
-        <a href="{{ geturlforblock:'Profiles':'ForgotPassword' }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a>
+        <a href="{{ geturlforblock('Profiles', 'ForgotPassword') }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a>
       </p>
     </footer>
   </div>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Profile.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Profile.html.twig
@@ -1,17 +1,17 @@
 <aside id="userActions">
   {% if isLoggedIn %}
-  <p>
-    <strong>{{ 'msg.WelcomeUserX'|trans|sprintf({$profileDisplayName }}})</strong>
-    <a href="{{ geturlforblock:'Profiles':'Settings' }}" title="{{ profileDisplayName }}">{{ 'lbl.ProfileSettings'|trans|capitalize }}</a>
-			<a href="{{ geturlforblock:'Profiles':'Logout' }}">{{ 'lbl.Logout'|trans|capitalize }}</a>
-		</p>
-	{% endif %}
+    <p>
+      <strong>{{ 'msg.WelcomeUserX'|trans|sprintf(profileDisplayName) }})</strong>
+      <a href="{{ geturlforblock('Profiles', 'Settings') }}" title="{{ profileDisplayName }}">{{ 'lbl.ProfileSettings'|trans|capitalize }}</a>
+      <a href="{{ geturlforblock('Profiles', 'Logout') }}">{{ 'lbl.Logout'|trans|capitalize }}</a>
+    </p>
+  {% endif %}
 
-	{% if not isLoggedIn %}
-		<p>
-			<a href="{{ geturlforblock:'Profiles':'Register' }}"><span class="icon pencilIcon"></span><span class="iconWrapper">{{ 'lbl.Register'|trans|capitalize }}</span></a>
-			<small> {{ 'lbl.Or'|trans }} </small>
-			<a href="{{ loginUrl }}"><span class="icon userIcon"></span><span class="iconWrapper">{{ 'lbl.Login'|trans|capitalize }}</span></a>
-		</p>
-	{% endif %}
+    {% if not isLoggedIn %}
+      <p>
+        <a href="{{ geturlforblock('Profiles', 'Register') }}"><span class="icon pencilIcon"></span><span class="iconWrapper">{{ 'lbl.Register'|trans|capitalize }}</span></a>
+        <small> {{ 'lbl.Or'|trans }} </small>
+        <a href="{{ loginUrl }}"><span class="icon userIcon"></span><span class="iconWrapper">{{ 'lbl.Login'|trans|capitalize }}</span></a>
+      </p>
+    {% endif %}
 </aside>

--- a/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
@@ -27,7 +27,7 @@
           {% form_field_error Email %}{% form_field Email %}
         </p>
         <p>
-          <a href="{{ geturlforblock:'Profiles':'ChangeEmail' }}">{{ 'msg.ChangeEmail'|trans }}</a>
+          <a href="{{ geturlforblock('Profiles', 'ChangeEmail') }}">{{ 'msg.ChangeEmail'|trans }}</a>
         </p>
         <p{% if txtFirstNameError %} class="errorArea"{% endif %}>
           <label for="firstName">{{ 'lbl.FirstName'|trans|capitalize }}</label>

--- a/src/Frontend/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Widgets/LoginBox.html.twig
@@ -41,7 +41,7 @@
       </div>
       <footer class="ft">
         <p>
-          <a href="{{ geturlforblock:'Profiles':'ForgotPassword' }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a>
+          <a href="{{ geturlforblock('Profiles', 'ForgotPassword') }}" title="{{ 'msg.ForgotPassword'|trans }}">{{ 'msg.ForgotPassword'|trans }}</a>
         </p>
       </footer>
     {% endif %}

--- a/src/Frontend/Modules/Profiles/Layout/Widgets/LoginLink.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Widgets/LoginLink.html.twig
@@ -6,8 +6,8 @@
 
 {% if isLoggedIn %}
   {{ 'msg.ProfilesLoggedInAs'|trans|sprintf({$profile.display_name }}:{{ profile.url.dashboard } }})
-  {% endif %}
+{% endif %}
 
-  {% if not isLoggedIn %}
-  <a href="{{ geturlforblock:'Profiles':'Login' }}?queryString={{ geturlforblock:'Profiles' }}">{{ 'lbl.Login'|trans|capitalize }}</a>
+{% if not isLoggedIn %}
+  <a href="{{ geturlforblock('Profiles', 'Login') }}?queryString={{ geturlforblock('Profiles') }}">{{ 'lbl.Login'|trans|capitalize }}</a>
 {% endif %}


### PR DESCRIPTION
Several small layout fixes. 


#### Summary
* I don't think `<a href="{{ geturlforblock:'Profiles':'Settings' }}"` has ever worked, doesn't look right? Syntax should be `<a href="{{ geturlforblock('Profiles', 'Settings') }}"`
* Indentation fixes + use spaces instead of tabs
* Move theme dropdown to the left of the template path: http://d.pr/i/18mRa
* When adding a new block in the theme template editor, it would add the new block on the first position. The way we calculate the current index is broken. Should be fixed now (proof): http://d.pr/v/1iqhX
* ~~Add a new template and you see a broken helper-text translation: http://d.pr/i/1a2yw~~ Seems already fixed by freshface in #1488
* When you add a new block (editor/module/widget) on a page, we used to have "editor" selected by default. Fixed that. Issue as seen here: http://d.pr/i/1iLkP

I'll leave this open for some days while I fix other issues I come along