### PR TITLE
FIX send mail by a Cronjob / URL object not available

### DIFF
--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -149,7 +149,7 @@ class TwigTemplate extends BaseTwigTemplate
         );
 
         // check on url object
-        if(class_exists('url')) {
+        if (class_exists('url')) {
 
             $url = Model::get('url');
 
@@ -391,7 +391,7 @@ class TwigTemplate extends BaseTwigTemplate
         $this->assign('timestamp', time());
 
         // check on url object
-        if(class_exists('url')) {
+        if (class_exists('url')) {
 
             // assign body ID
             $url = Model::get('url');

--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -148,28 +148,33 @@ class TwigTemplate extends BaseTwigTemplate
             Model::getContainer()->getParameter('site.multilanguage')
         );
 
-        $url = Model::get('url');
+        // check on url object
+        if(class_exists('url')) {
 
-        if ($url instanceof Url) {
-            // assign the current module
-            $this->assign('MODULE', $url->getModule());
+            $url = Model::get('url');
 
-            // assign the current action
-            if ($url->getAction() != '') {
-                $this->assign('ACTION', $url->getAction());
+            if ($url instanceof Url) {
+                // assign the current module
+                $this->assign('MODULE', $url->getModule());
+
+                // assign the current action
+                if ($url->getAction() != '') {
+                    $this->assign('ACTION', $url->getAction());
+                }
+
+                if ($url->getModule() == 'Core') {
+                    $this->assign(
+                        'BACKEND_MODULE_PATH',
+                        BACKEND_PATH . '/' . $url->getModule()
+                    );
+                } else {
+                    $this->assign(
+                        'BACKEND_MODULE_PATH',
+                        BACKEND_MODULES_PATH . '/' . $url->getModule()
+                    );
+                }
             }
 
-            if ($url->getModule() == 'Core') {
-                $this->assign(
-                    'BACKEND_MODULE_PATH',
-                    BACKEND_PATH . '/' . $url->getModule()
-                );
-            } else {
-                $this->assign(
-                    'BACKEND_MODULE_PATH',
-                    BACKEND_MODULES_PATH . '/' . $url->getModule()
-                );
-            }
         }
 
         // is the user object filled?
@@ -385,22 +390,27 @@ class TwigTemplate extends BaseTwigTemplate
         // assign current timestamp
         $this->assign('timestamp', time());
 
-        // assign body ID
-        $url = Model::get('url');
-        if ($url instanceof Url) {
-            $this->assign('bodyID', \SpoonFilter::toCamelCase($url->getModule(), '_', true));
+        // check on url object
+        if(class_exists('url')) {
 
-            // build classes
-            $bodyClass = \SpoonFilter::toCamelCase($url->getModule() . '_' . $url->getAction(), '_', true);
+            // assign body ID
+            $url = Model::get('url');
 
-            // special occasions
-            if ($url->getAction() == 'add' || $url->getAction() == 'edit'
-            ) {
-                $bodyClass = $url->getModule() . 'AddEdit';
+            if ($url instanceof Url) {
+                $this->assign('bodyID', \SpoonFilter::toCamelCase($url->getModule(), '_', true));
+
+                // build classes
+                $bodyClass = \SpoonFilter::toCamelCase($url->getModule() . '_' . $url->getAction(), '_', true);
+
+                // special occasions
+                if ($url->getAction() == 'add' || $url->getAction() == 'edit'
+                ) {
+                    $bodyClass = $url->getModule() . 'AddEdit';
+                }
+
+                // assign
+                $this->assign('bodyClass', $bodyClass);
             }
-
-            // assign
-            $this->assign('bodyClass', $bodyClass);
         }
 
         if (Model::has('navigation')) {

--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -149,8 +149,7 @@ class TwigTemplate extends BaseTwigTemplate
         );
 
         // check on url object
-        if (class_exists('url')) {
-
+        if (Model::getContainer()->has('url')) {
             $url = Model::get('url');
 
             if ($url instanceof Url) {
@@ -174,7 +173,6 @@ class TwigTemplate extends BaseTwigTemplate
                     );
                 }
             }
-
         }
 
         // is the user object filled?
@@ -391,9 +389,7 @@ class TwigTemplate extends BaseTwigTemplate
         $this->assign('timestamp', time());
 
         // check on url object
-        if (class_exists('url')) {
-
-            // assign body ID
+        if (Model::getContainer()->has('url')) {
             $url = Model::get('url');
 
             if ($url instanceof Url) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues

When sending an email from a cronjob (by Common/Mailer) the system throws an error, because the URL object is not known in the Cronjob.
Checking on the existence of the object fixes the error.

## Pull request description

Implemented class_exists().
It works, but if there is a better way let me know!