### PR TITLE
Make FormBuilder edit field buttons show "save". Fixes #1644

### DIFF
--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
@@ -346,7 +346,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="textboxDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -457,7 +457,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="textareaDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -565,7 +565,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="textareaDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -656,7 +656,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="dropdownDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -746,7 +746,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="radiobuttonDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -836,7 +836,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="checkboxDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -895,7 +895,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="headingDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>
@@ -920,7 +920,7 @@
             <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
           </button>
           <button id="paragraphDialogSubmit" type="button" class="btn btn-primary jsFieldDialogSubmit">
-            <span class="fa fa-plus-square"></span>{{ 'lbl.Add'|trans|ucfirst }}
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
           </button>
         </div>
       </div>


### PR DESCRIPTION
They showed "add" before.