### PR TITLE
Add missing Blog image validation

### DIFF
--- a/src/Backend/Modules/Blog/Actions/Edit.php
+++ b/src/Backend/Modules/Blog/Actions/Edit.php
@@ -337,6 +337,15 @@ class Edit extends BackendBaseActionEdit
             $this->frm->getField('publish_on_time')->isValid(BL::err('TimeIsInvalid'));
             $this->frm->getField('category_id')->isFilled(BL::err('FieldIsRequired'));
 
+            if ($this->imageIsAllowed) {
+                // validate the image
+                if ($this->frm->getField('image')->isFilled()) {
+                    // image extension and mime type
+                    $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                    $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
+                }
+            }
+
             // validate meta
             $this->meta->validate();
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
/

## Pull request description
While comparing the add.php and edit.php action of the blog module, I saw that the add.php action uses image validation, but the edit.php doesn't do that. Just copied the bit of add.php to edit.php to also use it there.
