### PR TITLE
Add profiles SecurePage widget

### DIFF
--- a/src/Backend/Modules/Profiles/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Profiles/Installer/Data/locale.xml
@@ -808,6 +808,12 @@
         <translation language="ru"><![CDATA[войдите ссылку]]></translation>
         <translation language="de"><![CDATA[Login-Link]]></translation>
       </item>
+      <item type="label" name="SecurePage">
+        <translation language="nl"><![CDATA[beveiligde pagina]]></translation>
+        <translation language="en"><![CDATA[secure page]]></translation>
+        <translation language="fr"><![CDATA[page sécurisée]]></translation>
+        <translation language="de"><![CDATA[sichere Seite]]></translation>
+      </item>
     </Core>
   </Backend>
   <Frontend>

--- a/src/Backend/Modules/Profiles/Installer/Installer.php
+++ b/src/Backend/Modules/Profiles/Installer/Installer.php
@@ -132,6 +132,7 @@ class Installer extends ModuleInstaller
 
         $this->insertExtra('Profiles', 'widget', 'LoginBox', 'LoginBox', null, 'N', 5010);
         $this->insertExtra('Profiles', 'widget', 'LoginLink', 'LoginLink', null, 'N', 5011);
+        $this->insertExtra('Profiles', 'widget', 'SecurePage', 'SecurePage', null, 'N', 5012);
 
         // get search widget id
         $searchId = (int) $this->getDB()->getVar(

--- a/src/Frontend/Modules/Profiles/Layout/Widgets/SecurePage.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Widgets/SecurePage.html.twig
@@ -1,0 +1,3 @@
+{#
+  This widget checks if a user is logged in, before accessing a page. It does not need a template.
+#}

--- a/src/Frontend/Modules/Profiles/Widgets/LoginLink.php
+++ b/src/Frontend/Modules/Profiles/Widgets/LoginLink.php
@@ -38,9 +38,6 @@ class LoginLink extends FrontendBaseWidget
         // is logged in
         if (FrontendProfilesAuthentication::isLoggedIn()) {
             // get the profile
-            /**
-             * @var FrontendProfilesProfile
-             */
             $profile = FrontendProfilesAuthentication::getProfile();
 
             // assign logged in profile

--- a/src/Frontend/Modules/Profiles/Widgets/SecurePage.php
+++ b/src/Frontend/Modules/Profiles/Widgets/SecurePage.php
@@ -30,9 +30,10 @@ class SecurePage extends FrontendBaseWidget
 
         // Check if we're logged in, else redirect to the login form.
         if (!FrontendProfilesAuthentication::isLoggedIn()) {
+            $queryString = $this->URL->getQueryString();
             throw new RedirectException(
                 'Redirect',
-                new RedirectResponse(Navigation::getURLForBlock('Profiles', 'Login'))
+                new RedirectResponse(Navigation::getURLForBlock('Profiles', 'Login') . '?queryString=' . $queryString)
             );
         }
     }

--- a/src/Frontend/Modules/Profiles/Widgets/SecurePage.php
+++ b/src/Frontend/Modules/Profiles/Widgets/SecurePage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Frontend\Modules\Profiles\Widgets;
+
+/*
+ * This file is part of Fork CMS.
+ *
+ * For the full copyright and license information, please view the license
+ * file that was distributed with this source code.
+ */
+
+use Common\Exception\RedirectException;
+use Frontend\Core\Engine\Base\Widget as FrontendBaseWidget;
+use Frontend\Core\Engine\Navigation;
+use Frontend\Modules\Profiles\Engine\Authentication as FrontendProfilesAuthentication;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * This is a widget to help you secure a page and make it only accessible for logged-in users.
+ */
+class SecurePage extends FrontendBaseWidget
+{
+    /**
+     * Execute the extra
+     */
+    public function execute()
+    {
+        parent::execute();
+        $this->loadTemplate();
+
+        // Check if we're logged in, else redirect to the login form.
+        if (!FrontendProfilesAuthentication::isLoggedIn()) {
+            throw new RedirectException(
+                'Redirect',
+                new RedirectResponse(Navigation::getURLForBlock('Profiles', 'Login'))
+            );
+        }
+    }
+}


### PR DESCRIPTION
If you have a normal page with some content on it, there's currently no easy way (as far as I know) to make the page only accessible for logged in users. I was creating something like this in a project, when someone asked me why this wasn't part of the profiles module yet, so here goes a PR...

This small widget can be added anywhere on a page and will check if a user is logged in, else it redirects to the login form.