### PR TITLE
Fix add link on the blog index page when filtering on a category

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Index.html.twig
@@ -5,7 +5,7 @@
     <div class="btn-group" role="group">
       {% if showBlogAdd %}
         {% if filterCategory %}
-          {{ macro.buttonIcon( geturl('add', null, '&category=#{filterCategory.id}'), 'plus-square', 'lbl.Add'|trans|ucfirst) }}
+          {{ macro.buttonIcon( geturl('add', null, '&category='~filterCategory.id), 'plus-square', 'lbl.Add'|trans|ucfirst) }}
         {% endif %}
         {% if not filterCategory %}
           {{ macro.buttonIcon( geturl('add'), 'plus-square', 'lbl.Add'|trans|ucfirst) }}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1770 

## Pull request description

The id of the category was not passed correctly to the add action