### PR TITLE
Show error when file size is too big

### DIFF
--- a/src/Backend/Core/Engine/FormFile.php
+++ b/src/Backend/Core/Engine/FormFile.php
@@ -76,13 +76,34 @@ class FormFile extends \SpoonFormFile
 
         // parse to template
         if ($template !== null) {
-            $template->assign('file' . \SpoonFilter::toCamelCase($this->attributes['name']), $output);
+            $template->assign('file' . SpoonFilter::toCamelCase($this->attributes['name']), $output);
             $template->assign(
-                'file' . \SpoonFilter::toCamelCase($this->attributes['name']) . 'Error',
+                'file' . SpoonFilter::toCamelCase($this->attributes['name']) . 'Error',
                 ($this->errors != '') ? '<span class="formError text-danger">' . $this->errors . '</span>' : ''
             );
         }
 
         return $output;
+    }
+
+    /**
+     * This function will return the errors. It is extended so we can do file checks automatically.
+     *
+     * @return string
+     */
+    public function getErrors()
+    {
+        // if the image is bigger then the allowed configuration it won't show up as filled but it is submitted
+        // the empty check is added because otherwise this error is shown like 7 times
+        if ($this->isSubmitted() && isset($_FILES[$this->getName()]['error']) && empty($this->errors)) {
+            $imageError = $_FILES[$this->getName()]['error'];
+            if ($imageError === UPLOAD_ERR_INI_SIZE && empty($this->errors)) {
+                $this->addError(
+                    SpoonFilter::ucfirst(sprintf(Language::err('FileTooBig'), Form::getUploadMaxFileSize()))
+                );
+            }
+        }
+
+        return $this->errors;
     }
 }

--- a/src/Backend/Core/Engine/FormFile.php
+++ b/src/Backend/Core/Engine/FormFile.php
@@ -40,32 +40,6 @@ class FormFile extends \SpoonFormFile
      */
     public function parse($template = null)
     {
-        // get upload_max_filesize
-        $uploadMaxFilesize = ini_get('upload_max_filesize');
-        if ($uploadMaxFilesize === false) {
-            $uploadMaxFilesize = 0;
-        }
-
-        // reformat if defined as an integer
-        if (\SpoonFilter::isInteger($uploadMaxFilesize)) {
-            $uploadMaxFilesize = $uploadMaxFilesize / 1024 . 'MB';
-        }
-
-        // reformat if specified in kB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'K') {
-            $uploadMaxFilesize = mb_substr($uploadMaxFilesize, 0, -1) . 'kB';
-        }
-
-        // reformat if specified in MB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'M') {
-            $uploadMaxFilesize .= 'B';
-        }
-
-        // reformat if specified in GB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'G') {
-            $uploadMaxFilesize .= 'B';
-        }
-
         // name is required
         if ($this->attributes['name'] == '') {
             throw new \SpoonFormException('A name is required for a file field. Please provide a name.');
@@ -89,13 +63,13 @@ class FormFile extends \SpoonFormFile
                            sprintf(
                                Language::getMessage('HelpFileFieldWithMaxFileSize', 'core'),
                                $this->attributes['extension'],
-                               $uploadMaxFilesize
+                               Form::getUploadMaxFileSize()
                            ) . '</p>';
             } else {
                 $output .= '<p class="help-block">' .
                            sprintf(
                                Language::getMessage('HelpMaxFileSize'),
-                               $uploadMaxFilesize
+                               Form::getUploadMaxFileSize()
                            ) . '</p>';
             }
         }

--- a/src/Backend/Core/Engine/FormImage.php
+++ b/src/Backend/Core/Engine/FormImage.php
@@ -103,32 +103,6 @@ class FormImage extends \SpoonFormImage
      */
     public function parse($template = null)
     {
-        // get upload_max_filesize
-        $uploadMaxFilesize = ini_get('upload_max_filesize');
-        if ($uploadMaxFilesize === false) {
-            $uploadMaxFilesize = 0;
-        }
-
-        // reformat if defined as an integer
-        if (\SpoonFilter::isInteger($uploadMaxFilesize)) {
-            $uploadMaxFilesize = $uploadMaxFilesize / 1024 . 'MB';
-        }
-
-        // reformat if specified in kB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'K') {
-            $uploadMaxFilesize = mb_substr($uploadMaxFilesize, 0, -1) . 'kB';
-        }
-
-        // reformat if specified in MB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'M') {
-            $uploadMaxFilesize .= 'B';
-        }
-
-        // reformat if specified in GB
-        if (mb_strtoupper(mb_substr($uploadMaxFilesize, -1, 1)) == 'G') {
-            $uploadMaxFilesize .= 'B';
-        }
-
         // name is required
         if ($this->attributes['name'] == '') {
             throw new \SpoonFormException('A name is required for a file field. Please provide a name.');
@@ -150,7 +124,7 @@ class FormImage extends \SpoonFormImage
             $output .= '<p class="help-block">' .
                         sprintf(
                             Language::getMessage('HelpImageFieldWithMaxFileSize', 'core'),
-                            $uploadMaxFilesize
+                            Form::getUploadMaxFileSize()
                         ) . '</p>';
         }
 

--- a/src/Backend/Core/Engine/FormImage.php
+++ b/src/Backend/Core/Engine/FormImage.php
@@ -9,6 +9,7 @@ namespace Backend\Core\Engine;
  * file that was distributed with this source code.
  */
 
+use SpoonFilter;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -77,6 +78,17 @@ class FormImage extends \SpoonFormImage
         if ($this->isFilled()) {
             $this->isAllowedExtension(array('jpg', 'jpeg', 'gif', 'png'), Language::err('JPGGIFAndPNGOnly'));
             $this->isAllowedMimeType(array('image/jpeg', 'image/gif', 'image/png'), Language::err('JPGGIFAndPNGOnly'));
+        }
+
+        // if the image is bigger then the allowed configuration it won't show up as filled but it is submitted
+        // the empty check is added because otherwise this error is shown like 7 times
+        if ($this->isSubmitted() && isset($_FILES[$this->getName()]['error']) && empty($this->errors)) {
+            $imageError = $_FILES[$this->getName()]['error'];
+            if ($imageError === UPLOAD_ERR_INI_SIZE && empty($this->errors)) {
+                $this->addError(
+                    SpoonFilter::ucfirst(sprintf(Language::err('FileTooBig'), Form::getUploadMaxFileSize()))
+                );
+            }
         }
 
         return $this->errors;

--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -3437,6 +3437,20 @@
         <translation language="el"><![CDATA[Αυτό το πεδίο είναι υποχρεωτικό]]></translation>
         <translation language="pl"><![CDATA[To pole jest wymagane.]]></translation>
       </item>
+      <item type="error" name="FileTooBig">
+        <translation language="nl"><![CDATA[maximum bestandsgrootte: %1$s]]></translation>
+        <translation language="en"><![CDATA[maximum filesize: %1$s]]></translation>
+        <translation language="hu"><![CDATA[maximális fájlméret: %1$s]]></translation>
+        <translation language="it"><![CDATA[dimensione massima: %1$s]]></translation>
+        <translation language="ru"><![CDATA[максимальный размер: %1$s]]></translation>
+        <translation language="zh"><![CDATA[不大于%1$s]]></translation>
+        <translation language="de"><![CDATA[(maximale Dateigröße: %1$s)]]></translation>
+        <translation language="fr"><![CDATA[taille de fichier maximale: %1$s]]></translation>
+        <translation language="es"><![CDATA[(máximo tamaño del archivo: %1$s)]]></translation>
+        <translation language="lt"><![CDATA[(maksimalus dydis: %1$s)]]></translation>
+        <translation language="sv"><![CDATA[maximal filstorlek: %1$s]]></translation>
+        <translation language="el"><![CDATA[μέγιστο μέγεθος αρχείου: %1$s]]></translation>
+      </item>
       <item type="error" name="FormError">
         <translation language="nl"><![CDATA[Er ging iets mis]]></translation>
         <translation language="en"><![CDATA[Something went wrong]]></translation>
@@ -11425,6 +11439,20 @@
         <translation language="lt"><![CDATA[Būtinas laukas.]]></translation>
         <translation language="sv"><![CDATA[Detta fält är obligatoriskt.]]></translation>
         <translation language="el"><![CDATA[Αυτό το πεδίο είναι υποχρεωτικό.]]></translation>
+      </item>
+      <item type="error" name="FileTooBig">
+        <translation language="nl"><![CDATA[maximum bestandsgrootte: %1$s]]></translation>
+        <translation language="en"><![CDATA[maximum filesize: %1$s]]></translation>
+        <translation language="hu"><![CDATA[maximális fájlméret: %1$s]]></translation>
+        <translation language="it"><![CDATA[dimensione massima: %1$s]]></translation>
+        <translation language="ru"><![CDATA[максимальный размер: %1$s]]></translation>
+        <translation language="zh"><![CDATA[不大于%1$s]]></translation>
+        <translation language="de"><![CDATA[(maximale Dateigröße: %1$s)]]></translation>
+        <translation language="fr"><![CDATA[taille de fichier maximale: %1$s]]></translation>
+        <translation language="es"><![CDATA[(máximo tamaño del archivo: %1$s)]]></translation>
+        <translation language="lt"><![CDATA[(maksimalus dydis: %1$s)]]></translation>
+        <translation language="sv"><![CDATA[maximal filstorlek: %1$s]]></translation>
+        <translation language="el"><![CDATA[μέγιστο μέγεθος αρχείου: %1$s]]></translation>
       </item>
       <item type="error" name="ForkAPIKeys">
         <translation language="nl"><![CDATA[Fork API-keys nog niet geconfigureerd.]]></translation>

--- a/src/Common/Core/Form.php
+++ b/src/Common/Core/Form.php
@@ -236,6 +236,39 @@ class Form extends \SpoonForm
         // create and return a time field
         return parent::addTime($name, $value, $class, $classError);
     }
+
+    /**
+     * @return string|null
+     */
+    public static function getUploadMaxFileSize()
+    {
+        $uploadMaxFileSize = ini_get('upload_max_filesize');
+        if ($uploadMaxFileSize === false) {
+            return null;
+        }
+
+        // reformat if defined as an integer
+        if (\SpoonFilter::isInteger($uploadMaxFileSize)) {
+            return $uploadMaxFileSize / 1024 . 'MB';
+        }
+
+        // reformat if specified in kB
+        if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1, 1)) == 'K') {
+            return mb_substr($uploadMaxFileSize, 0, -1) . 'kB';
+        }
+
+        // reformat if specified in MB
+        if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1, 1)) == 'M') {
+            return $uploadMaxFileSize . 'B';
+        }
+
+        // reformat if specified in GB
+        if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1, 1)) == 'G') {
+            return $uploadMaxFileSize . 'B';
+        }
+
+        return $uploadMaxFileSize;
+    }
 }
 
 /**

--- a/src/Common/Core/Form.php
+++ b/src/Common/Core/Form.php
@@ -248,7 +248,7 @@ class Form extends \SpoonForm
         }
 
         // reformat if defined as an integer
-        if (\SpoonFilter::isInteger($uploadMaxFileSize)) {
+        if (is_numeric($uploadMaxFileSize)) {
             return $uploadMaxFileSize / 1024 . 'MB';
         }
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

If a file was bigger than the allowed upload size it was ignored like it wasn't uploaded.

## Pull request description

This adds a check to see if the file is too large, if that is the case, an error is thrown

