### PR TITLE
Make sure the settings are loaded in cache before a setting

### DIFF
--- a/src/Frontend/Modules/Profiles/Engine/Profile.php
+++ b/src/Frontend/Modules/Profiles/Engine/Profile.php
@@ -322,6 +322,9 @@ class Profile
      */
     public function setSetting($name, $value)
     {
+        // make sure we have the current settings in cache
+        $this->getSettings();
+
         // set setting
         FrontendProfilesModel::setSetting($this->getId(), (string) $name, $value);
 
@@ -336,6 +339,9 @@ class Profile
      */
     public function setSettings(array $values)
     {
+        // make sure we have the current settings in cache
+        $this->getSettings();
+
         // set settings
         FrontendProfilesModel::setSettings($this->getId(), $values);
 


### PR DESCRIPTION
When setting a setting before getting the settings the cache would only show the one setting that was set