### PR TITLE
Fix link in cookie bar text in triton theme

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Cookies.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Cookies.html.twig
@@ -1,6 +1,6 @@
 {% if not cookieBarHide %}
   <div id="cookieBar" class="fullWidthAlert alert">
-    {{ 'msg.CookiesWarning'|trans }}
+    {{ 'msg.CookiesWarning'|trans|raw }}
     <a href="#" id="cookieBarAgree">{{ 'lbl.IAgree'|trans|ucfirst }}</a>
     <a href="#" id="cookieBarDisagree">{{ 'lbl.IDisagree'|trans|ucfirst }}</a>
   </div>


### PR DESCRIPTION
Link in cookie bar doesn't work without raw modifier: https://cloudup.com/c8TdsI6L_g8