### PR TITLE
Renaming "getName()" to "getBlockPrefix()" since this is deprecated since 2.8. and will be removed in 3.0

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Form/ContentBlockType.php
+++ b/src/Backend/Modules/ContentBlocks/Form/ContentBlockType.php
@@ -95,7 +95,7 @@ class ContentBlockType extends AbstractType
     /**
      * @return string
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'content_block';
     }


### PR DESCRIPTION
Symfony 3.0 requires this.