### PR TITLE
Use the correct language class instead of the deprecated one

### DIFF
--- a/src/Backend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Model.php
@@ -468,7 +468,7 @@ class Model
     public static function getLocale($name, $type = 'label', $application = 'Backend')
     {
         $name = \SpoonFilter::toCamelCase($name);
-        $class = \SpoonFilter::ucfirst($application) . '\Core\Engine\Language';
+        $class = \SpoonFilter::ucfirst($application) . '\Core\Language\Language';
         $function = 'get' . \SpoonFilter::ucfirst($type);
 
         // execute and return value

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -16,7 +16,7 @@ final class Language
      */
     public static function get()
     {
-        return APPLICATION . '\Core\Engine\Language';
+        return APPLICATION . '\Core\Language\Language';
     }
 
     /**


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

FormBuilder and Common\Language where still using the deprecated language class


