### PR TITLE
Fix module install button on detail page

### DIFF
--- a/src/Backend/Modules/Extensions/Layout/Templates/DetailModule.html.twig
+++ b/src/Backend/Modules/Extensions/Layout/Templates/DetailModule.html.twig
@@ -119,7 +119,7 @@
                 <button type="button" class="btn btn-default" data-dismiss="modal">
                   <span class="fa fa-times"></span>{{ 'lbl.Cancel'|trans|ucfirst }}
                 </button>
-                <a href="{{ geturl('install_module') }}&amp;theme={{ name }}" class="btn btn-primary">
+                <a href="{{ geturl('install_module') }}&amp;module={{ name }}" class="btn btn-primary">
                   <span class="fa fa-check"></span>{{ 'lbl.OK'|trans|ucfirst }}
                 </a>
               </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The install link added the module name as theme name, this prevented it from actually working


