### PR TITLE
Fix install button not hiding of installed theme

### DIFF
--- a/src/Backend/Modules/Extensions/Actions/DetailTheme.php
+++ b/src/Backend/Modules/Extensions/Actions/DetailTheme.php
@@ -152,7 +152,7 @@ class DetailTheme extends BackendBaseActionIndex
         $this->tpl->assign('warnings', $this->warnings);
         $this->tpl->assign('information', $this->information);
         $this->tpl->assign(
-            'showExtensionsInstallTheme',
+            'showInstallButton',
             !BackendExtensionsModel::isThemeInstalled($this->currentTheme) && BackendAuthentication::isAllowedAction(
                 'InstallTheme'
             )

--- a/src/Backend/Modules/Extensions/Layout/Templates/DetailTheme.html.twig
+++ b/src/Backend/Modules/Extensions/Layout/Templates/DetailTheme.html.twig
@@ -96,7 +96,7 @@
       </div>
     </div>
   {% endif %}
-  {% if showExtensionsInstallTheme %}
+  {% if showInstallButton %}
     <div class="row fork-module-actions">
       <div class="col-md-12">
         <div class="btn-toolbar">


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Hide the install button on already installed themes


