### PR TITLE
Remove non existent service mailer from installation

### DIFF
--- a/app/config/config_install.yml
+++ b/app/config/config_install.yml
@@ -40,7 +40,3 @@ services:
             - %database.port%
         calls:
             - [ execute, [ 'SET CHARACTER SET :charset, NAMES :charset, time_zone = "+0:00"', { 'charset': 'utf8mb4' } ] ]
-    mailer:
-        class: Common\Mailer
-        arguments:
-            - "@database"


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

there was a service for a class that didn't exist during the installation

## Pull request description

I removed the service


