### PR TITLE
Remove server root from loading dirs

### DIFF
--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -147,7 +147,6 @@ class TwigTemplate extends BaseTwigTemplate
                 $this->themePath,
                 FRONTEND_MODULES_PATH,
                 FRONTEND_PATH,
-                '/',
             ),
             function ($folder) use ($filesystem) {
                 return $filesystem->exists($folder);


### PR DESCRIPTION
## Type
- Critical bugfix
## Pull request description

Fix the error you get when open_basedir is active on a server.

`Warning: file_exists(): open_basedir restriction in effect. File(/) is not within the allowed path(s)`
