### PR TITLE
Fix form inputs turning & into &amp; and other special chars

### DIFF
--- a/src/Common/Core/Form.php
+++ b/src/Common/Core/Form.php
@@ -180,7 +180,7 @@ class Form extends \SpoonForm
      *
      * @return \SpoonFormText
      */
-    public function addText($name, $value = null, $maxLength = 255, $class = null, $classError = null, $HTML = false)
+    public function addText($name, $value = null, $maxLength = 255, $class = null, $classError = null, $HTML = true)
     {
         $name = (string) $name;
         $value = ($value !== null) ? (string) $value : null;
@@ -204,7 +204,7 @@ class Form extends \SpoonForm
      *
      * @return \SpoonFormTextarea
      */
-    public function addTextarea($name, $value = null, $class = null, $classError = null, $HTML = false)
+    public function addTextarea($name, $value = null, $class = null, $classError = null, $HTML = true)
     {
         $name = (string) $name;
         $value = ($value !== null) ? (string) $value : null;


### PR DESCRIPTION
because html isn't true htmlentities are applied to the input, text like "Ben & Jerry's" needs the raw parameter in twig because of that, this should not happen"