### PR TITLE
Make sure our emails are themable.

### DIFF
--- a/src/Frontend/Modules/Blog/Engine/Model.php
+++ b/src/Frontend/Modules/Blog/Engine/Model.php
@@ -975,7 +975,7 @@ class Model implements FrontendTagsInterface
                 ->setTo(array($to['email'] => $to['name']))
                 ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                 ->parseHtml(
-                    FRONTEND_CORE_PATH . '/Layout/Templates/Mails/Notification.html.twig',
+                    '/Core/Layout/Templates/Mails/Notification.html.twig',
                     $variables,
                     true
                 )
@@ -997,7 +997,7 @@ class Model implements FrontendTagsInterface
                 ->setTo(array($to['email'] => $to['name']))
                 ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                 ->parseHtml(
-                    FRONTEND_CORE_PATH . '/Layout/Templates/Mails/Notification.html.twig',
+                    '/Core/Layout/Templates/Mails/Notification.html.twig',
                     $variables,
                     true
                 )

--- a/src/Frontend/Modules/Faq/Actions/Detail.php
+++ b/src/Frontend/Modules/Faq/Actions/Detail.php
@@ -275,7 +275,7 @@ class Detail extends FrontendBaseBlock
                             ->setTo(array($to['email'] => $to['name']))
                             ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                             ->parseHtml(
-                                FRONTEND_MODULES_PATH . '/Faq/Layout/Templates/Mails/Feedback.html.twig',
+                                '/Faq/Layout/Templates/Mails/Feedback.html.twig',
                                 $variables,
                                 true
                             )

--- a/src/Frontend/Modules/Faq/Widgets/AskOwnQuestion.php
+++ b/src/Frontend/Modules/Faq/Widgets/AskOwnQuestion.php
@@ -124,7 +124,7 @@ class AskOwnQuestion extends FrontendBaseWidget
                     ->setTo(array($to['email'] => $to['name']))
                     ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                     ->parseHtml(
-                        FRONTEND_MODULES_PATH . '/Faq/Layout/Templates/Mails/OwnQuestion.html.twig',
+                        '/Faq/Layout/Templates/Mails/OwnQuestion.html.twig',
                         $variables,
                         true
                     )

--- a/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
+++ b/src/Frontend/Modules/FormBuilder/EventListener/FormBuilderSubmittedMailSubscriber.php
@@ -49,7 +49,7 @@ final class FormBuilderSubmittedMailSubscriber
             $fieldData = $this->getEmailFields($event->getData());
             $message = Message::newInstance(sprintf(Language::getMessage('FormBuilderSubject'), $form['name']))
                 ->parseHtml(
-                    FRONTEND_MODULES_PATH . '/FormBuilder/Layout/Templates/Mails/Form.html.twig',
+                    '/FormBuilder/Layout/Templates/Mails/Form.html.twig',
                     array(
                         'sentOn' => time(),
                         'name' => $form['name'],

--- a/src/Frontend/Modules/Profiles/Actions/ForgotPassword.php
+++ b/src/Frontend/Modules/Profiles/Actions/ForgotPassword.php
@@ -127,7 +127,7 @@ class ForgotPassword extends FrontendBaseBlock
                     ->setTo(array($txtEmail->getValue() => ''))
                     ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                     ->parseHtml(
-                        FRONTEND_MODULES_PATH . '/Profiles/Layout/Templates/Mails/ForgotPassword.html.twig',
+                        '/Profiles/Layout/Templates/Mails/ForgotPassword.html.twig',
                         $mailValues,
                         true
                     )

--- a/src/Frontend/Modules/Profiles/Actions/Register.php
+++ b/src/Frontend/Modules/Profiles/Actions/Register.php
@@ -175,7 +175,7 @@ class Register extends FrontendBaseBlock
                         ->setTo(array($txtEmail->getValue() => ''))
                         ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                         ->parseHtml(
-                            FRONTEND_MODULES_PATH . '/Profiles/Layout/Templates/Mails/Register.html.twig',
+                            '/Profiles/Layout/Templates/Mails/Register.html.twig',
                             $mailValues,
                             true
                         )

--- a/src/Frontend/Modules/Profiles/Actions/ResendActivation.php
+++ b/src/Frontend/Modules/Profiles/Actions/ResendActivation.php
@@ -127,7 +127,7 @@ class ResendActivation extends FrontendBaseBlock
                     ->setTo(array($profile->getEmail() => ''))
                     ->setReplyTo(array($replyTo['email'] => $replyTo['name']))
                     ->parseHtml(
-                        FRONTEND_MODULES_PATH . '/Profiles/Layout/Templates/Mails/Register.html.twig',
+                        '/Profiles/Layout/Templates/Mails/Register.html.twig',
                         $mailValues,
                         true
                     )


### PR DESCRIPTION
Our full path was hardcoded, causing our rendering to always take the
core templates instead of the ones in the theme.