### PR TITLE
Restrict access to the vendor directory with htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,6 +14,7 @@ FileETag MTime Size
 
 	# forbidden folders
 	RewriteRule \.git - [F]
+	RewriteRule vendor/.* - [F]
 	RewriteRule .*\.gitignore - [F]
 	RewriteRule \.editorconfig - [F]
 	RewriteRule \.travis.yml - [F]


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

At the moment the vendor directory can be accessed from the browser, since we don't always know what is in there it might pose some risks

## Pull request description

It restricts access to the vendor dir via .htaccess


