### PR TITLE
Fix install module button showing after module is installed

### DIFF
--- a/src/Backend/Modules/Extensions/Actions/DetailModule.php
+++ b/src/Backend/Modules/Extensions/Actions/DetailModule.php
@@ -150,7 +150,7 @@ class DetailModule extends BackendBaseActionIndex
         $this->tpl->assign('name', $this->currentModule);
         $this->tpl->assign('warnings', $this->warnings);
         $this->tpl->assign('information', $this->information);
-        $this->tpl->assign('showExtensionsInstallModule', !BackendModel::isModuleInstalled($this->currentModule) && BackendAuthentication::isAllowedAction('InstallModule'));
+        $this->tpl->assign('showInstallButton', !BackendModel::isModuleInstalled($this->currentModule) && BackendAuthentication::isAllowedAction('InstallModule'));
 
         // data grids
         $this->tpl->assign('dataGridEvents', (isset($this->dataGridEvents) && $this->dataGridEvents->getNumResults() > 0) ? $this->dataGridEvents->getContent() : false);

--- a/src/Backend/Modules/Extensions/Layout/Templates/DetailModule.html.twig
+++ b/src/Backend/Modules/Extensions/Layout/Templates/DetailModule.html.twig
@@ -95,7 +95,7 @@
       </div>
     </div>
   {% endif %}
-  {% if showExtensionsInstallModule %}
+  {% if showInstallButton %}
     <div class="row fork-module-actions">
       <div class="col-md-12">
         <div class="btn-toolbar">


### PR DESCRIPTION
The check for this was overwritten by the permission of the install action
fixes #1601