### PR TITLE
__DIR__ was added in PHP 5.3 so we can use that instead

### DIFF
--- a/app/console
+++ b/app/console
@@ -21,7 +21,7 @@ $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?:
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 // Fork has not yet been installed
-$parametersFile = dirname(__FILE__) . '/config/parameters.yml';
+$parametersFile = __DIR__ . '/config/parameters.yml';
 if (!file_exists($parametersFile)) {
     $env = 'install';
 }

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
  */
 
 // CLI/Nginx/Cron: We need to set the "current working directory" to this folder
-chdir(dirname(__FILE__));
+chdir(__DIR__);
 
 // vendors not installed
 if (!is_dir(__DIR__ . '/vendor')) {
@@ -29,7 +29,7 @@ $env = getenv('FORK_ENV') ?: 'prod';
 $debug = getenv('FORK_DEBUG') === '1';
 
 // Fork has not yet been installed
-$parametersFile = dirname(__FILE__) . '/app/config/parameters.yml';
+$parametersFile = __DIR__ . '/app/config/parameters.yml';
 $request = Request::createFromGlobals();
 if (!file_exists($parametersFile)) {
     $env = 'install';


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

Since __DIR__ was added in PHP 5.3 and the minimum version of fork is 5.5 I see no reason why we shouldn't use it


