### PR TITLE
Implement the symfony translator interface on the language classes

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -2,6 +2,9 @@ imports:
     - { resource: parameters.yml }
     - { resource: doctrine.yml }
 
+parameters:
+    translator.identity.class: Common\Language
+
 framework:
     secret:          %kernel.secret%
     router:

--- a/app/routing.php
+++ b/app/routing.php
@@ -56,6 +56,7 @@ class ApplicationRouting extends Controller
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
         defined('NAMED_APPLICATION') || define('NAMED_APPLICATION', 'private');
+        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('Backend');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -73,6 +74,7 @@ class ApplicationRouting extends Controller
     public function backendAjaxController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
+        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('BackendAjax');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -90,6 +92,7 @@ class ApplicationRouting extends Controller
     public function backendCronjobController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
+        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('BackendCronjob');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -108,6 +111,7 @@ class ApplicationRouting extends Controller
     public function frontendController(Request $request, $route)
     {
         defined('APPLICATION') || define('APPLICATION', 'Frontend');
+        $request->attributes->set('application', 'Frontend');
 
         $applicationClass = $this->initializeFrontend('Frontend');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -125,6 +129,7 @@ class ApplicationRouting extends Controller
     public function frontendAjaxController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Frontend');
+        $request->attributes->set('application', 'Frontend');
 
         $applicationClass = $this->initializeFrontend('FrontendAjax');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -144,6 +149,7 @@ class ApplicationRouting extends Controller
     public function apiController(Request $request, $version, $client)
     {
         defined('APPLICATION') || define('APPLICATION', 'Api');
+        $request->attributes->set('application', 'Api');
 
         $applicationClass = $this->initializeAPI('Api', $request);
         $application = new $applicationClass($this->container->get('kernel'));

--- a/app/routing.php
+++ b/app/routing.php
@@ -56,7 +56,6 @@ class ApplicationRouting extends Controller
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
         defined('NAMED_APPLICATION') || define('NAMED_APPLICATION', 'private');
-        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('Backend');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -74,7 +73,6 @@ class ApplicationRouting extends Controller
     public function backendAjaxController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
-        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('BackendAjax');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -92,7 +90,6 @@ class ApplicationRouting extends Controller
     public function backendCronjobController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Backend');
-        $request->attributes->set('application', 'Backend');
 
         $applicationClass = $this->initializeBackend('BackendCronjob');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -111,7 +108,6 @@ class ApplicationRouting extends Controller
     public function frontendController(Request $request, $route)
     {
         defined('APPLICATION') || define('APPLICATION', 'Frontend');
-        $request->attributes->set('application', 'Frontend');
 
         $applicationClass = $this->initializeFrontend('Frontend');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -129,7 +125,6 @@ class ApplicationRouting extends Controller
     public function frontendAjaxController(Request $request)
     {
         defined('APPLICATION') || define('APPLICATION', 'Frontend');
-        $request->attributes->set('application', 'Frontend');
 
         $applicationClass = $this->initializeFrontend('FrontendAjax');
         $application = new $applicationClass($this->container->get('kernel'));
@@ -149,7 +144,6 @@ class ApplicationRouting extends Controller
     public function apiController(Request $request, $version, $client)
     {
         defined('APPLICATION') || define('APPLICATION', 'Api');
-        $request->attributes->set('application', 'Api');
 
         $applicationClass = $this->initializeAPI('Api', $request);
         $application = new $applicationClass($this->container->get('kernel'));

--- a/src/Backend/Core/Engine/TemplateModifiers.php
+++ b/src/Backend/Core/Engine/TemplateModifiers.php
@@ -125,27 +125,6 @@ class TemplateModifiers extends BaseTwigModifiers
     }
 
     /**
-     * Translate a string.
-     *
-     * @param string $string The string that you want to apply this method on.
-     *
-     * @return string The string, to translate.
-     *
-     * @throws Exception
-     * @throw exception thrown when no 'dot' is found in string
-     *
-     */
-    public static function trans($string)
-    {
-        if (strpos($string, '.') === false) {
-            throw new Exception('translation needs a dot character in : '.$string);
-        }
-        list($action, $string) = explode('.', $string);
-
-        return BackendLanguage::$action($string);
-    }
-
-    /**
      * Convert this string into a well formed label.
      *  syntax: {$var|tolabel}.
      *

--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -9,6 +9,7 @@ use Common\Core\Twig\Extensions\TwigFilters;
 use ReflectionClass;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\FormExtension as SymfonyFormExtension;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Twig_Environment;
@@ -87,6 +88,9 @@ class TwigTemplate extends BaseTwigTemplate
                 new TwigRenderer($formEngine, Model::get('security.csrf.token_manager'))
             )
         );
+
+        $twigTranslationExtensionClass = Model::getContainer()->getParameter('twig.extension.trans.class');
+        $twig->addExtension(new $twigTranslationExtensionClass(Model::get('translator')));
 
         // debug options
         if ($this->debugMode === true) {

--- a/src/Backend/Modules/ContentBlocks/Command/CreateContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Command/CreateContentBlock.php
@@ -11,21 +11,21 @@ final class CreateContentBlock
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $title;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $template = ContentBlock::DEFAULT_TEMPLATE;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $text;
 

--- a/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlock.php
@@ -10,21 +10,21 @@ final class UpdateContentBlock
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $title;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $template = ContentBlock::DEFAULT_TEMPLATE;
 
     /**
      * @var string
      *
-     * @Assert\NotBlank()
+     * @Assert\NotBlank(message="err.FieldIsRequired")
      */
     public $text;
 

--- a/src/Common/Core/Twig/Extensions/TwigFilters.php
+++ b/src/Common/Core/Twig/Extensions/TwigFilters.php
@@ -36,7 +36,6 @@ class TwigFilters
         $twig->addFilter(new Twig_SimpleFilter('formatcurrency', $app.'::formatCurrency', ['is_safe' => ['html']]));
         $twig->addFilter(new Twig_SimpleFilter('usersetting', $app.'::userSetting'));
         $twig->addFilter(new Twig_SimpleFilter('uppercase', $app.'::uppercase'));
-        $twig->addFilter(new Twig_SimpleFilter('trans', $app.'::trans'));
         $twig->addFilter(new Twig_SimpleFilter('rand', $app.'::random'));
         $twig->addFilter(new Twig_SimpleFilter('formatfloat', $app.'::formatFloat'));
         $twig->addFilter(new Twig_SimpleFilter('truncate', $app.'::truncate'));

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -114,18 +114,24 @@ final class Language extends IdentityTranslator
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        if (strpos($id, '.') === false) {
-            parent::trans($id, $parameters, $domain, $locale);
+        // we are not in a normal fork context
+        if (!defined('APPLICATION')) {
+            return parent::trans($id, $parameters, $domain, $locale);
         }
-        list($action, $string) = explode('.', $id, 2);
 
         $possibleActions = ['lbl', 'err', 'msg'];
         if (self::get() === FrontendLanguage::class) {
             $possibleActions[] = 'act';
         }
 
+        if (!preg_match('/(' . implode('|', $possibleActions) . ')./', $id)) {
+            return parent::trans($id, $parameters, $domain, $locale);
+        }
+
+        list($action, $string) = explode('.', $id, 2);
+
         if (!in_array($action, $possibleActions)) {
-            parent::trans($id, $parameters, $domain, $locale);
+            return parent::trans($id, $parameters, $domain, $locale);
         }
 
         $translatedString = self::$action($string);

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -23,7 +23,7 @@ final class Language extends IdentityTranslator
     {
         $application = APPLICATION;
 
-        if ($application === 'Console') {
+        if ($application === 'Console' || $application === 'Api') {
             $application = 'Backend';
         }
 

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -131,8 +131,14 @@ final class Language extends IdentityTranslator
         $translatedString = self::$action($string);
 
         // we couldn't translate it, let the parent have a go
-        if ($translatedString === '{$' . $action . $string . '}') {
-            return parent::trans($id, $parameters, $domain, $locale);
+        if (preg_match('/\{\$' . $action . '.*' . $string . '\}/', $translatedString)) {
+            $parentTranslatedString = parent::trans($id, $parameters, $domain, $locale);
+            // If the parent couldn't translate return our default
+            if ($id === $parentTranslatedString) {
+                return $translatedString;
+            }
+
+            return $parentTranslatedString;
         }
 
         return $translatedString;

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -2,6 +2,7 @@
 
 namespace Common;
 
+use Common\Core\Model;
 use Frontend\Core\Language\Language as FrontendLanguage;
 use InvalidArgumentException;
 use Symfony\Component\Translation\IdentityTranslator;
@@ -21,10 +22,13 @@ final class Language extends IdentityTranslator
      */
     public static function get()
     {
-        $application = APPLICATION;
+        $application = 'Backend';
 
-        if ($application === 'Console' || $application === 'Api') {
-            $application = 'Backend';
+        if (Model::has('request')
+            && Model::get('request')->attributes->has('application')
+            && Model::get('request')->attributes->get('application') === 'Frontend'
+        ) {
+            $application = 'Frontend';
         }
 
         return $application . '\Core\Language\Language';

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -25,8 +25,8 @@ final class Language extends IdentityTranslator
         $application = 'Backend';
 
         if (Model::has('request')
-            && Model::get('request')->attributes->has('application')
-            && Model::get('request')->attributes->get('application') === 'Frontend'
+            && Model::get('request')->attributes->has('_route')
+            && strpos(Model::get('request')->attributes->get('_route'), 'frontend') === 0
         ) {
             $application = 'Frontend';
         }

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -2,21 +2,32 @@
 
 namespace Common;
 
+use Frontend\Core\Language\Language as FrontendLanguage;
 use InvalidArgumentException;
+use Symfony\Component\Translation\IdentityTranslator;
 
 /**
  * This class will make it possible to have 1 function to get the correct language class.
  * This is useful for when you want to use the same code in the Back- and Frontend.
  * For instance in a trait.
+ *
+ * @TODO switch our translation system to completely work with symfony instead of overriding methods to make it run
+ * on our system
  */
-final class Language
+final class Language extends IdentityTranslator
 {
     /**
      * @return string
      */
     public static function get()
     {
-        return APPLICATION . '\Core\Language\Language';
+        $application = APPLICATION;
+
+        if ($application === 'Console') {
+            $application = 'Backend';
+        }
+
+        return $application . '\Core\Language\Language';
     }
 
     /**
@@ -96,5 +107,34 @@ final class Language
     public static function msg($key)
     {
         return self::callLanguageFunction('msg', [$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        if (strpos($id, '.') === false) {
+            parent::trans($id, $parameters, $domain, $locale);
+        }
+        list($action, $string) = explode('.', $id, 2);
+
+        $possibleActions = ['lbl', 'err', 'msg'];
+        if (self::get() === FrontendLanguage::class) {
+            $possibleActions[] = 'act';
+        }
+
+        if (!in_array($action, $possibleActions)) {
+            parent::trans($id, $parameters, $domain, $locale);
+        }
+
+        $translatedString = self::$action($string);
+
+        // we couldn't translate it, let the parent have a go
+        if ($translatedString === '{$' . $action . $string . '}') {
+            return parent::trans($id, $parameters, $domain, $locale);
+        }
+
+        return $translatedString;
     }
 }

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -26,7 +26,7 @@ final class Language extends IdentityTranslator
 
         if (Model::has('request')
             && Model::get('request')->attributes->has('_route')
-            && strpos(Model::get('request')->attributes->get('_route'), 'frontend') === 0
+            && stripos(Model::get('request')->attributes->get('_route'), 'frontend') === 0
         ) {
             $application = 'Frontend';
         }

--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -118,11 +118,6 @@ final class Language extends IdentityTranslator
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        // we are not in a normal fork context
-        if (!defined('APPLICATION')) {
-            return parent::trans($id, $parameters, $domain, $locale);
-        }
-
         $possibleActions = ['lbl', 'err', 'msg'];
         if (self::get() === FrontendLanguage::class) {
             $possibleActions[] = 'act';

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -412,28 +412,6 @@ class TemplateModifiers extends BaseTwigModifiers
     }
 
     /**
-     * Translate a string.
-     *    syntax {{ $string|trans }}
-     *
-     * @param string $string The string that you want to apply this method on.
-     *
-     * @return string The string, to translate.
-     */
-    public static function trans($string)
-    {
-        if (strpos($string, '.') === false) {
-            return $string;
-        }
-        list($action, $string) = explode('.', $string);
-
-        if (!in_array($action, array('lbl', 'act', 'err', 'msg'))) {
-            return $string;
-        }
-
-        return Language::$action($string);
-    }
-
-    /**
      * Formats plain text as HTML, links will be detected, paragraphs will be inserted
      *    syntax: {{ $string|cleanupPlainText }}.
      *


### PR DESCRIPTION
## Type

- Feature

## Pull request description

You can now use the trans function of the translator service to translate strings with our system

Instead of `Language::lbl('MyLabel')` you can now do `$this->get'translator')->trans('lbl.MyLabel')`

If we can't translate it it will fallback to the default translation of symfony

If symfony also can't translate it we will return our normal fallback?-.

This was needed to be able to translate the error messages from symfony forms automatically but also makes it easier to move away from using static classes in our code to use the translations.

it also fixes the bug that the error messages when there was missing data for content blocks wasn't translated, see 935ffa1
