### PR TITLE
Custom html5 validation

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -3499,6 +3499,20 @@
         <translation language="el"><![CDATA[Λανθασμένος Κωδικός.]]></translation>
         <translation language="pl"><![CDATA[złe hasło]]></translation>
       </item>
+      <item type="error" name="InvalidValue">
+        <translation language="nl"><![CDATA[Ongeldige waarde.]]></translation>
+        <translation language="en"><![CDATA[Invalid value.]]></translation>
+        <translation language="hu"><![CDATA[Helytelen érték.]]></translation>
+        <translation language="ru"><![CDATA[Неверное значение.]]></translation>
+        <translation language="it"><![CDATA[Valore non valido.]]></translation>
+        <translation language="zh"><![CDATA[无效的值。]]></translation>
+        <translation language="fr"><![CDATA[Valeur incorrecte.]]></translation>
+        <translation language="de"><![CDATA[Ungültiger Wert.]]></translation>
+        <translation language="es"><![CDATA[Valor no válido.]]></translation>
+        <translation language="lt"><![CDATA[Neteisinga reikšmė.]]></translation>
+        <translation language="sv"><![CDATA[Ogiltigt värde.]]></translation>
+        <translation language="el"><![CDATA[Μη έγκυρη τιμή.]]></translation>
+      </item>
       <item type="error" name="InvalidPrice">
         <translation language="nl"><![CDATA[Gelieve een geldig bedrag in te geven.]]></translation>
         <translation language="en"><![CDATA[Please insert a valid price.]]></translation>

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -174,6 +174,7 @@ jsFrontend.forms =
 	{
 		jsFrontend.forms.placeholders();
 		jsFrontend.forms.datefields();
+		jsFrontend.forms.validation();
 		jsFrontend.forms.filled();
 	},
 
@@ -304,6 +305,23 @@ jsFrontend.forms =
 				});
 			}
 		}
+	},
+
+	validation: function()
+	{
+		$('input, textarea, select').each(function() {
+			var $input = $(this),
+				options = {};
+
+			// Check for custom error messages
+			$.each($input.data(), function(key, value) {
+				if (key.indexOf('error') < 0) return;
+				key = key.replace('error', '').toLowerCase();
+				options[key] = value;
+			});
+
+			$input.html5validation(options);
+		});
 	},
 
 	// placeholder fallback for browsers that don't support placeholder

--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -331,3 +331,47 @@
 		});
 	};
 })(jQuery);
+
+/**
+ * HTML5 validation
+ */
+(function($)
+{
+	$.fn.html5validation = function(options)
+	{
+		// define defaults
+		var $input = $(this),
+			errorMessage = '',
+			type = '',
+			defaults =
+			{
+				required: jsFrontend.locale.err('FieldIsRequired'),
+				email: 	  jsFrontend.locale.err('EmailIsInvalid'),
+				date: 	  jsFrontend.locale.err('DateIsInvalid'),
+				numeric:  jsFrontend.locale.err('NumberIsInvalid'),
+				value:    jsFrontend.locale.err('InvalidValue')
+			};
+
+		options = $.extend(defaults, options);
+
+		$input.on('invalid', function(e) {
+
+			if ($input.context.validity.valueMissing) {
+				errorMessage = options.required;
+			} else if (!$input.context.validity.valid) {
+				type = $input.context.type;
+				errorMessage = options.value;
+
+				if(options[type]) {
+					errorMessage = options[type];
+				}
+			}
+
+			e.target.setCustomValidity(errorMessage);
+
+			$input.on('input', function(e) {
+				e.target.setCustomValidity('');
+			});
+		});
+	};
+})(jQuery);

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -10,6 +10,9 @@ use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Modules\FormBuilder\Engine\Model as FrontendFormBuilderModel;
 use Frontend\Modules\FormBuilder\FormBuilderEvents;
 use Frontend\Modules\FormBuilder\Event\FormBuilderSubmittedEvent;
+use SpoonFormAttributes;
+use SpoonFormMultiCheckbox;
+use SpoonFormRadiobutton;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -148,6 +151,7 @@ class Form extends FrontendBaseWidget
 
         // exists and has fields
         if (!empty($this->item) && !empty($this->item['fields'])) {
+            //dump($this->item['fields'] );die;
             // loop fields
             foreach ($this->item['fields'] as $field) {
                 // init
@@ -157,6 +161,7 @@ class Form extends FrontendBaseWidget
                 $item['placeholder'] = (isset($field['settings']['placeholder']) ? $field['settings']['placeholder'] : null);
                 $item['classname'] = (isset($field['settings']['classname']) ? $field['settings']['classname'] : null);
                 $item['required'] = isset($field['validations']['required']);
+                $item['validations'] = isset($field['validations']) ? $field['validations'] : [];
                 $item['html'] = '';
 
                 // form values
@@ -187,6 +192,7 @@ class Form extends FrontendBaseWidget
                         $ddm->setAttribute('required', null);
                     }
 
+                    $this->setCustomHTML5ErrorMessages($item, $ddm);
                     // get content
                     $item['html'] = $ddm->parse();
                 } elseif ($field['type'] == 'radiobutton') {
@@ -217,12 +223,17 @@ class Form extends FrontendBaseWidget
                     if ($item['required']) {
                         $txt->setAttribute('required', null);
                     }
-                    if (isset($field['validations']['email'])) {
+                    if (isset($item['validations']['email'])) {
                         $txt->setAttribute('type', 'email');
+                    }
+                    if (isset($item['validations']['numeric'])) {
+                        $txt->setAttribute('type', 'number');
                     }
                     if ($item['placeholder']) {
                         $txt->setAttribute('placeholder', $item['placeholder']);
                     }
+
+                    $this->setCustomHTML5ErrorMessages($item, $txt);
 
                     // get content
                     $item['html'] = $txt->parse();
@@ -269,6 +280,8 @@ class Form extends FrontendBaseWidget
                         $datetime->setAttribute('required', null);
                     }
 
+                    $this->setCustomHTML5ErrorMessages($item, $datetime);
+
                     // get content
                     $item['html'] = $datetime->parse();
                 } elseif ($field['type'] == 'textarea') {
@@ -284,6 +297,8 @@ class Form extends FrontendBaseWidget
                         $txt->setAttribute('placeholder', $item['placeholder']);
                     }
 
+                    $this->setCustomHTML5ErrorMessages($item, $txt);
+
                     // get content
                     $item['html'] = $txt->parse();
                 } elseif ($field['type'] == 'heading') {
@@ -297,6 +312,20 @@ class Form extends FrontendBaseWidget
                 // add to list
                 $this->fieldsHTML[] = $item;
             }
+        }
+    }
+
+    /**
+     * @param array $item
+     * @param SpoonFormAttributes $formField
+     */
+    private function setCustomHTML5ErrorMessages(array $item, SpoonFormAttributes $formField)
+    {
+        foreach ($item['validations'] as $validation) {
+            $formField->setAttribute(
+                'data-error-' . $validation['type'],
+                $validation['error_message']
+            );
         }
     }
 


### PR DESCRIPTION
## Type

- Enhancement
- Feature

## Pull request description

HTML5 validation messages use the translations and can be custom set by adding a data-error attribute on a form element.