### PR TITLE
Make sure the real data is loaded when using the template modifier parsewidget

### DIFF
--- a/src/Frontend/Core/Engine/Block/Widget.php
+++ b/src/Frontend/Core/Engine/Block/Widget.php
@@ -258,4 +258,33 @@ class Widget extends FrontendBaseObject
     {
         $this->module = (string) $module;
     }
+
+    /**
+     * @param KernelInterface $kernel
+     * @param string $module The module to load.
+     * @param string $action The action to load.
+     * @param int|null $id This is not the modules_extra id but the id of the item itself
+     *
+     * @return string|null if we have data it is still serialised since it will be unserialized in the constructor
+     */
+    public static function getForId(KernelInterface $kernel, $module, $action, $id = null)
+    {
+        $query = 'SELECT data FROM modules_extras WHERE type = :widget AND module = :module AND action = :action';
+        $parameters = [
+            'widget' => 'widget',
+            'module' => $module,
+            'action' => $action,
+        ];
+        if (is_numeric($id)) {
+            $query .= ' AND data LIKE :data';
+            $parameters['data'] = '%s:2:"id";i:' . (int) $id . ';%';
+        }
+
+        return new self(
+            $kernel,
+            $module,
+            $action,
+            $kernel->getContainer()->get('database')->getVar($query, $parameters)
+        );
+    }
 }

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -327,10 +327,13 @@ class TemplateModifiers extends BaseTwigModifiers
      */
     public static function parseWidget($module, $action, $id = null)
     {
-        $data = $id !== null ? serialize(array('id' => $id)) : null;
-
         // create new widget instance and return parsed content
-        $extra = new FrontendBlockWidget(Model::get('kernel'), $module, $action, $data);
+        $extra = FrontendBlockWidget::getForId(
+            Model::get('kernel'),
+            $module,
+            $action,
+            $id
+        );
 
         // set parseWidget because we will need it to skip setting headers in the display
         Model::getContainer()->set('parseWidget', true);


### PR DESCRIPTION
## Type

- Non critical bugfix

The data was never loaded, it just added the id if given
This caused widgets that need other data to crash
I've added a static constructor that will try to get the real data from the table modules_extras