### PR TITLE
Use |raw for pagetitle to avoid html entities

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Navigation.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Navigation.html.twig
@@ -2,7 +2,7 @@
   <ul>
     {% for nav in navigation %}
       <li{% if nav.selected %} class="selected"{% endif %}>
-        <a href="{{ nav.link }}" title="{{ nav.navigation_title }}"{% if nav.nofollow %} rel="nofollow"{% endif %}>{{ nav.navigation_title }}</a>
+        <a href="{{ nav.link }}" title="{{ nav.navigation_title }}"{% if nav.nofollow %} rel="nofollow"{% endif %}>{{ nav.navigation_title|raw }}</a>
         {% if nav.selected %}{{ nav.children|raw }}{% endif %}
       </li>
     {% endfor %}

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Default.html.twig
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Default.html.twig
@@ -86,7 +86,7 @@
         {# Page title #}
         {% if not hideContentTitle %}
           <header class="mainTitle">
-            <h1>{{ page.title }}</h1>
+            <h1>{{ page.title|raw }}</h1>
           </header>
         {% endif %}
 

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Head.html.twig
@@ -7,7 +7,7 @@
   {{ meta|raw }}
   {{ metaCustom|raw }}
 
-  <title>{{ pageTitle }}</title>
+  <title>{{ pageTitle|raw }}</title>
 
   {# Favicon and Apple touch icon #}
   <link rel="shortcut icon" href="{{ THEME_URL }}/favicon.ico" />

--- a/src/Frontend/Themes/triton/Core/Layout/Templates/Home.html.twig
+++ b/src/Frontend/Themes/triton/Core/Layout/Templates/Home.html.twig
@@ -63,7 +63,7 @@
         {# Page title #}
         {% if not hideContentTitle %}
           <header class="mainTitle">
-            <h1>{{ page.title }}</h1>
+            <h1>{{ page.title|raw }}</h1>
           </header>
         {% endif %}
 


### PR DESCRIPTION
If you use a pagetitle "Test & Test", it would render as "Test &amp; Test" in the triton theme