### PR TITLE
Fully delete timezones table

### DIFF
--- a/src/Backend/Core/Installer/Data/install.sql
+++ b/src/Backend/Core/Installer/Data/install.sql
@@ -39,14 +39,6 @@ CREATE TABLE IF NOT EXISTS `modules_tags` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
-DROP TABLE IF EXISTS `timezones`;
-CREATE TABLE IF NOT EXISTS `timezones` (
- `id` int(11) NOT NULL auto_increment,
- `timezone` varchar(255) NOT NULL,
- PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=1 ;
-
-
 CREATE TABLE IF NOT EXISTS `groups` (
  `id` int(11) NOT NULL auto_increment,
  `name` varchar(255) NOT NULL,


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

After insalling ForkCMS `timezones` table is created in the database.

## Pull request description

`timezones` table is now completely removed from core `install.sql`.

