### PR TITLE
ContentBlocks: Fixes template error when using {{ parsewidget('ContentBlocks', 'Detail', 1) }}

### DIFF
--- a/src/Frontend/Modules/ContentBlocks/Widgets/Detail.php
+++ b/src/Frontend/Modules/ContentBlocks/Widgets/Detail.php
@@ -23,11 +23,19 @@ class Detail extends FrontendBaseWidget
             Locale::frontendLanguage()
         );
 
+        // Init template
+        $template = "Default.html.twig";
+
         // if the content block is not found or if it is hidden, just return an array with empty text
         // @deprecated fix this for version 5, we just shouldn't assign this instead of this hack, but we need it for BC
         if (!$contentBlock instanceof ContentBlock || $contentBlock->isHidden()) {
             $contentBlock = ['text' => ''];
+        } else {
+            $template = $contentBlock->getTemplate();
         }
+
+        // Load template
+        $this->loadTemplate('ContentBlocks/Layout/Widgets/' . $template);
 
         $this->tpl->assign('widgetContentBlocks', $contentBlock);
         // That's all folks!


### PR DESCRIPTION
**Problem description**

When using `{{ parsewidget('ContentBlocks', 'Detail', 1) }}` in a template, the content block template was not found. Since it was not defined in the module.

The error was: Template "" is not defined in
Core/Layout/Templates/Home.html.twig at line 59
![schermafbeelding 2016-09-01 om 10 16 06](https://cloud.githubusercontent.com/assets/588616/18161080/a5508e52-7030-11e6-9243-03b8a733d551.png)