### PR TITLE
Fix editing a form of the FormBuilder removes the edit_link on the page editor

### DIFF
--- a/src/Backend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Model.php
@@ -566,7 +566,12 @@ class Model
 
         // build array
         $extra['data'] = serialize(
-            array('language' => BL::getWorkingLanguage(), 'extra_label' => $values['name'], 'id' => $id)
+            array(
+                'language' => BL::getWorkingLanguage(),
+                'extra_label' => $values['name'],
+                'id' => $id,
+                'edit_url' => BackendModel::createURLForAction('Edit') . '&id=' . $id,
+            )
         );
 
         // update extra


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1752

## Pull request description

fixes the fact that editing a form of the form builder removed the edit link