### PR TITLE
Make the formatCurrency modifier use formatNumber. Fixes #1531

### DIFF
--- a/src/Backend/Core/Engine/TemplateModifiers.php
+++ b/src/Backend/Core/Engine/TemplateModifiers.php
@@ -50,21 +50,24 @@ class TemplateModifiers extends BaseTwigModifiers
 
     /**
      * Format a number
-     * syntax: {$var|formatnumber}
+     *    syntax: {{ $string|formatnumber($decimals) }}
      *
-     * @param float $var The number to format.
+     * @param float $number The number to format.
+     * @param int $decimals The number of decimals
      *
      * @return string
      */
-    public static function formatNumber($var)
+    public static function formatNumber($number, $decimals = null)
     {
-        $var = (float) $var;
+        $number = (float) $number;
 
         // get setting
         $format = Authentication::getUser()->getSetting('number_format', 'dot_nothing');
 
         // get amount of decimals
-        $decimals = (mb_strpos($var, '.') ? mb_strlen(mb_substr($var, mb_strpos($var, '.') + 1)) : 0);
+        if ($decimals === null) {
+            $decimals = (mb_strpos($number, '.') ? mb_strlen(mb_substr($number, mb_strpos($number, '.') + 1)) : 0);
+        }
 
         // get separators
         $separators = explode('_', $format);
@@ -77,7 +80,7 @@ class TemplateModifiers extends BaseTwigModifiers
         );
 
         // format the number
-        return number_format($var, $decimals, $decimalSeparator, $thousandsSeparator);
+        return number_format($number, $decimals, $decimalSeparator, $thousandsSeparator);
     }
 
     /**

--- a/src/Common/Core/Twig/Extensions/BaseTwigModifiers.php
+++ b/src/Common/Core/Twig/Extensions/BaseTwigModifiers.php
@@ -37,7 +37,24 @@ class BaseTwigModifiers
             default:
         }
 
-        return $currency.'&nbsp;'.number_format((float) $string, $decimals, ',', '&nbsp;');
+        return $currency.'&nbsp;'.static::formatNumber($string, $decimals);
+    }
+
+    /**
+     * Fallback for if our parent functions don't implement this method
+     *
+     * @param string $number
+     * @param int $decimals
+     *
+     * @return string
+     */
+    public static function formatNumber($number, $decimals = null)
+    {
+        if ($decimals === null) {
+            $decimals = 2;
+        }
+
+        return number_format((float) $number, $decimals, ',', '&nbsp;');
     }
 
     /**

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -35,13 +35,14 @@ class TemplateModifiers extends BaseTwigModifiers
 
     /**
      * Format a number
-     *    syntax: {{ $string|formatnumber }}
+     *    syntax: {{ $string|formatnumber($decimals) }}
      *
      * @param float $string The number to format.
+     * @param int $decimals The number of decimals
      *
      * @return string
      */
-    public static function formatNumber($string)
+    public static function formatNumber($string, $decimals = null)
     {
         // redefine
         $string = (float) $string;
@@ -50,7 +51,9 @@ class TemplateModifiers extends BaseTwigModifiers
         $format = FrontendModel::get('fork.settings')->get('Core', 'number_format');
 
         // get amount of decimals
-        $decimals = (mb_strpos($var, '.') ? mb_strlen(mb_substr($var, mb_strpos($var, '.') + 1)) : 0);
+        if ($decimals === null) {
+            $decimals = (mb_strpos($string, '.') ? mb_strlen(mb_substr($string, mb_strpos($string, '.') + 1)) : 0);
+        }
 
         // get separators
         $separators = explode('_', $format);

--- a/src/Frontend/Core/Tests/TemplateModifiersTest.php
+++ b/src/Frontend/Core/Tests/TemplateModifiersTest.php
@@ -8,34 +8,6 @@ use PHPUnit_Framework_TestCase;
 
 class TemplateModifiersTest extends PHPUnit_Framework_TestCase
 {
-    public function test_format_currency()
-    {
-        $this->assertEquals(
-            '€&nbsp;1,23',
-            TemplateModifiers::formatCurrency(1.2324, 'EUR', 2)
-        );
-
-        $this->assertEquals(
-            '€&nbsp;1,23',
-            TemplateModifiers::formatCurrency(1.2324, 'EUR', null)
-        );
-
-        $this->assertEquals(
-            '€&nbsp;1',
-            TemplateModifiers::formatCurrency(1.2324, 'EUR', 0)
-        );
-
-        $this->assertEquals(
-            '€&nbsp;1,2324',
-            TemplateModifiers::formatCurrency(1.2324, 'EUR', 4)
-        );
-
-        $this->assertEquals(
-            'USD&nbsp;1,23',
-            TemplateModifiers::formatCurrency(1.2324, 'USD')
-        );
-    }
-
     public function test_format_float()
     {
         $this->assertEquals(


### PR DESCRIPTION
This way, the configured number format is used instead of a default one.

Note that I didn't add localizedcurrency yet, since this adds a lot of new features which shouldn't be added in a bugfix release.