### PR TITLE
Make sure that extra things added to the data of a content block aren't lost when updating

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
@@ -299,17 +299,20 @@ class ContentBlock
 
         // update data for the extra
         // @TODO replace this with an implementation with doctrine
-        Model::updateExtra(
-            $this->extraId,
-            'data',
-            [
-                'id' => $this->id,
-                'extra_label' => $this->title,
-                'language' => (string) $this->locale,
-                'edit_url' => $editUrl,
-                'custom_template' => $this->template,
-            ]
-        );
+        $extras = Model::getExtras([$this->extraId]);
+        $extra = reset($extras);
+        $data = [
+            'id' => $this->id,
+            'language' => (string) $this->locale,
+            'edit_url' => $editUrl,
+        ];
+        if (isset($extra['data'])) {
+            $data = $data + (array) $extra['data'];
+        }
+        $data['custom_template'] = $this->template;
+        $data['extra_label'] = $this->title;
+
+        Model::updateExtra($this->extraId, 'data', $data);
     }
 
     /**


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1713 

## Pull request description

Make sure that extra things added to the data of a content block aren't lost when updating

We now get the current data and only overwrite the things that we need