### PR TITLE
Fixes fork for mysql 5.7

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -55,6 +55,9 @@ services:
             - %database.port%
         calls:
             - [ execute, [ 'SET CHARACTER SET :charset, NAMES :charset, time_zone = "+0:00"', { 'charset': 'utf8mb4' } ] ]
+            # The following line removes the ONLY_FULL_GROUP_BY from the sessions sql_mode, it was added in 5.7
+            # and caused some queries to break.
+            - [ execute, [ 'SET sql_mode = REPLACE(@@SESSION.sql_mode, "ONLY_FULL_GROUP_BY", "")'] ]
             - [ setDebug, [ %kernel.debug% ]]
     mailer_configurator:
         class: Common\Mailer\Configurator


### PR DESCRIPTION
## Type

> remove the types that don't apply

- Critical bugfix

## Resolves the following issues

some queries don't work in mysql 5.7^

## Pull request description

In mysql 5.7 the sql_mode ONLY_FULL_GROUP_BY was enabled by default. This didn't work together with some old queries in fork
This should remove that from the session configuration so fork works on mysql 5.7 while we migrate to depricating SpoonDatabase in favour of Doctrine