### PR TITLE
Fix the error logging using swiftmailer. Fixes #1576

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -36,7 +36,9 @@ monolog:
         #     from_email: %fork.debug_email%
         #     to_email:   %fork.debug_email%
         #     subject:    %site.default_title% %fork.debug_message%
-        #     level:      critical
+        #     level:      error
+        #     formatter:  monolog.formatter.html
+        #     content_type: text/html
 
 swiftmailer:
     transport: "mail"


### PR DESCRIPTION
The needed config for sending error mails using swiftmailer has changed.
http://symfony.com/doc/2.8/cookbook/logging/monolog_email.html