### PR TITLE
Fix getCoordinates to fetch geocodes.

### DIFF
--- a/src/Backend/Modules/Location/Engine/Model.php
+++ b/src/Backend/Modules/Location/Engine/Model.php
@@ -138,13 +138,8 @@ class Model
         // define address
         $address = implode(' ', $item);
 
-        // define Google Maps API key
-        $apikey = BackendModel::get('fork.settings')->get('Core', 'google_maps_key');
-
-        // define url
-        $url = 'http://maps.googleapis.com/maps/api/geocode/json?address=' . rawurlencode($address) . '&key=' . $apikey;
-
-        // define result
+        // fetch the geo coordinates
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . rawurlencode($address);
         $geocodes = json_decode(file_get_contents($url), true);
 
         // return coordinates latitude/longitude


### PR DESCRIPTION
If we use a key, we should use a server key. This is a fast fix that
makes it work again, but for a long term fix, we should use a server key
everywhere. see
https://github.com/forkcms/forkcms/pull/1673#issuecomment-241993336

Fixes #1672 