### PR TITLE
Render each widget one at a time.

### DIFF
--- a/src/Frontend/Core/Engine/Base/Widget.php
+++ b/src/Frontend/Core/Engine/Base/Widget.php
@@ -173,10 +173,15 @@ class Widget extends Object
     /**
      * Get parsed template content
      *
+     * @param string $template
      * @return string
      */
-    public function getContent()
+    public function getContent($template = null)
     {
+        if ($template !== null) {
+            return $this->tpl->getContent($template);
+        }
+
         return $this->tpl->getContent($this->templatePath);
     }
 

--- a/src/Frontend/Core/Engine/Block/Widget.php
+++ b/src/Frontend/Core/Engine/Block/Widget.php
@@ -112,7 +112,8 @@ class Widget extends FrontendBaseObject
         }
 
         // call the execute method of the real action (defined in the module)
-        $this->output = $this->object->execute();
+        $this->object->execute();
+        $this->output = $this->render($this->getCustomTemplate());
     }
 
     /**
@@ -134,15 +135,25 @@ class Widget extends FrontendBaseObject
     }
 
     /**
-     * Get the block content
-     *
      * @return string
      */
     public function getContent()
     {
+        return $this->output;
+    }
+
+    /**
+     * Get the block content
+     *
+     * @param string $template
+     *
+     * @return string
+     */
+    public function render($template = null)
+    {
         // set path to template if the widget didn't return any data
         if ($this->output === null) {
-            return trim($this->object->getContent());
+            return trim($this->object->getContent($template));
         }
 
         // return possible output
@@ -157,6 +168,17 @@ class Widget extends FrontendBaseObject
     public function getData()
     {
         return $this->data;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCustomTemplate()
+    {
+        $data = @unserialize($this->data);
+        if (is_array($data) && array_key_exists('custom_template', $data)) {
+            return $this->module . '/Layout/Widgets/' . $data['custom_template'];
+        }
     }
 
     /**

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -386,7 +386,9 @@ class Page extends FrontendBaseObject
                     $positions[$position][$i]['blockIsHTML'] = $positions[$position][$i]['blockIsEditor'];
                 } else {
                     $positions[$position][$i] = $block;
-                    $positions[$position][$i]['html'] = $block['blockContent'];
+                    if (array_key_exists('blockContent', $block)) {
+                        $positions[$position][$i]['html'] = $block['blockContent'];
+                    }
                 }
             }
 

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -93,6 +93,12 @@ class TwigTemplate extends BaseTwigTemplate
         );
     }
 
+    /**
+     * @param string $template
+     * @param array $variables
+     *
+     * @return string
+     */
     public function render($template, array $variables = array())
     {
         if (!empty($this->forms)) {

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -149,15 +149,7 @@ class TwigTemplate extends BaseTwigTemplate
     {
         $template = $this->getPath($template);
 
-        $path = pathinfo($template);
         $this->templates[] = $template;
-
-        // collect the Widgets and Actions, we need them later
-        if (strpos($path['dirname'], 'Widgets') !== false) {
-            $this->widgets[$path['filename']] = $this->getPath($template);
-        } elseif (strpos($path['dirname'], 'Core/Layout/Templates') === false) {
-            $this->block = $this->getPath($template);
-        }
 
         if ($this->baseSpoonFile !== $template) {
             return $this->render(

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -54,13 +54,6 @@ class TwigTemplate extends BaseTwigTemplate
     private $baseFile;
 
     /**
-     * Base file location
-     *
-     * @var string
-     */
-    private $baseSpoonFile;
-
-    /**
      * The constructor will store the instance in the reference, preset some settings and map the custom modifiers.
      */
     public function __construct()
@@ -116,7 +109,6 @@ class TwigTemplate extends BaseTwigTemplate
         // page hook, last call
         if ($key === 'page') {
             $this->baseFile = $values['template_path'];
-            $this->baseSpoonFile = $values['template_path'];
         }
 
         parent::assign($key, $values);
@@ -151,17 +143,10 @@ class TwigTemplate extends BaseTwigTemplate
 
         $this->templates[] = $template;
 
-        if ($this->baseSpoonFile !== $template) {
-            return $this->render(
-                $template,
-                $this->variables
-            );
-        }
-
-        // only baseFile can start the render
-        if ($this->baseSpoonFile === $template) {
-            return $this->renderTemplate();
-        }
+        return $this->render(
+            $template,
+            $this->variables
+        );
     }
 
     public function render($template, array $variables = array())
@@ -179,22 +164,5 @@ class TwigTemplate extends BaseTwigTemplate
         }
 
         return $this->environment->render($template, $variables);
-    }
-
-    /**
-     * Renders the Page
-     *
-     * @param string $template path to render
-     *
-     * @return string
-     */
-    public function renderTemplate($template = null)
-    {
-        // template
-        if ($template === null) {
-            $template = $this->baseFile;
-        }
-
-        return $this->render($template, $this->variables);
     }
 }

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -61,16 +61,6 @@ class TwigTemplate extends BaseTwigTemplate
     }
 
     /**
-     * Returns the template type
-     *
-     * @return string Returns the template type
-     */
-    public function getTemplateType()
-    {
-        return 'twig';
-    }
-
-    /**
      * Convert a filename extension
      *
      * @param string $template

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -198,18 +198,11 @@ class TwigTemplate extends BaseTwigTemplate
      */
     public function renderTemplate($template = null)
     {
-        if (!empty($this->forms)) {
-            foreach ($this->forms as $form) {
-                // using assign to pass the form as global
-                $this->environment->addGlobal('form_' . $form->getName(), $form);
-            }
-        }
-
         // template
         if ($template === null) {
             $template = $this->baseFile;
         }
 
-        return $this->environment->render($template, $this->variables);
+        return $this->render($template, $this->variables);
     }
 }

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -61,11 +61,6 @@ class TwigTemplate extends BaseTwigTemplate
     private $baseSpoonFile;
 
     /**
-     * @var array
-     */
-    private $positions;
-
-    /**
      * The constructor will store the instance in the reference, preset some settings and map the custom modifiers.
      */
     public function __construct()
@@ -128,54 +123,6 @@ class TwigTemplate extends BaseTwigTemplate
     }
 
     /**
-     * From assign we capture the Core Page assign
-     * so we could rebuild the positions with included
-     * module Path for widgets and actions
-     *
-     * I must admit this is ugly
-     *
-     * @param array $positions
-     *
-     * @return array
-     */
-    private function setPositions(array $positions)
-    {
-        /*foreach ($positions as &$blocks) {
-            foreach ($blocks as &$block) {
-                // skip html
-                if (!empty($block['html'])) {
-                    continue;
-                }
-
-                $block['extra_data'] = @unserialize($block['extra_data']);
-
-                // legacy search the correct module path
-                if ($block['extra_type'] === 'widget' && $block['extra_action']) {
-                    if (isset($block['extra_data']['template'])) {
-                        $tpl = substr($block['extra_data']['template'], 0, -5);
-                        $block['include_path'] = $this->widgets[$tpl];
-                    } elseif (isset($block['extra_data']['custom_template'])) {
-                        // make content blocks work again
-                        $block['include_path'] = $this->getPath(
-                            $block['extra_module'] . '/Layout/Widgets/' . $block['extra_data']['custom_template']
-                        );
-                    } else {
-                        $block['include_path'] = $this->getPath(
-                            $block['extra_module'] . '/Layout/Widgets/' . $block['extra_action'] . '.html.twig'
-                        );
-                    }
-
-                // main action block
-                } else {
-                    $block['include_path'] = $this->block;
-                }
-            }
-        }
-
-        return $positions;*/
-    }
-
-    /**
      * Convert a filename extension
      *
      * @param string $template
@@ -234,11 +181,6 @@ class TwigTemplate extends BaseTwigTemplate
             }
         }
 
-        // set the positions array
-        if (!empty($this->positions)) {
-            $this->environment->addGlobal('positions', $this->setPositions($this->positions));
-        }
-
         // template
         if ($template === null) {
             $template = $this->baseFile;
@@ -261,11 +203,6 @@ class TwigTemplate extends BaseTwigTemplate
                 // using assign to pass the form as global
                 $this->environment->addGlobal('form_' . $form->getName(), $form);
             }
-        }
-
-        // set the positions array
-        if (!empty($this->positions)) {
-            $this->environment->addGlobal('positions', $this->positions);
         }
 
         // template

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -19,39 +19,11 @@ use Common\Core\Twig\Extensions\TwigFilters;
 class TwigTemplate extends BaseTwigTemplate
 {
     /**
-     * List of passed templates
-     *
-     * @var array
-     */
-    private $templates = array();
-
-    /**
-     * List of passed widgets
-     *
-     * @var array
-     */
-    private $widgets = array();
-
-    /**
-     * main action block
-     *
-     * @var array
-     */
-    private $block = '';
-
-    /**
      * theme path location
      *
      * @var string
      */
     private $themePath;
-
-    /**
-     * Base file location
-     *
-     * @var string
-     */
-    private $baseFile;
 
     /**
      * The constructor will store the instance in the reference, preset some settings and map the custom modifiers.
@@ -99,22 +71,6 @@ class TwigTemplate extends BaseTwigTemplate
     }
 
     /**
-     * Spoon assign method
-     *
-     * @param string $key
-     * @param mixed $values
-     */
-    public function assign($key, $values = null)
-    {
-        // page hook, last call
-        if ($key === 'page') {
-            $this->baseFile = $values['template_path'];
-        }
-
-        parent::assign($key, $values);
-    }
-
-    /**
      * Convert a filename extension
      *
      * @param string $template
@@ -141,8 +97,6 @@ class TwigTemplate extends BaseTwigTemplate
     {
         $template = $this->getPath($template);
 
-        $this->templates[] = $template;
-
         return $this->render(
             $template,
             $this->variables
@@ -156,11 +110,6 @@ class TwigTemplate extends BaseTwigTemplate
                 // using assign to pass the form as global
                 $this->environment->addGlobal('form_' . $form->getName(), $form);
             }
-        }
-
-        // template
-        if ($template === null) {
-            $template = $this->baseFile;
         }
 
         return $this->environment->render($template, $variables);

--- a/src/Frontend/Core/Layout/Templates/Default.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Default.html.twig
@@ -42,8 +42,6 @@
             </div>
           </div>
         </section>
-      {% else %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </section>

--- a/src/Frontend/Core/Layout/Templates/Home.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Home.html.twig
@@ -42,8 +42,6 @@
             </div>
           </div>
         </section>
-      {% elseif main.include_path %}
-        {% include main.include_path %}
       {% endif %}
     {% endfor %}
   </section>

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Default.html.twig
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Default.html.twig
@@ -33,8 +33,6 @@
       {% for top in positions.top %}
         {% if top.html %}
           {{ top.html|raw }}
-        {% elseif top.include_path %}
-          {% include top.include_path %}
         {% endif %}
       {% endfor %}
 
@@ -50,8 +48,6 @@
           <div id="headerAd">
             {{ advertisement.html|raw }}
           </div>
-        {% elseif advertisement.include_path %}
-          {% include advertisement.include_path %}
         {% endif %}
       {% endfor %}
     </div>
@@ -79,8 +75,6 @@
                 </div>
               </div>
             </section>
-          {% elseif left.include_path %}
-            {% include left.include_path %}
           {% endif %}
         {% endfor %}
 
@@ -106,8 +100,6 @@
                 </div>
               </div>
             </section>
-          {% else %}
-            {% include main.include_path %}
           {% endif %}
         {% endfor %}
       </div>

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Home.html.twig
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Home.html.twig
@@ -33,8 +33,6 @@
       {% for top in positions.top %}
         {% if top.html %}
           {{ top.html|raw }}
-        {% elseif top.include_path %}
-          {% include top.include_path %}
         {% endif %}
       {% endfor %}
 
@@ -50,8 +48,6 @@
           <div id="headerAd">
             {{ advertisement.html|raw }}
           </div>
-        {% elseif advertisement.include_path %}
-          {% include advertisement.include_path %}
         {% endif %}
       {% endfor %}
 
@@ -81,8 +77,6 @@
                 </div>
               </div>
             </section>
-          {% elseif main.include_path %}
-            {% include main.include_path %}
           {% endif %}
         {% endfor %}
 
@@ -101,8 +95,6 @@
                 </div>
               </div>
             </section>
-          {% elseif left.include_path %}
-            {% include left.include_path %}
           {% endif %}
         {% endfor %}
 
@@ -121,8 +113,6 @@
                 </div>
               </div>
             </section>
-          {% elseif right.include_path %}
-            {% include right.include_path %}
           {% endif %}
         {% endfor %}
 


### PR DESCRIPTION
Previously, we added all variables first and then rendered one template
with includes. This resulted in errors when multiple instances of the
same widget but with different content were shown on one page.

As another good side effect, this fixes the infinite loop when we have
widgets containing random data.

Fixes #1564, #1498 and #1470