### PR TITLE
Ignore foreign key checks when removing all the tables

### DIFF
--- a/tools/prepare_for_reinstall
+++ b/tools/prepare_for_reinstall
@@ -51,7 +51,7 @@ clear_database() {
 
     for t in $tables
     do
-        $mysql_command -e "drop table $t"
+        $mysql_command -e "SET FOREIGN_KEY_CHECKS = 0;drop table $t;"
     done
 
     return 1;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

I had some tables with foreign keys and when there was a conflict those tables didn't get deleted
This then gave errors when installing the module since the tables partially already existed