### PR TITLE
Remove devtools plugin from CKEditor

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -358,7 +358,7 @@ jsBackend.ckeditor =
         extraPlugins: 'stylesheetparser,mediaembed',
 
         // remove useless plugins
-        removePlugins: 'a11yhelp,about,bidi,colorbutton,colordialog,elementspath,font,find,flash,forms,horizontalrule,indent,newpage,pagebreak,preview,print,scayt,smiley,showblocks',
+        removePlugins: 'a11yhelp,about,bidi,colorbutton,colordialog,elementspath,font,find,flash,forms,horizontalrule,indent,newpage,pagebreak,preview,print,scayt,smiley,showblocks,devtools',
 
         // templates
         templates_files: [],


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
- Annoying devtools tooltips when using CKeditor: http://d.pr/v/1iACj

## Pull request description
Remove devtools from the ckeditor plugins. 

