### PR TITLE
Fix duplicate use statements

### DIFF
--- a/src/Backend/Core/Engine/FormFile.php
+++ b/src/Backend/Core/Engine/FormFile.php
@@ -9,9 +9,7 @@ namespace Backend\Core\Engine;
  * file that was distributed with this source code.
  */
 use SpoonFilter;
-
 use Backend\Core\Language\Language as BackendLanguage;
-use \SpoonFilter;
 
 /**
  * This is our extended version of \SpoonFormFile


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

Pages using spoon file crash because of duplicate namespace

## Pull request description

removes the duplicate one

probably a merge error