### PR TITLE
Only show the tags tab when the user has permission

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -9,6 +9,7 @@ namespace Backend\Modules\Pages\Actions;
  * file that was distributed with this source code.
  */
 
+use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Base\ActionAdd as BackendBaseActionAdd;
 use Backend\Core\Engine\Authentication as BackendAuthentication;
 use Backend\Core\Engine\Form as BackendForm;
@@ -259,8 +260,10 @@ class Add extends BackendBaseActionAdd
         $this->frm->addCheckbox('navigation_title_overwrite');
         $this->frm->addText('navigation_title');
 
-        // tags
-        $this->frm->addText('tags', null, null, 'form-control js-tags-input', 'form-control danger js-tags-input');
+        if ($this->showTags()) {
+            // tags
+            $this->frm->addText('tags', null, null, 'form-control js-tags-input', 'form-control danger js-tags-input');
+        }
 
         // a specific action
         $this->frm->addCheckbox('is_action', false);
@@ -291,6 +294,7 @@ class Add extends BackendBaseActionAdd
         $this->tpl->assign('extrasById', json_encode(BackendExtensionsModel::getExtras()));
         $this->tpl->assign('prefixURL', rtrim(BackendPagesModel::getFullURL(1), '/'));
         $this->tpl->assign('formErrors', (string) $this->frm->getErrors());
+        $this->tpl->assign('showTags', $this->showTags());
 
         // get default template id
         $defaultTemplateId = $this->get('fork.settings')->get('Pages', 'default_template', 1);
@@ -438,12 +442,14 @@ class Add extends BackendBaseActionAdd
                 // trigger an event
                 BackendModel::triggerEvent($this->getModule(), 'after_add', $page);
 
-                // save tags
-                BackendTagsModel::saveTags(
-                    $page['id'],
-                    $this->frm->getField('tags')->getValue(),
-                    $this->URL->getModule()
-                );
+                if ($this->showTags()) {
+                    // save tags
+                    BackendTagsModel::saveTags(
+                        $page['id'],
+                        $this->frm->getField('tags')->getValue(),
+                        $this->URL->getModule()
+                    );
+                }
 
                 // build the cache
                 BackendPagesModel::buildCache(BL::getWorkingLanguage());
@@ -485,5 +491,21 @@ class Add extends BackendBaseActionAdd
                 }
             }
         }
+    }
+
+    /**
+     * Check if the user has the right to see/edit tags
+     *
+     * @return bool
+     */
+    private function showTags()
+    {
+        if (!Authentication::isAllowedAction('Edit', 'Tags')
+            || !Authentication::isAllowedAction('GetAllTags', 'Tags')
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -9,6 +9,7 @@ namespace Backend\Modules\Pages\Actions;
  * file that was distributed with this source code.
  */
 
+use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Base\ActionEdit as BackendBaseActionEdit;
 use Backend\Core\Engine\Authentication as BackendAuthentication;
 use Backend\Core\Engine\DataGridDB as BackendDataGridDB;
@@ -405,14 +406,16 @@ class Edit extends BackendBaseActionEdit
         $this->frm->addCheckbox('navigation_title_overwrite', ($this->record['navigation_title_overwrite'] == 'Y'));
         $this->frm->addText('navigation_title', $this->record['navigation_title']);
 
-        // tags
-        $this->frm->addText(
-            'tags',
-            BackendTagsModel::getTags($this->URL->getModule(), $this->id),
-            null,
-            'form-control js-tags-input',
-            'error js-tags-input'
-        );
+        if ($this->showTags()) {
+            // tags
+            $this->frm->addText(
+                'tags',
+                BackendTagsModel::getTags($this->URL->getModule(), $this->id),
+                null,
+                'form-control js-tags-input',
+                'error js-tags-input'
+            );
+        }
 
         // a specific action
         $isAction = (isset($this->record['data']['is_action']) && $this->record['data']['is_action'] == true) ? true : false;
@@ -516,6 +519,7 @@ class Edit extends BackendBaseActionEdit
         $this->tpl->assign('extrasById', json_encode(BackendExtensionsModel::getExtras()));
         $this->tpl->assign('prefixURL', rtrim(BackendPagesModel::getFullURL($this->record['parent_id']), '/'));
         $this->tpl->assign('formErrors', (string) $this->frm->getErrors());
+        $this->tpl->assign('showTags', $this->showTags());
 
         // init var
         $showDelete = true;
@@ -682,12 +686,14 @@ class Edit extends BackendBaseActionEdit
                 // trigger an event
                 BackendModel::triggerEvent($this->getModule(), 'after_edit', array('item' => $page));
 
-                // save tags
-                BackendTagsModel::saveTags(
-                    $page['id'],
-                    $this->frm->getField('tags')->getValue(),
-                    $this->URL->getModule()
-                );
+                if ($this->showTags()) {
+                    // save tags
+                    BackendTagsModel::saveTags(
+                        $page['id'],
+                        $this->frm->getField('tags')->getValue(),
+                        $this->URL->getModule()
+                    );
+                }
 
                 // build cache
                 BackendPagesModel::buildCache(BL::getWorkingLanguage());
@@ -729,5 +735,21 @@ class Edit extends BackendBaseActionEdit
                 }
             }
         }
+    }
+
+    /**
+     * Check if the user has the right to see/edit tags
+     *
+     * @return bool
+     */
+    private function showTags()
+    {
+        if (!Authentication::isAllowedAction('Edit', 'Tags')
+            || !Authentication::isAllowedAction('GetAllTags', 'Tags')
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -53,9 +53,11 @@
           <li class="pull-right" role="presentation">
             <a href="#tabRedirect" aria-controls="messages" role="tab" data-toggle="tab">{{ 'lbl.Redirect'|trans|ucfirst }}</a>
           </li>
-          <li class="pull-right" role="presentation">
-            <a href="#tabTags" aria-controls="settings" role="tab" data-toggle="tab">{{ 'lbl.Tags'|trans|ucfirst }}</a>
-          </li>
+          {% if showTags %}
+            <li class="pull-right" role="presentation">
+              <a href="#tabTags" aria-controls="settings" role="tab" data-toggle="tab">{{ 'lbl.Tags'|trans|ucfirst }}</a>
+            </li>
+          {% endif %}
           <li class="pull-right" role="presentation">
             <a href="#tabSEO" aria-controls="settings" role="tab" data-toggle="tab">{{ 'lbl.SEO'|trans|ucfirst }}</a>
           </li>
@@ -168,14 +170,16 @@
               </div>
             </div>
           </div>
-          <div role="tabpanel" class="tab-pane" id="tabTags">
-            <div class="row">
-              <div class="col-md-12">
-                <p class="tab-pane-title">{{ 'msg.AddTagsHere'|trans }}</p>
-                {% form_field_error tags %} {% form_field tags %}
+          {% if showTags %}
+            <div role="tabpanel" class="tab-pane" id="tabTags">
+              <div class="row">
+                <div class="col-md-12">
+                  <p class="tab-pane-title">{{ 'msg.AddTagsHere'|trans }}</p>
+                  {% form_field_error tags %} {% form_field tags %}
+                </div>
               </div>
             </div>
-          </div>
+          {% endif %}
           <div role="tabpanel" class="tab-pane" id="tabSEO">
             {% seo %}
           </div>

--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -66,9 +66,11 @@
           <li class="pull-right" role="presentation">
             <a href="#tabRedirect" aria-controls="redirect" role="tab" data-toggle="tab">{{ 'lbl.Redirect'|trans|ucfirst }}</a>
           </li>
-          <li class="pull-right" role="presentation">
-            <a href="#tabTags" aria-controls="tags" role="tab" data-toggle="tab">{{ 'lbl.Tags'|trans|ucfirst }}</a>
-          </li>
+          {% if showTags %}
+            <li class="pull-right" role="presentation">
+              <a href="#tabTags" aria-controls="tags" role="tab" data-toggle="tab">{{ 'lbl.Tags'|trans|ucfirst }}</a>
+            </li>
+          {% endif %}
           <li class="pull-right" role="presentation">
             <a href="#tabSEO" aria-controls="seo" role="tab" data-toggle="tab">{{ 'lbl.SEO'|trans|ucfirst }}</a>
           </li>
@@ -229,14 +231,16 @@
               </div>
             </div>
           </div>
-          <div role="tabpanel" class="tab-pane" id="tabTags">
-            <div class="row">
-              <div class="col-md-12">
-                <p class="tab-pane-title">{{ 'msg.AddTagsHere'|trans }}</p>
-                {% form_field_error tags %} {% form_field tags %}
+          {% if showTags %}
+            <div role="tabpanel" class="tab-pane" id="tabTags">
+              <div class="row">
+                <div class="col-md-12">
+                  <p class="tab-pane-title">{{ 'msg.AddTagsHere'|trans }}</p>
+                  {% form_field_error tags %} {% form_field tags %}
+                </div>
               </div>
             </div>
-          </div>
+          {% endif %}
           <div role="tabpanel" class="tab-pane" id="tabSEO">
             {% seo %}
           </div>


### PR DESCRIPTION
If the user had permission to edit/add pages but no access to the tags module
an alert with the error module not allowed was shown.
This was because the ajax call to get the tags would fail.
Now we only show that tabs if the user has sufficient permissions.

fixes #1562