### PR TITLE
Fixing bug in imageDelete when building the full path of the file

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -686,15 +686,15 @@ class Model extends \Common\Core\Model
         }
 
         $fs = new Filesystem();
-        foreach (array_keys($fileSizes) as $sizeDir) {
+        foreach ($fileSizes as $sizeDir) {
             $fullPath = FRONTEND_FILES_PATH . '/' . $module .
-                        (empty($subDirectory) ? '/' : $subDirectory . '/') . $sizeDir . '/' . $filename;
+                        (empty($subDirectory) ? '/' : '/' . $subDirectory . '/') . $sizeDir . '/' . $filename;
             if (is_file($fullPath)) {
                 $fs->remove($fullPath);
             }
         }
         $fullPath = FRONTEND_FILES_PATH . '/' . $module .
-                    (empty($subDirectory) ? '/' : $subDirectory . '/') . 'source/' . $filename;
+                    (empty($subDirectory) ? '/' : '/' . $subDirectory . '/') . 'source/' . $filename;
         if (is_file($fullPath)) {
             $fs->remove($fullPath);
         }


### PR DESCRIPTION
There is a `/` missing in front of the subdirectory if there is one specified
Also removed array keys, so that the passed array can just contain the names of the folders of the files sizes.
For example: `[ '64x64' ]` instead of `[ '64x64' => null ]`