### PR TITLE
Fix error's not showing when adding categories on the blog add or edit action

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
@@ -174,7 +174,7 @@
               {{ macro.required }}
             </label>
             <input type="text" name="categoryTitle" id="categoryTitle" class="form-control" maxlength="255" />
-            <p class="text-danger" id="categoryTitle'err.r" style="display: none;">{{ 'err.FieldIsRequired'|trans|ucfirst }}</p>
+            <p class="text-danger" id="categoryTitleError" style="display: none;">{{ 'err.FieldIsRequired'|trans|ucfirst }}</p>
           </div>
         </div>
         <div class="modal-footer">

--- a/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
@@ -258,7 +258,7 @@
               {{ macro.required }}
             </label>
             <input type="text" name="categoryTitle" id="categoryTitle" class="form-control" maxlength="255" />
-            <p class="text-danger" id="categoryTitle'err.r" style="display: none;">{{ 'err.FieldIsRequired'|trans|ucfirst }}</p>
+            <p class="text-danger" id="categoryTitleError" style="display: none;">{{ 'err.FieldIsRequired'|trans|ucfirst }}</p>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Type
- Non critical bugfix
## Pull request description

The id was broken of the paragraph where the errors would be shown
