### PR TITLE
Remove SpoonDirectory

### DIFF
--- a/src/Backend/Modules/Profiles/Installer/Installer.php
+++ b/src/Backend/Modules/Profiles/Installer/Installer.php
@@ -10,6 +10,7 @@ namespace Backend\Modules\Profiles\Installer;
  */
 
 use Backend\Core\Installer\ModuleInstaller;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Installer for the profiles module.
@@ -38,10 +39,11 @@ class Installer extends ModuleInstaller
         $this->setSetting('Profiles', 'send_mail_for_new_profile_to_profile', false);
 
         // add folders
-        \SpoonDirectory::create(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/source/');
-        \SpoonDirectory::create(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/240x240/');
-        \SpoonDirectory::create(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/64x64/');
-        \SpoonDirectory::create(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/32x32/');
+        $fs = new Filesystem();
+        $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/source/');
+        $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/240x240/');
+        $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/64x64/');
+        $fs->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/32x32/');
 
         // module rights
         $this->setModuleRights(1, 'Profiles');


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

We need to get rid of SpoonDirectory (and all of Spoon)

## Pull request description

Replace SpoonDirectory with Symfony's filesystem. Profiles module was the only place that still used SpoonDirectory. 


