### PR TITLE
Fix incorrectly resolving css file into theme

### DIFF
--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -132,7 +132,11 @@ class Header extends FrontendBaseObject
         $file = (string) $file;
         $minify = (bool) $minify;
         $addTimestamp = (bool) $addTimestamp;
-        $file = Theme::getPath($file);
+
+        // get file path
+        if (mb_substr($file, 0, 4) != 'http') {
+            $file = Theme::getPath($file);
+        }
 
         // no minifying when debugging
         if ($this->getContainer()->getParameter('kernel.debug')) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
/

## Pull request description
Occurred to me while doing development for a project. I need to add `https://api.mapbox.com/mapbox-gl-js/v0.25.1/mapbox-gl.css` to the frontend module, but I could not add it with `addCss`. It would resolve the file path to the local theme. The `addJs` method however has these 3 lines that checks for 'http' in the string. The `addCss` method however, did not have these lines. So that fixes the issue 👍 


