### PR TITLE
Fix add synonym link when there are no synonyms

### DIFF
--- a/src/Backend/Modules/Search/Layout/Templates/Synonyms.html.twig
+++ b/src/Backend/Modules/Search/Layout/Templates/Synonyms.html.twig
@@ -19,7 +19,7 @@
         </div>
       {% endif %}
       {% if not dataGrid %}
-        <p>{{ 'msg.NoSynonyms'|trans|format(geturl('add_synonym')|raw) }}</p>
+        <p>{{ 'msg.NoSynonyms'|trans|format(geturl('add_synonym'))|raw }}</p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

the code behind the link was shown when there are no synonyms yet

## Pull request description

it fixes it so that you actually get the link instead of the code for the link


