### PR TITLE
Fix incorrect language variable

### DIFF
--- a/src/Frontend/Core/Engine/Ajax.php
+++ b/src/Frontend/Core/Engine/Ajax.php
@@ -195,6 +195,7 @@ class Ajax extends \KernelLoader implements \ApplicationInterface
 
         // define constant
         defined('FRONTEND_LANGUAGE') || define('FRONTEND_LANGUAGE', $this->language);
+        defined('LANGUAGE') || define('LANGUAGE', $this->language);
 
         // set the locale (we need this for the labels)
         Language::setLocale($this->language);

--- a/src/Frontend/Core/Engine/Footer.php
+++ b/src/Frontend/Core/Engine/Footer.php
@@ -70,10 +70,10 @@ class Footer extends FrontendBaseObject
     protected function getFacebookHtml($facebookAppId)
     {
         // build correct locale
-        $locale = mb_strtolower(FRONTEND_LANGUAGE) . '_' . mb_strtoupper(FRONTEND_LANGUAGE);
+        $locale = mb_strtolower(LANGUAGE) . '_' . mb_strtoupper(LANGUAGE);
 
         // reform some locale
-        switch (FRONTEND_LANGUAGE) {
+        switch (LANGUAGE) {
             case 'en':
                 $locale = 'en_US';
                 break;

--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -632,7 +632,7 @@ class Header extends FrontendBaseObject
         $this->tpl->addGlobal('pageTitle', (string) $this->getPageTitle());
         $this->tpl->addGlobal(
             'siteTitle',
-            (string) $this->get('fork.settings')->get('Core', 'site_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE)
+            (string) $this->get('fork.settings')->get('Core', 'site_title_' . LANGUAGE, SITE_DEFAULT_TITLE)
         );
     }
 
@@ -701,7 +701,7 @@ class Header extends FrontendBaseObject
         }
 
         // store language
-        $this->jsData['FRONTEND_LANGUAGE'] = FRONTEND_LANGUAGE;
+        $this->jsData['LANGUAGE'] = LANGUAGE;
 
         // encode and add
         $jsData = json_encode($this->jsData);
@@ -749,7 +749,7 @@ class Header extends FrontendBaseObject
         // should we add extra open-graph data?
         if ($parseFacebook) {
             // build correct locale
-            switch (FRONTEND_LANGUAGE) {
+            switch (LANGUAGE) {
                 case 'en':
                     $locale = 'en_US';
                     break;
@@ -779,7 +779,7 @@ class Header extends FrontendBaseObject
                     break;
 
                 default:
-                    $locale = mb_strtolower(FRONTEND_LANGUAGE) . '_' . mb_strtoupper(FRONTEND_LANGUAGE);
+                    $locale = mb_strtolower(LANGUAGE) . '_' . mb_strtoupper(LANGUAGE);
             }
 
             $this->addOpenGraphData('locale', $locale);
@@ -981,7 +981,7 @@ class Header extends FrontendBaseObject
             if (empty($value)) {
                 $this->pageTitle = $this->get('fork.settings')->get(
                     'Core',
-                    'site_title_' . FRONTEND_LANGUAGE,
+                    'site_title_' . LANGUAGE,
                     SITE_DEFAULT_TITLE
                 );
             } else {
@@ -990,7 +990,7 @@ class Header extends FrontendBaseObject
                     $this->pageTitle = $value . ' -  ' .
                                        $this->get('fork.settings')->get(
                                            'Core',
-                                           'site_title_' . FRONTEND_LANGUAGE,
+                                           'site_title_' . LANGUAGE,
                                            SITE_DEFAULT_TITLE
                                        );
                 } else {

--- a/src/Frontend/Core/Engine/Language.php
+++ b/src/Frontend/Core/Engine/Language.php
@@ -325,7 +325,7 @@ class Language
     public static function setLocale($language = null, $force = false)
     {
         // redefine
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // validate language
         if (!$force && !in_array($language, self::getActiveLanguages())) {

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -157,7 +157,7 @@ class Model extends \Common\Core\Model
              INNER JOIN themes_templates AS t ON p.template_id = t.id
              WHERE p.id = ? AND p.status = ? AND p.language = ?
              LIMIT 1',
-            array($pageId, 'active', FRONTEND_LANGUAGE)
+            array($pageId, 'active', LANGUAGE)
         );
 
         // validate
@@ -243,7 +243,7 @@ class Model extends \Common\Core\Model
              INNER JOIN themes_templates AS t ON p.template_id = t.id
              WHERE p.revision_id = ? AND p.language = ?
              LIMIT 1',
-            array($revisionId, FRONTEND_LANGUAGE)
+            array($revisionId, LANGUAGE)
         );
 
         // validate

--- a/src/Frontend/Core/Engine/Navigation.php
+++ b/src/Frontend/Core/Engine/Navigation.php
@@ -65,7 +65,7 @@ class Navigation extends FrontendBaseObject
     ) {
         $action = (string) $action;
         $module = (string) $module;
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
         $queryString = '';
 
         // add at least one parameter
@@ -179,7 +179,7 @@ class Navigation extends FrontendBaseObject
      */
     public static function getKeys($language = null)
     {
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         return BackendPagesModel::getCacheBuilder()->getKeys($language);
     }
@@ -194,7 +194,7 @@ class Navigation extends FrontendBaseObject
      */
     public static function getNavigation($language = null)
     {
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         return BackendPagesModel::getCacheBuilder()->getNavigation($language);
     }
@@ -374,7 +374,7 @@ class Navigation extends FrontendBaseObject
     {
         // redefine
         $URL = trim((string) $URL, '/');
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // get menu items array
         $keys = self::getKeys($language);
@@ -439,7 +439,7 @@ class Navigation extends FrontendBaseObject
     public static function getURL($pageId, $language = null)
     {
         $pageId = (int) $pageId;
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // init URL
         $URL = (FrontendModel::getContainer()->getParameter('site.multilanguage'))
@@ -477,7 +477,7 @@ class Navigation extends FrontendBaseObject
     {
         $module = (string) $module;
         $action = ($action !== null) ? (string) $action : null;
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // init var
         $pageIdForURL = null;
@@ -554,7 +554,7 @@ class Navigation extends FrontendBaseObject
     public static function getURLForExtraId($id, $language = null)
     {
         $id = (int) $id;
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // get the menuItems
         $navigation = self::getNavigation($language);

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -332,7 +332,7 @@ class Page extends FrontendBaseObject
                 $temp['url'] = '/' . $language;
                 $temp['label'] = $language;
                 $temp['name'] = Language::msg(mb_strtoupper($language));
-                $temp['current'] = (bool) ($language == FRONTEND_LANGUAGE);
+                $temp['current'] = (bool) ($language == LANGUAGE);
 
                 // add
                 $languages[] = $temp;

--- a/src/Frontend/Core/Engine/Rss.php
+++ b/src/Frontend/Core/Engine/Rss.php
@@ -42,11 +42,11 @@ class Rss extends \SpoonFeedRSS
         );
 
         $siteTitle = \SpoonFilter::htmlspecialcharsDecode(
-            Model::get('fork.settings')->get('Core', 'site_title_' . FRONTEND_LANGUAGE)
+            Model::get('fork.settings')->get('Core', 'site_title_' . LANGUAGE)
         );
 
         // set feed properties
-        $this->setLanguage(FRONTEND_LANGUAGE);
+        $this->setLanguage(LANGUAGE);
         $this->setCopyright(\SpoonDate::getDate('Y') . ' ' . $siteTitle);
         $this->setGenerator($siteTitle);
         $this->setImage(SITE_URL . FRONTEND_CORE_URL . '/Layout/images/rss_image.png', $title, $link);

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -130,8 +130,8 @@ class TemplateModifiers extends BaseTwigModifiers
                 'time_format'
             ),
             $string,
-            FRONTEND_LANGUAGE
-        ).'">'.\SpoonDate::getTimeAgo($string, FRONTEND_LANGUAGE).'</abbr>';
+            LANGUAGE
+        ).'">'.\SpoonDate::getTimeAgo($string, LANGUAGE).'</abbr>';
     }
 
     /**

--- a/src/Frontend/Core/Engine/Url.php
+++ b/src/Frontend/Core/Engine/Url.php
@@ -286,6 +286,7 @@ class Url extends \KernelLoader
 
         // define the language
         defined('FRONTEND_LANGUAGE') || define('FRONTEND_LANGUAGE', $language);
+        defined('LANGUAGE') || define('LANGUAGE', $language);
 
         // sets the locale file
         Language::setLocale($language);

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -9,7 +9,7 @@ var jsFrontend =
 	// init, something like a constructor
 	init: function()
 	{
-		jsFrontend.current.language = jsFrontend.data.get('FRONTEND_LANGUAGE');
+		jsFrontend.current.language = jsFrontend.data.get('LANGUAGE');
 
 		// init stuff
 		jsFrontend.initAjax();

--- a/src/Frontend/Modules/Blog/Actions/Archive.php
+++ b/src/Frontend/Modules/Blog/Actions/Archive.php
@@ -166,7 +166,7 @@ class Archive extends FrontendBaseBlock
     private function parse()
     {
         // get RSS-link
-        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE);
+        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE);
         $rssLink = FrontendNavigation::getURLForBlock('Blog', 'Rss');
 
         // add RSS-feed
@@ -177,7 +177,7 @@ class Archive extends FrontendBaseBlock
         $this->breadcrumb->addElement($this->year);
         if ($this->month !== null) {
             $this->breadcrumb->addElement(
-                \SpoonDate::getDate('F', $this->startDate, FRONTEND_LANGUAGE, true)
+                \SpoonDate::getDate('F', $this->startDate, LANGUAGE, true)
             );
         }
 
@@ -186,7 +186,7 @@ class Archive extends FrontendBaseBlock
         $this->header->setPageTitle($this->year);
         if ($this->month !== null) {
             $this->header->setPageTitle(
-                \SpoonDate::getDate('F', $this->startDate, FRONTEND_LANGUAGE, true)
+                \SpoonDate::getDate('F', $this->startDate, LANGUAGE, true)
             );
         }
 

--- a/src/Frontend/Modules/Blog/Actions/Category.php
+++ b/src/Frontend/Modules/Blog/Actions/Category.php
@@ -119,7 +119,7 @@ class Category extends FrontendBaseBlock
     private function parse()
     {
         // get RSS-link
-        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE);
+        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE);
         $rssLink = FrontendNavigation::getURLForBlock('Blog', 'Rss');
 
         // add RSS-feed

--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -144,7 +144,7 @@ class Detail extends FrontendBaseBlock
     private function parse()
     {
         // get RSS-link
-        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE);
+        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE);
         $rssLink = FrontendNavigation::getURLForBlock('Blog', 'Rss');
 
         // add RSS-feed
@@ -174,7 +174,7 @@ class Detail extends FrontendBaseBlock
         $this->header->addOpenGraphData('url', SITE_URL . $this->record['full_url'], true);
         $this->header->addOpenGraphData(
             'site_name',
-            $this->get('fork.settings')->get('Core', 'site_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE),
+            $this->get('fork.settings')->get('Core', 'site_title_' . LANGUAGE, SITE_DEFAULT_TITLE),
             true
         );
         $this->header->addOpenGraphData(
@@ -340,7 +340,7 @@ class Detail extends FrontendBaseBlock
 
                 // build array
                 $comment['post_id'] = $this->record['id'];
-                $comment['language'] = FRONTEND_LANGUAGE;
+                $comment['language'] = LANGUAGE;
                 $comment['created_on'] = FrontendModel::getUTCDate();
                 $comment['author'] = $author;
                 $comment['email'] = $email;

--- a/src/Frontend/Modules/Blog/Actions/Index.php
+++ b/src/Frontend/Modules/Blog/Actions/Index.php
@@ -97,7 +97,7 @@ class Index extends FrontendBaseBlock
             array(
                  'rel' => 'alternate',
                  'type' => 'application/rss+xml',
-                 'title' => $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE),
+                 'title' => $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE),
                  'href' => $rssLink,
             ),
             true

--- a/src/Frontend/Modules/Blog/Actions/Rss.php
+++ b/src/Frontend/Modules/Blog/Actions/Rss.php
@@ -61,9 +61,9 @@ class Rss extends FrontendBaseBlock
     private function parse()
     {
         // get vars
-        $title = (isset($this->settings['rss_title_' . FRONTEND_LANGUAGE])) ? $this->settings['rss_title_' . FRONTEND_LANGUAGE] : $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE);
+        $title = (isset($this->settings['rss_title_' . LANGUAGE])) ? $this->settings['rss_title_' . LANGUAGE] : $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE, SITE_DEFAULT_TITLE);
         $link = SITE_URL . FrontendNavigation::getURLForBlock('Blog');
-        $description = (isset($this->settings['rss_description_' . FRONTEND_LANGUAGE])) ? $this->settings['rss_description_' . FRONTEND_LANGUAGE] : null;
+        $description = (isset($this->settings['rss_description_' . LANGUAGE])) ? $this->settings['rss_description_' . LANGUAGE] : null;
 
         // create new rss instance
         $rss = new FrontendRSS($title, $link, $description);
@@ -76,7 +76,7 @@ class Rss extends FrontendBaseBlock
             $description = ($item['introduction'] != '') ? $item['introduction'] : $item['text'];
 
             // meta is wanted
-            if ($this->get('fork.settings')->get('Blog', 'rss_meta_' . FRONTEND_LANGUAGE, true)) {
+            if ($this->get('fork.settings')->get('Blog', 'rss_meta_' . LANGUAGE, true)) {
                 // append meta
                 $description .= '<div class="meta">' . "\n";
                 $description .= '	<p><a href="' . $link . '" title="' . $title . '">' . $title . '</a> ' .

--- a/src/Frontend/Modules/Blog/Engine/Model.php
+++ b/src/Frontend/Modules/Blog/Engine/Model.php
@@ -47,7 +47,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m2 ON c.meta_id = m2.id
              WHERE i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on <= ? AND m.url = ?
              LIMIT 1',
-            array('active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', (string) $URL)
+            array('active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', (string) $URL)
         );
 
         // unserialize
@@ -92,7 +92,7 @@ class Model implements FrontendTagsInterface
              LIMIT ?, ?',
             array(
                 'active',
-                FRONTEND_LANGUAGE,
+                LANGUAGE,
                 'N',
                 FrontendModel::getUTCDate('Y-m-d H:i') . ':00',
                 (int) $offset,
@@ -169,7 +169,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON c.meta_id = m.id
              WHERE c.language = ? AND i.status = ? AND i.hidden = ? AND i.publish_on <= ?
              GROUP BY c.id',
-            array(FRONTEND_LANGUAGE, 'active', 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00'),
+            array(LANGUAGE, 'active', 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00'),
             'id'
         );
 
@@ -203,7 +203,7 @@ class Model implements FrontendTagsInterface
              GROUP BY i.id
              ORDER BY i.created_on DESC
              LIMIT ?, ?',
-            array('published', FRONTEND_LANGUAGE, (int) $offset, (int) $limit)
+            array('published', LANGUAGE, (int) $offset, (int) $limit)
         );
     }
 
@@ -218,7 +218,7 @@ class Model implements FrontendTagsInterface
             'SELECT COUNT(i.id) AS count
              FROM blog_posts AS i
              WHERE i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on <= ?',
-            array('active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
+            array('active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
         );
     }
 
@@ -247,7 +247,7 @@ class Model implements FrontendTagsInterface
              LIMIT ?, ?',
             array(
                 'active',
-                FRONTEND_LANGUAGE,
+                LANGUAGE,
                 'N',
                 FrontendModel::getUTCDate('Y-m-d H:i') . ':00',
                 (string) $categoryURL,
@@ -325,7 +325,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN blog_categories AS c ON i.category_id = c.id
              INNER JOIN meta AS m ON c.meta_id = m.id
              WHERE i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on <= ? AND m.url = ?',
-            array('active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', (string) $URL)
+            array('active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', (string) $URL)
         );
     }
 
@@ -361,7 +361,7 @@ class Model implements FrontendTagsInterface
              LIMIT ?, ?',
             array(
                 'active',
-                FRONTEND_LANGUAGE,
+                LANGUAGE,
                 'N',
                 FrontendModel::getUTCDate('Y-m-d H:i', $start),
                 FrontendModel::getUTCDate('Y-m-d H:i', $end),
@@ -442,7 +442,7 @@ class Model implements FrontendTagsInterface
              WHERE i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on BETWEEN ? AND ?',
             array(
                 'active',
-                FRONTEND_LANGUAGE,
+                LANGUAGE,
                 'N',
                 FrontendModel::getUTCDate('Y-m-d H:i:s', $start),
                 FrontendModel::getUTCDate('Y-m-d H:i:s', $end),
@@ -464,7 +464,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on <= ?
              GROUP BY month',
-            array('active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
+            array('active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
         );
 
         // init vars
@@ -554,7 +554,7 @@ class Model implements FrontendTagsInterface
              FROM blog_comments AS c
              WHERE c.post_id = ? AND c.status = ? AND c.language = ?
              ORDER BY c.id ASC',
-            array((int) $id, 'published', FRONTEND_LANGUAGE)
+            array((int) $id, 'published', LANGUAGE)
         );
 
         // loop comments and create gravatar id
@@ -667,7 +667,7 @@ class Model implements FrontendTagsInterface
                 ((i.publish_on = ? AND i.id < ?) OR i.publish_on < ?)
              ORDER BY i.publish_on DESC, i.id DESC
              LIMIT 1',
-            array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date, $id, $date)
+            array($detailLink, $id, 'active', 'N', LANGUAGE, $date, $id, $date)
         );
 
         // get next post
@@ -679,7 +679,7 @@ class Model implements FrontendTagsInterface
                 ((i.publish_on = ? AND i.id > ?) OR i.publish_on > ?)
              ORDER BY i.publish_on ASC, i.id ASC
              LIMIT 1',
-            array($detailLink, $id, 'active', 'N', FRONTEND_LANGUAGE, $date, $id, $date)
+            array($detailLink, $id, 'active', 'N', LANGUAGE, $date, $id, $date)
         );
 
         // if empty, unset it
@@ -719,7 +719,7 @@ class Model implements FrontendTagsInterface
              WHERE c.status = ? AND i.status = ? AND i.language = ? AND i.hidden = ? AND i.publish_on <= ?
              ORDER BY c.id DESC
              LIMIT ?',
-            array('published', 'active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', $limit)
+            array('published', 'active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', $limit)
         );
 
         // validate
@@ -774,7 +774,7 @@ class Model implements FrontendTagsInterface
             implode(',', $relatedIDs) . ')
              ORDER BY i.publish_on DESC, i.id DESC
              LIMIT ?',
-            array('active', FRONTEND_LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', $limit),
+            array('active', LANGUAGE, 'N', FrontendModel::getUTCDate('Y-m-d H:i') . ':00', $limit),
             'id'
         );
 
@@ -812,7 +812,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m2 ON c.meta_id = m2.id
              WHERE i.language = ? AND i.revision_id = ? AND m.url = ?
              LIMIT 1',
-            array(FRONTEND_LANGUAGE, (int) $revision, (string) $URL)
+            array(LANGUAGE, (int) $revision, (string) $URL)
         );
 
         // unserialize
@@ -857,7 +857,7 @@ class Model implements FrontendTagsInterface
                  INNER JOIN blog_posts AS p ON i.post_id = p.id AND i.language = p.language
                  WHERE i.status = ? AND i.post_id = ? AND i.language = ? AND p.status = ?
                  GROUP BY i.post_id',
-                array('published', $comment['post_id'], FRONTEND_LANGUAGE, 'active')
+                array('published', $comment['post_id'], LANGUAGE, 'active')
             );
 
             // update num comments
@@ -1026,7 +1026,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.status = ? AND i.hidden = ? AND i.language = ? AND i.publish_on <= ? AND i.id IN (' .
             implode(',', $ids) . ')',
-            array('active', 'N', FRONTEND_LANGUAGE, date('Y-m-d H:i') . ':00'),
+            array('active', 'N', LANGUAGE, date('Y-m-d H:i') . ':00'),
             'id'
         );
 

--- a/src/Frontend/Modules/Blog/Widgets/Archive.php
+++ b/src/Frontend/Modules/Blog/Widgets/Archive.php
@@ -33,10 +33,10 @@ class Archive extends FrontendBaseWidget
     private function parse()
     {
         // we will cache this widget for 24 hours
-        $this->tpl->cache(FRONTEND_LANGUAGE . '_blogWidgetArchiveCache', (24 * 60 * 60));
+        $this->tpl->cache(LANGUAGE . '_blogWidgetArchiveCache', (24 * 60 * 60));
 
         // if the widget isn't cached, assign the variables
-        if (!$this->tpl->isCached(FRONTEND_LANGUAGE . '_blogWidgetArchiveCache')) {
+        if (!$this->tpl->isCached(LANGUAGE . '_blogWidgetArchiveCache')) {
             // get the numbers
             $this->tpl->assign('widgetBlogArchive', FrontendBlogModel::getArchiveNumbers());
         }

--- a/src/Frontend/Modules/Blog/Widgets/RecentArticlesFull.php
+++ b/src/Frontend/Modules/Blog/Widgets/RecentArticlesFull.php
@@ -34,7 +34,7 @@ class RecentArticlesFull extends FrontendBaseWidget
     private function parse()
     {
         // get RSS-link
-        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE);
+        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE);
         $rssLink = FrontendNavigation::getURLForBlock('Blog', 'Rss');
 
         // add RSS-feed

--- a/src/Frontend/Modules/Blog/Widgets/RecentArticlesList.php
+++ b/src/Frontend/Modules/Blog/Widgets/RecentArticlesList.php
@@ -34,7 +34,7 @@ class RecentArticlesList extends FrontendBaseWidget
     private function parse()
     {
         // get RSS-link
-        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . FRONTEND_LANGUAGE);
+        $rssTitle = $this->get('fork.settings')->get('Blog', 'rss_title_' . LANGUAGE);
         $rssLink = FrontendNavigation::getURLForBlock('Blog', 'Rss');
 
         // add RSS-feed into the metaCustom

--- a/src/Frontend/Modules/ContentBlocks/Engine/Model.php
+++ b/src/Frontend/Modules/ContentBlocks/Engine/Model.php
@@ -22,7 +22,7 @@ class Model
             'SELECT i.title, i.text, i.template
              FROM content_blocks AS i
              WHERE i.id = ? AND i.status = ? AND i.hidden = ? AND i.language = ?',
-            array((int) $id, 'active', 'N', FRONTEND_LANGUAGE)
+            array((int) $id, 'active', 'N', LANGUAGE)
         );
     }
 }

--- a/src/Frontend/Modules/Faq/Engine/Model.php
+++ b/src/Frontend/Modules/Faq/Engine/Model.php
@@ -37,7 +37,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m2 ON c.meta_id = m2.id
              WHERE m.url = ? AND i.language = ? AND i.hidden = ?
              ORDER BY i.sequence',
-            array((string) $url, FRONTEND_LANGUAGE, 'N')
+            array((string) $url, LANGUAGE, 'N')
         );
     }
 
@@ -66,7 +66,7 @@ class Model implements FrontendTagsInterface
                  AND i.id NOT IN (' . implode(',', $excludeIds) . ')
              ORDER BY i.sequence
              LIMIT ?',
-                array((int) $categoryId, FRONTEND_LANGUAGE, 'N', (int) $limit)
+                array((int) $categoryId, LANGUAGE, 'N', (int) $limit)
             );
         } else {
             $items = (array) FrontendModel::getContainer()->get('database')->getRecords(
@@ -76,7 +76,7 @@ class Model implements FrontendTagsInterface
                  WHERE i.category_id = ? AND i.language = ? AND i.hidden = ?
                  AND i.id NOT IN (' . implode(',', $excludeIds) . ')
              ORDER BY i.sequence',
-                array((int) $categoryId, FRONTEND_LANGUAGE, 'N')
+                array((int) $categoryId, LANGUAGE, 'N')
             );
         }
 
@@ -104,7 +104,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.language = ?
              ORDER BY i.sequence',
-            array(FRONTEND_LANGUAGE)
+            array(LANGUAGE)
         );
 
         // init var
@@ -133,7 +133,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE m.url = ? AND i.language = ?
              ORDER BY i.sequence',
-            array((string) $url, FRONTEND_LANGUAGE)
+            array((string) $url, LANGUAGE)
         );
     }
 
@@ -152,7 +152,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.id = ? AND i.language = ?
              ORDER BY i.sequence',
-            array((int) $id, FRONTEND_LANGUAGE)
+            array((int) $id, LANGUAGE)
         );
     }
 
@@ -217,7 +217,7 @@ class Model implements FrontendTagsInterface
              WHERE i.num_views > 0 AND i.language = ? AND i.hidden = ?
              ORDER BY (i.num_usefull_yes + i.num_usefull_no) DESC
              LIMIT ?',
-            array(FRONTEND_LANGUAGE, 'N', (int) $limit)
+            array(LANGUAGE, 'N', (int) $limit)
         );
 
         $link = FrontendNavigation::getURLForBlock('Faq', 'Detail');
@@ -243,7 +243,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.language = ? AND i.category_id = ?
              ORDER BY i.sequence ASC',
-            array(FRONTEND_LANGUAGE, (int) $id)
+            array(LANGUAGE, (int) $id)
         );
 
         $link = FrontendNavigation::getURLForBlock('Faq', 'Detail');
@@ -280,7 +280,7 @@ class Model implements FrontendTagsInterface
              WHERE i.language = ? AND i.hidden = ? AND i.id IN(' . implode(',', $relatedIDs) . ')
              ORDER BY i.question
              LIMIT ?',
-            array(FRONTEND_LANGUAGE, 'N', (int) $limit),
+            array(LANGUAGE, 'N', (int) $limit),
             'id'
         );
 
@@ -341,7 +341,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN faq_categories AS c ON c.id = i.category_id
              INNER JOIN meta AS m2 ON c.meta_id = m2.id
              WHERE i.hidden = ? AND i.language = ? AND i.id IN (' . implode(',', $ids) . ')',
-            array('N', FRONTEND_LANGUAGE),
+            array('N', LANGUAGE),
             'id'
         );
 

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -85,7 +85,7 @@ class Form extends FrontendBaseWidget
 
         // single language
         if ($this->getContainer()->getParameter('site.multilanguage')) {
-            $action = FRONTEND_LANGUAGE . '/' . $action;
+            $action = LANGUAGE . '/' . $action;
         }
 
         // add to action

--- a/src/Frontend/Modules/Location/Engine/Model.php
+++ b/src/Frontend/Modules/Location/Engine/Model.php
@@ -76,7 +76,7 @@ class Model
             'SELECT *
              FROM location
              WHERE id = ? AND language = ?',
-            array((int) $id, FRONTEND_LANGUAGE)
+            array((int) $id, LANGUAGE)
         );
     }
 
@@ -89,7 +89,7 @@ class Model
     {
         return (array) FrontendModel::getContainer()->get('database')->getRecords(
             'SELECT * FROM location WHERE language = ? AND show_overview = ?',
-            array(FRONTEND_LANGUAGE, 'Y')
+            array(LANGUAGE, 'Y')
         );
     }
 

--- a/src/Frontend/Modules/Mailmotor/Actions/Index.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Index.php
@@ -42,7 +42,7 @@ class Index extends FrontendBaseBlock
         // create a new source-object
         $source = new \SpoonDataGridSourceDB(
             FrontendModel::getContainer()->get('database'),
-            array(FrontendMailmotorModel::QRY_DATAGRID_BROWSE_SENT, array('sent', FRONTEND_LANGUAGE))
+            array(FrontendMailmotorModel::QRY_DATAGRID_BROWSE_SENT, array('sent', LANGUAGE))
         );
 
         // create data grid

--- a/src/Frontend/Modules/Mailmotor/Engine/Model.php
+++ b/src/Frontend/Modules/Mailmotor/Engine/Model.php
@@ -130,7 +130,7 @@ class Model
              FROM mailmotor_groups AS mg
              WHERE mg.is_default = ? AND mg.language = ?
              LIMIT 1',
-            array('Y', FRONTEND_LANGUAGE)
+            array('Y', LANGUAGE)
         );
     }
 

--- a/src/Frontend/Modules/Pages/Engine/Model.php
+++ b/src/Frontend/Modules/Pages/Engine/Model.php
@@ -36,14 +36,14 @@ class Model implements FrontendTagsInterface
              WHERE i.status = ? AND i.hidden = ? AND i.language = ? AND i.publish_on <= ? AND i.id IN (' .
             implode(',', $ids) . ')
              ORDER BY i.title ASC',
-            array('active', 'N', FRONTEND_LANGUAGE, FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
+            array('active', 'N', LANGUAGE, FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
         );
 
         // has items
         if (!empty($items)) {
             // reset url
             foreach ($items as &$row) {
-                $row['full_url'] = FrontendNavigation::getURL($row['id'], FRONTEND_LANGUAGE);
+                $row['full_url'] = FrontendNavigation::getURL($row['id'], LANGUAGE);
             }
         }
 
@@ -81,14 +81,14 @@ class Model implements FrontendTagsInterface
              WHERE i.parent_id = ? AND i.status = ? AND i.hidden = ?
              AND i.language = ? AND i.publish_on <= ?
              ORDER BY i.sequence ASC',
-            array((int) $id, 'active', 'N', FRONTEND_LANGUAGE, FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
+            array((int) $id, 'active', 'N', LANGUAGE, FrontendModel::getUTCDate('Y-m-d H:i') . ':00')
         );
 
         // has items
         if (!empty($items)) {
             // reset url
             foreach ($items as &$row) {
-                $row['full_url'] = FrontendNavigation::getURL($row['id'], FRONTEND_LANGUAGE);
+                $row['full_url'] = FrontendNavigation::getURL($row['id'], LANGUAGE);
             }
         }
 
@@ -123,7 +123,7 @@ class Model implements FrontendTagsInterface
              INNER JOIN themes_templates AS t ON p.template_id = t.id
              WHERE p.id IN (' . implode(', ', $ids) . ') AND p.id NOT IN (' .
             implode(', ', $ignore) . ') AND p.status = ? AND p.hidden = ? AND p.language = ?',
-            array('active', 'N', FRONTEND_LANGUAGE),
+            array('active', 'N', LANGUAGE),
             'id'
         );
 

--- a/src/Frontend/Modules/Profiles/Actions/Register.php
+++ b/src/Frontend/Modules/Profiles/Actions/Register.php
@@ -121,7 +121,7 @@ class Register extends FrontendBaseBlock
 
                 // generate salt
                 $settings['salt'] = FrontendProfilesModel::getRandomString();
-                $settings['language'] = FRONTEND_LANGUAGE;
+                $settings['language'] = LANGUAGE;
 
                 // values
                 $values['email'] = $txtEmail->getValue();

--- a/src/Frontend/Modules/Profiles/Actions/Settings.php
+++ b/src/Frontend/Modules/Profiles/Actions/Settings.php
@@ -85,7 +85,7 @@ class Settings extends FrontendBaseBlock
 
         // birthdate dropdown values
         $days = range(1, 31);
-        $months = \SpoonLocale::getMonths(FRONTEND_LANGUAGE);
+        $months = \SpoonLocale::getMonths(LANGUAGE);
         $years = range(date('Y'), 1900);
 
         // get settings
@@ -113,7 +113,7 @@ class Settings extends FrontendBaseBlock
         $this->frm->addText('city', $this->profile->getSetting('city'));
         $this->frm->addDropdown(
             'country',
-            Intl::getRegionBundle()->getCountryNames(FRONTEND_LANGUAGE),
+            Intl::getRegionBundle()->getCountryNames(LANGUAGE),
             $this->profile->getSetting('country')
         );
         $this->frm->addDropdown('gender', $genderValues, $this->profile->getSetting('gender'));

--- a/src/Frontend/Modules/Search/Actions/Index.php
+++ b/src/Frontend/Modules/Search/Actions/Index.php
@@ -95,7 +95,7 @@ class Index extends FrontendBaseBlock
         $this->limit = $this->get('fork.settings')->get('Search', 'overview_num_items', 20);
         $this->offset = ($this->requestedPage * $this->limit) - $this->limit;
         $this->cacheFile = FRONTEND_CACHE_PATH . '/' . $this->getModule() . '/' .
-                           FRONTEND_LANGUAGE . '_' . md5($this->term) . '_' .
+                           LANGUAGE . '_' . md5($this->term) . '_' .
                            $this->offset . '_' . $this->limit . '.php';
 
         // load the cached data
@@ -289,7 +289,7 @@ class Index extends FrontendBaseBlock
             // format data
             $this->statistics = array();
             $this->statistics['term'] = $this->term;
-            $this->statistics['language'] = FRONTEND_LANGUAGE;
+            $this->statistics['language'] = LANGUAGE;
             $this->statistics['time'] = FrontendModel::getUTCDate();
             $this->statistics['data'] = serialize(array('server' => $_SERVER));
             $this->statistics['num_results'] = $this->pagination['num_items'];

--- a/src/Frontend/Modules/Search/Ajax/Autocomplete.php
+++ b/src/Frontend/Modules/Search/Ajax/Autocomplete.php
@@ -39,7 +39,7 @@ class Autocomplete extends FrontendBaseAJAXAction
             $this->output(self::BAD_REQUEST, null, 'term-parameter is missing.');
         } else {
             // get matches
-            $matches = FrontendSearchModel::getStartsWith($term, FRONTEND_LANGUAGE, $limit);
+            $matches = FrontendSearchModel::getStartsWith($term, LANGUAGE, $limit);
 
             // get search url
             $url = FrontendNavigation::getURLForBlock('Search');

--- a/src/Frontend/Modules/Search/Ajax/Autosuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Autosuggest.php
@@ -86,7 +86,7 @@ class Autosuggest extends FrontendBaseAJAXAction
         $this->limit = (int) $this->get('fork.settings')->get('Search', 'autosuggest_num_items', 10);
         $this->offset = ($this->requestedPage * $this->limit) - $this->limit;
         $this->cacheFile = FRONTEND_CACHE_PATH . '/' . $this->getModule() . '/' .
-                           FRONTEND_LANGUAGE . '_' . md5($this->term) . '_' .
+                           LANGUAGE . '_' . md5($this->term) . '_' .
                            $this->offset . '_' . $this->limit . '.php';
 
         // load the cached data

--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -92,7 +92,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         $this->limit = (int) $this->get('fork.settings')->get('Search', 'overview_num_items', 20);
         $this->offset = ($this->requestedPage * $this->limit) - $this->limit;
         $this->cacheFile = FRONTEND_CACHE_PATH . '/' . $this->getModule() . '/' .
-                           FRONTEND_LANGUAGE . '_' . md5($this->term) . '_' .
+                           LANGUAGE . '_' . md5($this->term) . '_' .
                            $this->offset . '_' . $this->limit . '.php';
 
         // load the cached data

--- a/src/Frontend/Modules/Search/Ajax/Save.php
+++ b/src/Frontend/Modules/Search/Ajax/Save.php
@@ -50,7 +50,7 @@ class Save extends FrontendBaseAJAXAction
                 // format data
                 $this->statistics = array();
                 $this->statistics['term'] = $term;
-                $this->statistics['language'] = FRONTEND_LANGUAGE;
+                $this->statistics['language'] = LANGUAGE;
                 $this->statistics['time'] = FrontendModel::getUTCDate();
                 $this->statistics['data'] = serialize(array('server' => $_SERVER));
                 $this->statistics['num_results'] = FrontendSearchModel::getTotal($term);

--- a/src/Frontend/Modules/Search/Engine/Model.php
+++ b/src/Frontend/Modules/Search/Engine/Model.php
@@ -119,7 +119,7 @@ class Model
                 $params2 = array_merge(
                     $params2,
                     $terms,
-                    array((string) $field, FRONTEND_LANGUAGE, 'Y', 'Y')
+                    array((string) $field, LANGUAGE, 'Y', 'Y')
                 );
             }
 
@@ -169,7 +169,7 @@ class Model
             $params = array_merge(
                 $terms,
                 $terms,
-                array(FRONTEND_LANGUAGE, 'Y', 'Y', $offset, $limit)
+                array(LANGUAGE, 'Y', 'Y', $offset, $limit)
             );
         }
 
@@ -322,7 +322,7 @@ class Model
                 $params = array_merge(
                     $params,
                     $terms,
-                    array((string) $field, FRONTEND_LANGUAGE, 'Y', 'Y')
+                    array((string) $field, LANGUAGE, 'Y', 'Y')
                 );
             }
 
@@ -364,7 +364,7 @@ class Model
                 GROUP BY i.module, i.other_id
             ) AS results';
 
-            $params = array_merge($terms, array(FRONTEND_LANGUAGE, 'Y', 'Y'));
+            $params = array_merge($terms, array(LANGUAGE, 'Y', 'Y'));
         }
 
         // get the search results
@@ -530,7 +530,7 @@ class Model
                 WHERE language = ? AND active = ?
                 GROUP BY module, other_id
                 LIMIT ?, ?',
-                array(FRONTEND_LANGUAGE, 'N', $offset, $limit)
+                array(LANGUAGE, 'N', $offset, $limit)
             );
 
             // none found? good news!

--- a/src/Frontend/Modules/Tags/Engine/Model.php
+++ b/src/Frontend/Modules/Tags/Engine/Model.php
@@ -57,7 +57,7 @@ class Model
     public static function get($URL, $language = null)
     {
         // redefine language
-        $language = ($language !== null) ? (string) $language : FRONTEND_LANGUAGE;
+        $language = ($language !== null) ? (string) $language : LANGUAGE;
 
         // exists
         return (array) FrontendModel::getContainer()->get('database')->getRecord(
@@ -80,7 +80,7 @@ class Model
              FROM tags AS t
              WHERE t.language = ? AND t.number > 0
              ORDER BY t.tag',
-            array(FRONTEND_LANGUAGE)
+            array(LANGUAGE)
         );
     }
 

--- a/src/Frontend/Modules/Tags/Widgets/Related.php
+++ b/src/Frontend/Modules/Tags/Widgets/Related.php
@@ -64,7 +64,7 @@ class Related extends FrontendBaseWidget
                  FROM modules_tags AS mt
                  INNER JOIN tags AS t ON t.id = mt.tag_id
                  WHERE t.language = ? AND t.tag = ?',
-                array(FRONTEND_LANGUAGE, $tag)
+                array(LANGUAGE, $tag)
             );
 
             // loop items


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

/

## Pull request description

Go to the demo for example, http://demo.fork-cms.com/, and checkout the body class. It's empty, should have "en" or "nl" or a language. 
Checkout a dutch frontend website, http://demo.fork-cms.com/nl/blog, the dates are in english instead of dutch.
... numerous other examples

*Why this is happening?*
Everywhere in twig we use `LANGUAGE` which doesn't exist and renders nothing at all. We should use `BACKEND_LANGUAGE` and `FRONTEND_LANGUAGE` to make this working again, right?