### PR TITLE
Hide the notification after the css animation has finished

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -1743,7 +1743,7 @@ jsBackend.messages =
     // hide a message
     hide: function (element) {
         // fade out
-        element.removeClass('active');
+        element.removeClass('active').delay(250).hide(1);
     },
 
     // add a new message into the que


### PR DESCRIPTION
This will solve the problem that the notification stayed as an invisible overlay.
fixes #1578