### PR TITLE
Fix incorrect use of $this->header->addJS

### DIFF
--- a/src/Backend/Modules/Location/Actions/Edit.php
+++ b/src/Backend/Modules/Location/Actions/Edit.php
@@ -44,7 +44,7 @@ class Edit extends BackendBaseActionEdit
 
         // does the item exists
         if ($this->id !== null && BackendLocationModel::exists($this->id)) {
-            $this->header->addJS(FrontendLocationModel::getPathToMapStyles(), true);
+            $this->header->addJS(FrontendLocationModel::getPathToMapStyles());
             parent::execute();
 
             // define Google Maps API key

--- a/src/Backend/Modules/Location/Actions/Index.php
+++ b/src/Backend/Modules/Location/Actions/Index.php
@@ -41,7 +41,7 @@ class Index extends BackendBaseActionIndex
      */
     public function execute()
     {
-        $this->header->addJS(FrontendLocationModel::getPathToMapStyles(), true);
+        $this->header->addJS(FrontendLocationModel::getPathToMapStyles());
         parent::execute();
 
         // define Google Maps API key


### PR DESCRIPTION
## Type
- Critical bugfix
## Resolves the following issues

You got a filemtime(): start failed error on the backend location index and edit actions, plus the maps didn't work, obviously.
## Pull request description

Fixed the way the LocationMapStyles.js map was included in the backend, this was a poor copy of the frontend inclusions, this caused our module to be '1'
