### PR TITLE
Remove the tightly coupling between authentication and content blocks

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Actions/Add.php
+++ b/src/Backend/Modules/ContentBlocks/Actions/Add.php
@@ -9,6 +9,7 @@ namespace Backend\Modules\ContentBlocks\Actions;
  * file that was distributed with this source code.
  */
 
+use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Base\ActionAdd as BackendBaseActionAdd;
 use Backend\Core\Engine\Model as BackendModel;
 use Backend\Modules\ContentBlocks\Command\CreateContentBlock;
@@ -46,6 +47,7 @@ class Add extends BackendBaseActionAdd
 
         /** @var CreateContentBlock $createContentBlock */
         $createContentBlock = $form->getData();
+        $createContentBlock->userId = Authentication::getUser()->getUserId();
 
         // The command bus will handle the saving of the content block in the database.
         $this->get('command_bus')->handle($createContentBlock);

--- a/src/Backend/Modules/ContentBlocks/Command/CopyContentBlocksToOtherLocaleHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Command/CopyContentBlocksToOtherLocaleHandler.php
@@ -37,6 +37,7 @@ final class CopyContentBlocksToOtherLocaleHandler
 
                 $otherLocaleContentBlock = ContentBlock::create(
                     $this->contentBlockRepository->getNextIdForLanguage($copyContentBlocksToOtherLocale->toLocale),
+                    $contentBlock->getUserId(),
                     $copyContentBlocksToOtherLocale->extraIdMap[$contentBlock->getExtraId()],
                     $copyContentBlocksToOtherLocale->toLocale,
                     $contentBlock->getTitle(),

--- a/src/Backend/Modules/ContentBlocks/Command/CreateContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Command/CreateContentBlock.php
@@ -45,6 +45,11 @@ final class CreateContentBlock
     public $contentBlock;
 
     /**
+     * @var int
+     */
+    public $userId;
+
+    /**
      * @param Locale|null $language
      */
     public function __construct(Locale $language = null)

--- a/src/Backend/Modules/ContentBlocks/Command/CreateContentBlockHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Command/CreateContentBlockHandler.php
@@ -28,6 +28,7 @@ final class CreateContentBlockHandler
     {
         $createContentBlock->contentBlock = ContentBlock::create(
             $this->contentBlockRepository->getNextIdForLanguage($createContentBlock->language),
+            $createContentBlock->userId,
             $this->getNewExtraId(),
             $createContentBlock->language,
             $createContentBlock->title,

--- a/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
@@ -2,7 +2,6 @@
 
 namespace Backend\Modules\ContentBlocks\Entity;
 
-use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Model;
 use Backend\Core\Language\Locale;
 use Backend\Modules\ContentBlocks\ValueObject\ContentBlockStatus;
@@ -139,6 +138,7 @@ class ContentBlock
 
     /**
      * @param int $id
+     * @param int $userId
      * @param int $extraId The id of the module extra
      * @param string $locale
      * @param string $title
@@ -150,6 +150,7 @@ class ContentBlock
      */
     public static function create(
         $id,
+        $userId,
         $extraId,
         $locale,
         $title,
@@ -159,7 +160,7 @@ class ContentBlock
     ) {
         return new self(
             $id,
-            Authentication::getUser()->getUserId(),
+            $userId,
             $extraId,
             $template,
             $locale,
@@ -324,7 +325,16 @@ class ContentBlock
     {
         $this->status = ContentBlockStatus::archived();
 
-        return self::create($this->id, $this->extraId, $this->locale, $title, $text, $isHidden, $template);
+        return self::create(
+            $this->id,
+            $this->userId,
+            $this->extraId,
+            $this->locale,
+            $title,
+            $text,
+            $isHidden,
+            $template
+        );
     }
 
     public function archive()


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1710

## Pull request description

Removes the tightly coupling


