### PR TITLE
Remove obsolete validation

### DIFF
--- a/src/Backend/Modules/Blog/Actions/Add.php
+++ b/src/Backend/Modules/Blog/Actions/Add.php
@@ -125,15 +125,6 @@ class Add extends BackendBaseActionAdd
                 $this->frm->getField('category_id')->addError(BL::err('FieldIsRequired'));
             }
 
-            if ($this->imageIsAllowed) {
-                // validate the image
-                if ($this->frm->getField('image')->isFilled()) {
-                    // image extension and mime type
-                    $this->frm->getField('image')->isAllowedExtension(array('jpg', 'png', 'gif', 'jpeg'), BL::err('JPGGIFAndPNGOnly'));
-                    $this->frm->getField('image')->isAllowedMimeType(array('image/jpg', 'image/png', 'image/gif', 'image/jpeg'), BL::err('JPGGIFAndPNGOnly'));
-                }
-            }
-
             // validate meta
             $this->meta->validate();
 

--- a/src/Backend/Modules/Users/Actions/Add.php
+++ b/src/Backend/Modules/Users/Actions/Add.php
@@ -155,22 +155,6 @@ class Add extends BackendBaseActionAdd
                 }
             }
 
-            // validate avatar
-            if ($this->frm->getField('avatar')->isFilled()) {
-                // correct extension
-                if ($this->frm->getField('avatar')->isAllowedExtension(
-                    array('jpg', 'jpeg', 'gif', 'png'),
-                    BL::err('JPGGIFAndPNGOnly')
-                )
-                ) {
-                    // correct mimetype?
-                    $this->frm->getField('avatar')->isAllowedMimeType(
-                        array('image/gif', 'image/jpg', 'image/jpeg', 'image/png'),
-                        BL::err('JPGGIFAndPNGOnly')
-                    );
-                }
-            }
-
             // no errors?
             if ($this->frm->isCorrect()) {
                 // build settings-array

--- a/src/Backend/Modules/Users/Actions/Edit.php
+++ b/src/Backend/Modules/Users/Actions/Edit.php
@@ -302,22 +302,6 @@ class Edit extends BackendBaseActionEdit
                 }
             }
 
-            // validate avatar
-            if ($fields['avatar']->isFilled()) {
-                // correct extension
-                if ($fields['avatar']->isAllowedExtension(
-                    array('jpg', 'jpeg', 'gif', 'png'),
-                    BL::err('JPGGIFAndPNGOnly')
-                )
-                ) {
-                    // correct mimetype?
-                    $fields['avatar']->isAllowedMimeType(
-                        array('image/gif', 'image/jpg', 'image/jpeg', 'image/png'),
-                        BL::err('JPGGIFAndPNGOnly')
-                    );
-                }
-            }
-
             // no errors?
             if ($this->frm->isCorrect()) {
                 // build user-array


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
Validation is already done in the FormImage itself in the backend, and in FrontendFormImage in the frontend. 

## Pull request description
Removed obsolete image validation from modules that use FormImage elements
See #1674


