### PR TITLE
Moved `modules_extras` table install from extensions installer to core installer

### DIFF
--- a/src/Backend/Core/Installer/Data/install.sql
+++ b/src/Backend/Core/Installer/Data/install.sql
@@ -23,6 +23,19 @@ CREATE TABLE IF NOT EXISTS `modules` (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
+CREATE TABLE IF NOT EXISTS `modules_extras` (
+ `id` int(11) NOT NULL auto_increment COMMENT 'Unique ID for the extra.',
+ `module` varchar(255) CHARACTER SET utf8 NOT NULL COMMENT 'The name of the module this extra belongs to.',
+ `type` enum('homepage','block','widget') NOT NULL COMMENT 'The type of the block.',
+ `label` varchar(255) NOT NULL COMMENT 'The label for this extra. It will be used for displaying purposes.',
+ `action` varchar(255) default NULL,
+ `data` text COMMENT 'A serialized value with the optional parameters',
+ `hidden` enum('N','Y') NOT NULL default 'N' COMMENT 'Should the extra be shown in the backend?',
+ `sequence` int(11) NOT NULL COMMENT 'The sequence in the backend.',
+ PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='The possible extras' AUTO_INCREMENT=1 ;
+
+
 CREATE TABLE IF NOT EXISTS `modules_settings` (
  `module` varchar(255) CHARACTER SET utf8 NOT NULL COMMENT 'name of the module',
  `name` varchar(255) NOT NULL COMMENT 'name of the setting',

--- a/src/Backend/Modules/Extensions/Installer/Data/install.sql
+++ b/src/Backend/Modules/Extensions/Installer/Data/install.sql
@@ -1,16 +1,3 @@
-CREATE TABLE IF NOT EXISTS `modules_extras` (
- `id` int(11) NOT NULL auto_increment COMMENT 'Unique ID for the extra.',
- `module` varchar(255) CHARACTER SET utf8 NOT NULL COMMENT 'The name of the module this extra belongs to.',
- `type` enum('homepage','block','widget') NOT NULL COMMENT 'The type of the block.',
- `label` varchar(255) NOT NULL COMMENT 'The label for this extra. It will be used for displaying purposes.',
- `action` varchar(255) default NULL,
- `data` text COMMENT 'A serialized value with the optional parameters',
- `hidden` enum('N','Y') NOT NULL default 'N' COMMENT 'Should the extra be shown in the backend?',
- `sequence` int(11) NOT NULL COMMENT 'The sequence in the backend.',
- PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='The possible extras' AUTO_INCREMENT=1 ;
-
-
 CREATE TABLE IF NOT EXISTS `themes_templates` (
  `id` int(11) NOT NULL auto_increment COMMENT 'Unique ID for the template.',
  `theme` varchar(255) default NULL COMMENT 'The name of the theme.',


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Resolves #1739

## Pull request description

Moves `modules_extras` table install from extensions installer to core installer