### PR TITLE
fix non existent service session.handler

### DIFF
--- a/src/Backend/Core/Js/ckfinder/config.php
+++ b/src/Backend/Core/Js/ckfinder/config.php
@@ -25,7 +25,6 @@ $debug = getenv('FORK_DEBUG') === '1';
 
 $kernel = new AppKernel($env, $debug);
 $loader = new KernelLoader($kernel);
-$kernel->getContainer()->get('session.handler');
 $loader->passContainerToModels();
 
 // after registring autoloaders, let's add use statements for our needed classes


### PR DESCRIPTION
When removing this line the editor kept working so I just removed it
this fixes #1653 

@WouterSioen you added that 2 years ago, does it still serve a purpose ?