### PR TITLE
Redirect to the index page of the module when switching languages in the backend

### DIFF
--- a/src/Backend/Core/Layout/Templates/header.html.twig
+++ b/src/Backend/Core/Layout/Templates/header.html.twig
@@ -22,7 +22,7 @@
               <ul class="dropdown-menu" role="menu">
                 {% for workingLanguage in workingLanguages %}
                   <li{% if workingLanguage.selected %} class="active"{% endif %}>
-                    <a href="{{ geturl(null,null,null,workingLanguage.abbr) }}" title="{{ workingLanguage.label|ucfirst }}">{{ ('lbl.'~workingLanguage.abbr|uppercase)|trans|ucfirst }}</a>
+                    <a href="{{ geturl('',null,null,workingLanguage.abbr) }}" title="{{ workingLanguage.label|ucfirst }}">{{ ('lbl.'~workingLanguage.abbr|uppercase)|trans|ucfirst }}</a>
                   </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
## Type

- Non-critical bug

## Resolves the following issues

When changing languages in the backend while on a detail page, i.e a blog post you would go to the index of the blog module with the message that the post could not be found. This was because the id was tied to a language

## Pull request description

Now you will be redirected to the default action of the module when switching languages