### PR TITLE
Fixing Backend sandbox to stand alone

### DIFF
--- a/src/Backend/Core/Engine/Base/Action.php
+++ b/src/Backend/Core/Engine/Base/Action.php
@@ -62,7 +62,7 @@ class Action extends Object
         parent::__construct($kernel);
 
         // get objects from the reference so they are accessible from the action-object
-        $this->tpl = $this->getContainer()->get('template');
+        $this->tpl = new TwigTemplate();
         $this->URL = $this->getContainer()->get('url');
         $this->header = $this->getContainer()->get('header');
 

--- a/src/Backend/Core/Engine/Base/Widget.php
+++ b/src/Backend/Core/Engine/Base/Widget.php
@@ -71,7 +71,7 @@ class Widget extends \KernelLoader
     {
         parent::__construct($kernel);
 
-        $this->tpl = $this->getContainer()->get('template');
+        $this->tpl = new TwigTemplate();
         $this->header = $this->getContainer()->get('header');
     }
 

--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -30,14 +30,11 @@ class TwigTemplate extends BaseTwigTemplate
 {
     /**
      * The constructor will store the instance in the reference, preset some settings and map the custom modifiers.
-     *
-     * @param bool $addToReference Should the instance be added into the reference.
      */
-    public function __construct($addToReference = true)
+    public function __construct()
     {
-        if ($addToReference) {
-            Model::getContainer()->set('template', $this);
-        }
+        // We must set the template for later use
+        Model::getContainer()->set('template', $this);
 
         $this->forkSettings = Model::get('fork.settings');
         $this->debugMode = Model::getContainer()->getParameter('kernel.debug');

--- a/src/Backend/Modules/Extensions/Engine/Model.php
+++ b/src/Backend/Modules/Extensions/Engine/Model.php
@@ -17,6 +17,7 @@ use Backend\Core\Engine\Navigation;
 use Backend\Core\Engine\Exception;
 use Backend\Core\Language\Language as BL;
 use Backend\Core\Engine\Model as BackendModel;
+use Backend\Core\Engine\TwigTemplate;
 
 /**
  * In this file we store all generic functions that we will be using in the extensions module.
@@ -126,7 +127,7 @@ class Model
             }
         }
 
-        $templating = BackendModel::get('template');
+        $templating = new TwigTemplate();
         $templating->assign('table', $htmlContent);
         $html = $templating->getContent('Extensions/Layout/Templates/Templates.html.twig');
 

--- a/src/Common/Core/Twig/BaseTwigTemplate.php
+++ b/src/Common/Core/Twig/BaseTwigTemplate.php
@@ -73,6 +73,10 @@ abstract class BaseTwigTemplate extends TwigEngine
             return;
         }
 
+        if (array_key_exists($key, $this->variables) && strpos($key, 'show') === 0) {
+            throw new \Exception('The variable "' . $key . '" you are trying to assign is already automatically generated based on the "action rights of the user" and therefore can\'t be overwritten.');
+        }
+
         // in all other cases
         $this->variables[$key] = $values;
     }
@@ -105,7 +109,7 @@ abstract class BaseTwigTemplate extends TwigEngine
         // merge the variables array_merge might be to slow for bigger sites
         // as array_merge tend to slow down at +100 keys
         foreach ($variables as $key => $val) {
-            $this->variables[$key] = $val;
+            $this->assign($key, $val);
         }
     }
 


### PR DESCRIPTION
I've discovered that the Backend uses previous template ($this->get('template)) for every widget that it creates. This isn't correct behavior for sandboxed templates. They should be empty at start.

Note: The same occurs in Frontend... When you try generating a widget, all previously assigned variables are gone, poefff, foetsie!!!


More information:

**This doesn't work**
```php
    /**
     * Parse
     */
    protected function parse()
    {
        // Assign MediaGallery
        $this->tpl->assign(
            'mediaGallery',
            ($this->mediaGallery) ? $this->mediaGallery : false
        );

        // Assign widget
        $this->tpl->assign(
            'widget',
            // We can create widget for the MediaGroup id
            $this->get('media_library.helper.frontend')->parseWidget(
                $this->mediaGallery->getAction(),
                $this->mediaGroup->getId()
            )
        );
    }
```
> Because we define "widget" (which generated a widget) after "mediaGallery", the widget sandbox deletes everything from the parent sandbox (= this is a BUG). Which will mean that "mediaGallery" is not parsed to the template.

Temporary fix:
Moving the "mediaGallery" assign below the "widget" assign fixes everything...

Another problem:
When you want to assign "two generated widgets" new problems occur, since the first widget will now be removed (because of this sandbox error).

Temporary fix for that:
```php
$this->tpl->assignArray(
    array(
        array(
            'firstWidget',
            // We can create widget for the MediaGroup id
            $this->get('media_library.helper.frontend')->parseWidget(
                $this->mediaGallery->getAction(),
                $this->mediaGroup->getId()
            ),
            'secondWidget',
            // We can create widget for the MediaGroup id
            $this->get('media_library.helper.frontend')->parseWidget(
                $this->mediaGallery->getAction(),
                $this->mediaGroup->getId()
            )
        ) 
    )
)
```