### PR TITLE
Officially deprecate our own events in favour of symfony events

### DIFF
--- a/src/Backend/Core/Cronjobs/ProcessQueuedHooks.php
+++ b/src/Backend/Core/Cronjobs/ProcessQueuedHooks.php
@@ -16,6 +16,10 @@ use Backend\Core\Engine\Model as BackendModel;
 
 /**
  * This is the cronjob that processes the queued hooks.
+ *
+ * @deprecated use the symfony event dispatcher instead
+ *
+ * When removing this the table in the database should also be removed
  */
 class ProcessQueuedHooks extends Cronjob
 {
@@ -24,6 +28,11 @@ class ProcessQueuedHooks extends Cronjob
      */
     public function execute()
     {
+        trigger_error(
+            'Deprecated, you should use the symfony event dispatcher',
+            E_USER_DEPRECATED
+        );
+
         // no timelimit
         set_time_limit(0);
 

--- a/src/Common/Core/Model.php
+++ b/src/Common/Core/Model.php
@@ -304,9 +304,16 @@ class Model extends \BaseModel
      * @param mixed  $callback    The callback that should be executed when the event is triggered.
      *
      * @throws \Exception          When the callback is invalid
+     *
+     * @deprecated use the symfony event dispatcher instead
      */
     public static function subscribeToEvent($eventModule, $eventName, $module, $callback)
     {
+        trigger_error(
+            'Deprecated, all events will be replaced with symfony events',
+            E_USER_DEPRECATED
+        );
+
         // validate
         if (!is_callable($callback)) {
             throw new \Exception('Invalid callback!');
@@ -351,6 +358,8 @@ class Model extends \BaseModel
      * @param string $module    The module that triggers the event.
      * @param string $eventName The name of the event.
      * @param mixed  $data      The data that should be send to subscribers.
+     *
+     * @deprecated use the symfony event dispatcher instead
      */
     public static function triggerEvent($module, $eventName, $data = null)
     {
@@ -399,6 +408,8 @@ class Model extends \BaseModel
 
     /**
      * Start processing the hooks
+     *
+     * @deprecated use the symfony event dispatcher instead
      */
     public static function startProcessingHooks()
     {
@@ -487,6 +498,8 @@ class Model extends \BaseModel
      * @param string $eventModule The module that triggers the event.
      * @param string $eventName   The name of the event.
      * @param string $module      The module that subscribes to the event.
+     *
+     * @deprecated use the symfony event dispatcher instead
      */
     public static function unsubscribeFromEvent($eventModule, $eventName, $module)
     {


### PR DESCRIPTION
## Type

- Deprecation

Like asked in https://github.com/forkcms/forkcms/pull/1125