### PR TITLE
Blog hide page title

### DIFF
--- a/src/Common/Core/Twig/BaseTwigTemplate.php
+++ b/src/Common/Core/Twig/BaseTwigTemplate.php
@@ -2,7 +2,9 @@
 
 namespace Common\Core\Twig;
 
+use Common\ModulesSettings;
 use Symfony\Bundle\TwigBundle\TwigEngine;
+use Twig_Environment;
 
 /*
  * This file is part of Fork CMS.
@@ -53,7 +55,7 @@ abstract class BaseTwigTemplate extends TwigEngine
     protected $variables = array();
 
     /**
-     * @var Fork settings
+     * @var ModulesSettings
      */
     protected $forkSettings;
 
@@ -121,7 +123,7 @@ abstract class BaseTwigTemplate extends TwigEngine
     /** @todo Refactor out constants #1106
      * We need to deprecate this asap
      *
-     * @param $twig
+     * @param Twig_Environment $twig
      */
     protected function startGlobals(&$twig)
     {
@@ -141,9 +143,6 @@ abstract class BaseTwigTemplate extends TwigEngine
 
         // get all defined constants
         $constants = get_defined_constants(true);
-
-        // init var
-        $realConstants = array();
 
         // remove protected constants aka constants that should not be used in the template
         foreach ($constants['user'] as $key => $value) {

--- a/src/Common/Core/Twig/BaseTwigTemplate.php
+++ b/src/Common/Core/Twig/BaseTwigTemplate.php
@@ -78,6 +78,15 @@ abstract class BaseTwigTemplate extends TwigEngine
     }
 
     /**
+     * @param string $key
+     * @param mixed $value
+     */
+    public function assignGlobal($key, $value)
+    {
+        $this->environment->addGlobal($key, $value);
+    }
+
+    /**
      * Assign an entire array with keys & values.
      *
      * @param array $variables This array with keys and values will be used to search and replace in the template file.

--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -57,7 +57,7 @@ class Detail extends FrontendBaseBlock
     public function execute()
     {
         parent::execute();
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
         $this->loadTemplate();
         $this->getData();
         $this->loadForm();

--- a/src/Frontend/Modules/Faq/Actions/Category.php
+++ b/src/Frontend/Modules/Faq/Actions/Category.php
@@ -35,7 +35,7 @@ class Category extends FrontendBaseBlock
     {
         parent::execute();
 
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
         $this->getData();
         $this->loadTemplate();
         $this->parse();

--- a/src/Frontend/Modules/Faq/Actions/Detail.php
+++ b/src/Frontend/Modules/Faq/Actions/Detail.php
@@ -59,7 +59,7 @@ class Detail extends FrontendBaseBlock
         parent::execute();
 
         // hide contentTitle, in the template the title is wrapped with an inverse-option
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
 
         $this->loadTemplate();
         $this->getData();

--- a/src/Frontend/Modules/Mailmotor/Actions/Detail.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Detail.php
@@ -143,7 +143,7 @@ class Detail extends FrontendBaseBlock
     {
         $this->breadcrumb->addElement($this->mailing['name']);
         $this->header->setPageTitle($this->mailing['name']);
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
         $this->tpl->assign('body', $this->getEmailBody());
     }
 }

--- a/src/Frontend/Modules/Mailmotor/Actions/Index.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Index.php
@@ -28,7 +28,7 @@ class Index extends FrontendBaseBlock
     public function execute()
     {
         parent::execute();
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
         $this->loadTemplate();
         $this->loadDataGrid();
         $this->parseDataGrid();

--- a/src/Frontend/Modules/Tags/Actions/Detail.php
+++ b/src/Frontend/Modules/Tags/Actions/Detail.php
@@ -47,7 +47,7 @@ class Detail extends FrontendBaseBlock
     {
         parent::execute();
 
-        $this->tpl->assign('hideContentTitle', true);
+        $this->tpl->assignGlobal('hideContentTitle', true);
         $this->loadTemplate();
         $this->getData();
         $this->parse();


### PR DESCRIPTION
## Type

- Non critical bugfix
- Enhancement

## Resolves the following issues

fixes #1732

## Pull request description

Since we fixed the bug where the template parameters of different blocks interfered with each other there was no longer a way to assign global parameters.

This caused things like hideContentTitle to stop working

This is fixed by adding a new function to assign the global parameters `assignGlobal`

