### PR TITLE
Only show the successMessage when the form itself is submitted.

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -303,6 +303,7 @@ class Form extends FrontendBaseWidget
         $formName = 'form' . $this->item['id'];
         $this->tpl->assign('formName', $formName);
         $this->tpl->assign('formAction', $this->createAction() . '#' . $formName);
+        $this->tpl->assign('successMessage', false);
 
         // got fields
         if (!empty($this->fieldsHTML)) {


### PR DESCRIPTION
The widgets still share some data, since we still assign all variables
to one template. This makes sure we don't have the success message
anymore if the first formBuilder is submitted and the second isn't.

Fixes #1637 