### PR TITLE
Make sure widgets and blocks don't interfere with each other. Fixes #1637

### DIFF
--- a/src/Common/Core/Twig/BaseTwigTemplate.php
+++ b/src/Common/Core/Twig/BaseTwigTemplate.php
@@ -146,13 +146,8 @@ abstract class BaseTwigTemplate extends TwigEngine
         // remove protected constants aka constants that should not be used in the template
         foreach ($constants['user'] as $key => $value) {
             if (!in_array($key, $notPublicConstants)) {
-                $realConstants[$key] = $value;
+                $twig->addGlobal($key, $value);
             }
-        }
-
-        // we should only assign constants if there are constants to assign
-        if (!empty($realConstants)) {
-            $this->assignArray($realConstants);
         }
 
         /* Setup Backend for the Twig environment. */

--- a/src/Frontend/Core/Engine/Breadcrumb.php
+++ b/src/Frontend/Core/Engine/Breadcrumb.php
@@ -142,6 +142,6 @@ class Breadcrumb extends FrontendBaseObject
     public function parse()
     {
         // assign
-        $this->tpl->assign('breadcrumb', $this->items);
+        $this->tpl->addGlobal('breadcrumb', $this->items);
     }
 }

--- a/src/Frontend/Core/Engine/Footer.php
+++ b/src/Frontend/Core/Engine/Footer.php
@@ -34,7 +34,7 @@ class Footer extends FrontendBaseObject
     public function parse()
     {
         $footerLinks = (array) Navigation::getFooterLinks();
-        $this->tpl->assign('footerLinks', $footerLinks);
+        $this->tpl->addGlobal('footerLinks', $footerLinks);
 
         $siteHTMLFooter = (string) $this->get('fork.settings')->get('Core', 'site_html_footer', null);
 
@@ -57,7 +57,7 @@ class Footer extends FrontendBaseObject
         }
 
         // assign site wide html
-        $this->tpl->assign('siteHTMLFooter', $siteHTMLFooter);
+        $this->tpl->addGlobal('siteHTMLFooter', $siteHTMLFooter);
     }
 
     /**

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -597,8 +597,8 @@ class Header extends FrontendBaseObject
         $this->parseJS();
         $this->parseCustomHeaderHTMLAndGoogleAnalytics();
 
-        $this->tpl->assign('pageTitle', (string) $this->getPageTitle());
-        $this->tpl->assign(
+        $this->tpl->addGlobal('pageTitle', (string) $this->getPageTitle());
+        $this->tpl->addGlobal(
             'siteTitle',
             (string) $this->get('fork.settings')->get('Core', 'site_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE)
         );
@@ -625,7 +625,7 @@ class Header extends FrontendBaseObject
             }
         }
 
-        $this->tpl->assign('cssFiles', $cssFiles);
+        $this->tpl->addGlobal('cssFiles', $cssFiles);
     }
 
     /**
@@ -676,7 +676,7 @@ class Header extends FrontendBaseObject
         $siteHTMLHeader .= "\n" . '<script>var jsData = ' . $jsData . '</script>';
 
         // assign site wide html
-        $this->tpl->assign('siteHTMLHeader', trim($siteHTMLHeader));
+        $this->tpl->addGlobal('siteHTMLHeader', trim($siteHTMLHeader));
     }
 
     /**
@@ -800,7 +800,7 @@ class Header extends FrontendBaseObject
             }
         }
 
-        $this->tpl->assign('jsFiles', $jsFiles);
+        $this->tpl->addGlobal('jsFiles', $jsFiles);
     }
 
     /**
@@ -828,8 +828,8 @@ class Header extends FrontendBaseObject
             $link .= '>' . "\n";
         }
 
-        $this->tpl->assign('meta', $meta . "\n" . $link);
-        $this->tpl->assign('metaCustom', $this->getMetaCustom());
+        $this->tpl->addGlobal('meta', $meta . "\n" . $link);
+        $this->tpl->addGlobal('metaCustom', $this->getMetaCustom());
     }
 
     /**

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -160,18 +160,6 @@ class Page extends FrontendBaseObject
      */
     public function display()
     {
-        // parse header
-        $this->header->parse();
-
-        // parse breadcrumb
-        $this->breadcrumb->parse();
-
-        // parse languages
-        $this->parseLanguages();
-
-        // parse footer
-        $this->footer->parse();
-
         // assign the id so we can use it as an option
         $this->tpl->addGlobal('isPage' . $this->pageId, true);
         $this->tpl->addGlobal('isChildOfPage' . $this->record['parent_id'], true);
@@ -193,6 +181,18 @@ class Page extends FrontendBaseObject
                 array()
             );
         }
+
+        // parse header
+        $this->header->parse();
+
+        // parse breadcrumb
+        $this->breadcrumb->parse();
+
+        // parse languages
+        $this->parseLanguages();
+
+        // parse footer
+        $this->footer->parse();
 
         // output
         return new Response(

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -173,8 +173,8 @@ class Page extends FrontendBaseObject
         $this->footer->parse();
 
         // assign the id so we can use it as an option
-        $this->tpl->assign('isPage' . $this->pageId, true);
-        $this->tpl->assign('isChildOfPage' . $this->record['parent_id'], true);
+        $this->tpl->addGlobal('isPage' . $this->pageId, true);
+        $this->tpl->addGlobal('isChildOfPage' . $this->record['parent_id'], true);
 
         // hide the cookiebar from within the code to prevent flickering
         $this->tpl->assign(
@@ -340,7 +340,7 @@ class Page extends FrontendBaseObject
 
             // assign
             if (count($languages) > 1) {
-                $this->tpl->assign('languages', $languages);
+                $this->tpl->addGlobal('languages', $languages);
             }
         }
     }
@@ -362,6 +362,8 @@ class Page extends FrontendBaseObject
             foreach ($blocks as $i => $block) {
                 // check for extras that need to be reparsed
                 if (isset($block['extra'])) {
+                    $block['extra']->execute();
+
                     // fetch extra-specific variables
                     if (isset($positions[$position][$i]['variables'])) {
                         $extraVariables = $positions[$position][$i]['variables'];
@@ -413,16 +415,12 @@ class Page extends FrontendBaseObject
 
             // all extras extend FrontendBaseObject, which extends KernelLoader
             $extra->setKernel($this->getKernel());
-            $extra->execute();
 
             // overwrite the template
             if (is_callable(array($extra, 'getOverwrite')) && $extra->getOverwrite()
             ) {
                 $this->templatePath = $extra->getTemplatePath();
             }
-
-            // assign the variables from this extra to the main template
-            $this->tpl->assignArray((array) $extra->getTemplate()->getAssignedVariables());
         }
     }
 
@@ -463,7 +461,7 @@ class Page extends FrontendBaseObject
         // assign content
         $pageInfo = Navigation::getPageInfo($this->record['id']);
         $this->record['has_children'] = $pageInfo['has_children'];
-        $this->tpl->assign('page', $this->record);
+        $this->tpl->addGlobal('page', $this->record);
 
         // set template path
         $this->templatePath = $this->record['template_path'];

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -72,6 +72,17 @@ class TwigTemplate extends BaseTwigTemplate
     }
 
     /**
+     * Adds a global variable to the template
+     *
+     * @param string $name
+     * @param mixed $value
+     */
+    public function addGlobal($name, $value)
+    {
+        $this->environment->addGlobal($name, $value);
+    }
+
+    /**
      * Fetch the parsed content from this template.
      *
      * @param string $template      The location of the template file, used to display this template.
@@ -82,10 +93,14 @@ class TwigTemplate extends BaseTwigTemplate
     {
         $template = $this->getPath($template);
 
-        return $this->render(
+        $content = $this->render(
             $template,
             $this->variables
         );
+
+        $this->variables = array();
+
+        return $content;
     }
 
     /**

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -117,10 +117,6 @@ class Form extends FrontendBaseWidget
             $this->validateForm();
             $this->parse();
         }
-
-        return $this->tpl->getContent(
-            FRONTEND_MODULES_PATH . '/' . $this->getModule() . '/Layout/Widgets/' . $this->getAction() . '.html.twig'
-        );
     }
 
     /**


### PR DESCRIPTION
We now render them in complete isolation. We assign all core stuff in
global variables so they can be used in modules though.