### PR TITLE
Return a clone of the file when there are changes

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -97,18 +97,22 @@ abstract class AbstractFile
      * Sets file.
      *
      * @param UploadedFile $file
+     *
+     * @return static
      */
     public function setFile(UploadedFile $file = null)
     {
         $this->file = $file;
         // check if we have an old image path
         if (!isset($this->fileName)) {
-            return;
+            return $this;
         }
 
         // store the old name to delete after the update
         $this->oldPath = $this->fileName;
         $this->fileName = null;
+
+        return clone $this;
     }
 
     /**


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

This will make it easier to let doctrine detect the changes
SInce it is a value object you had to add a changed on to make doctrine update the entity
By returning a clone when there is a change the object reference will have changed causing doctrine to detect it