### PR TITLE
Fix white error messages and using the wrong icon font

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -64,3 +64,15 @@
 {%- block label_asterisk -%}
   <abbr title="{{ 'lbl.RequiredField'|trans({}, translation_domain)|ucfirst }}">*</abbr>
 {%- endblock label_asterisk -%}
+
+{% block form_errors -%}
+  {% if errors|length > 0 -%}
+    {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
+    <ul class="list-unstyled">
+        {%- for error in errors -%}
+          <li class="formError"><span class="fa fa-exclamation-triangle"></span> {{ error.message }}</li>
+        {%- endfor -%}
+    </ul>
+    {% if form.parent %}</span>{% else %}</div>{% endif %}
+  {%- endif %}
+{%- endblock form_errors %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

error messages where white so you didn't see them in symfony forms because of the custom styling in the backend on top of the bootstrap theme


