### PR TITLE
Limit depth when fetching thumbnail folders.

### DIFF
--- a/src/Common/Core/Model.php
+++ b/src/Common/Core/Model.php
@@ -193,7 +193,7 @@ class Model extends \BaseModel
             $finder->name('source');
         }
 
-        foreach ($finder->directories()->in($path) as $directory) {
+        foreach ($finder->directories()->in($path)->depth('== 0') as $directory) {
             $chunks = explode('x', $directory->getBasename(), 2);
             if (count($chunks) != 2 && !$includeSource) {
                 continue;


### PR DESCRIPTION
In a directory containing 50.000 files, fetching the thumbnail folders took over 10 seconds.
Note that storing 50.000 files in one folder is very bad, but this shouldn't affect this method.