### PR TITLE
Remove useless assignment of the action variable.

### DIFF
--- a/src/Backend/Core/Engine/Action.php
+++ b/src/Backend/Core/Engine/Action.php
@@ -121,8 +121,5 @@ class Action extends Base\Object
 
         // create config-object, the constructor will do some magic
         $this->config = new $configClass($this->getKernel(), $this->getModule());
-
-        // set action
-        $action = ($this->config->getDefaultAction() !== null) ? $this->config->getDefaultAction() : 'Index';
     }
 }

--- a/src/Backend/Core/Engine/AjaxAction.php
+++ b/src/Backend/Core/Engine/AjaxAction.php
@@ -74,8 +74,5 @@ class AjaxAction extends Base\Object
 
         // create config-object, the constructor will do some magic
         $this->config = new $configClass($this->getKernel(), $this->getModule());
-
-        // set action
-        $action = ($this->config->getDefaultAction() !== null) ? $this->config->getDefaultAction() : 'Index';
     }
 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

none

## Pull request description

We don't use it and it does not have side effects, so we can just remove it.

The real logic for determining the action is done in `src/Backend/Core/Engine/Url`.