### PR TITLE
Fix web path of images if they are in a subdirectory

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -52,8 +52,14 @@ abstract class AbstractImage extends AbstractFile
     public function getWebPath($subDirectory = null)
     {
         $file = $this->getAbsolutePath($subDirectory);
+
         if (is_file($file) && file_exists($file)) {
-            return FRONTEND_FILES_URL . '/' . $this->getTrimmedUploadDir() . '/' . $this->fileName;
+            $webPath = FRONTEND_FILES_URL . '/' . $this->getTrimmedUploadDir() . '/';
+            if ($subDirectory !== null) {
+                $webPath .= $subDirectory . '/';
+            }
+
+            return $webPath . $this->fileName;
         }
 
         return static::FALLBACK_IMAGE;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

the web path did check if the image existed in the subdirectory but didn't include the subdirectory in the returned url


