### PR TITLE
Mark the output of format currency as safe so we can use non breaking spaces

### DIFF
--- a/src/Common/Core/Twig/Extensions/BaseTwigModifiers.php
+++ b/src/Common/Core/Twig/Extensions/BaseTwigModifiers.php
@@ -40,7 +40,7 @@ class BaseTwigModifiers
             default:
         }
 
-        return $currency.' '.number_format((float) $string, $decimals, ',', ' ');
+        return $currency.'&nbsp;'.number_format((float) $string, $decimals, ',', '&nbsp;');
     }
 
     /**

--- a/src/Common/Core/Twig/Extensions/TwigFilters.php
+++ b/src/Common/Core/Twig/Extensions/TwigFilters.php
@@ -31,7 +31,7 @@ class TwigFilters
         $twig->addFilter(new Twig_SimpleFilter('getpageinfo', $app.'::getPageInfo'));
         $twig->addFilter(new Twig_SimpleFilter('highlight', $app.'::highlightCode'));
         $twig->addFilter(new Twig_SimpleFilter('profilesetting', $app.'::profileSetting'));
-        $twig->addFilter(new Twig_SimpleFilter('formatcurrency', $app.'::formatCurrency'));
+        $twig->addFilter(new Twig_SimpleFilter('formatcurrency', $app.'::formatCurrency', ['is_safe' => ['html']]));
         $twig->addFilter(new Twig_SimpleFilter('usersetting', $app.'::userSetting'));
         $twig->addFilter(new Twig_SimpleFilter('uppercase', $app.'::uppercase'));
         $twig->addFilter(new Twig_SimpleFilter('trans', $app.'::trans'));

--- a/src/Frontend/Core/Tests/TemplateModifiersTest.php
+++ b/src/Frontend/Core/Tests/TemplateModifiersTest.php
@@ -11,27 +11,27 @@ class TemplateModifiersTest extends PHPUnit_Framework_TestCase
     public function test_format_currency()
     {
         $this->assertEquals(
-            '€ 1,23',
+            '€&nbsp;1,23',
             TemplateModifiers::formatCurrency(1.2324, 'EUR', 2)
         );
 
         $this->assertEquals(
-            '€ 1,23',
+            '€&nbsp;1,23',
             TemplateModifiers::formatCurrency(1.2324, 'EUR', null)
         );
 
         $this->assertEquals(
-            '€ 1',
+            '€&nbsp;1',
             TemplateModifiers::formatCurrency(1.2324, 'EUR', 0)
         );
 
         $this->assertEquals(
-            '€ 1,2324',
+            '€&nbsp;1,2324',
             TemplateModifiers::formatCurrency(1.2324, 'EUR', 4)
         );
 
         $this->assertEquals(
-            'USD 1,23',
+            'USD&nbsp;1,23',
             TemplateModifiers::formatCurrency(1.2324, 'USD')
         );
     }


### PR DESCRIPTION
fixes #1546 