### PR TITLE
Make sure the names of the translations start with a capital letter

### DIFF
--- a/src/Backend/Modules/Locale/Engine/Model.php
+++ b/src/Backend/Modules/Locale/Engine/Model.php
@@ -603,7 +603,7 @@ class Model
                     // attributes
                     $attributes = $item->attributes();
                     $type = \SpoonFilter::getValue($attributes['type'], $possibleTypes, '');
-                    $name = \SpoonFilter::getValue($attributes['name'], null, '');
+                    $name = ucfirst(\SpoonFilter::getValue($attributes['name'], null, ''));
 
                     // missing attributes
                     if ($type == '' || $name == '') {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1540

## Pull request description

it will make sure the names of the translations start with a capital letter


