### PR TITLE
Add missing createForm method in the frontend

### DIFF
--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -15,6 +15,8 @@ use Frontend\Core\Engine\Breadcrumb;
 use Frontend\Core\Engine\Exception;
 use Frontend\Core\Engine\Header;
 use Frontend\Core\Engine\TwigTemplate;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -564,5 +566,19 @@ class Block extends Object
                 ['name' => 'robots', 'content' => $meta->getSEOIndex()]
             );
         }
+    }
+
+    /**
+     * Creates and returns a Form instance from the type of the form.
+     *
+     * @param string|FormTypeInterface $type The built type of the form
+     * @param mixed $data The initial data for the form
+     * @param array $options Options for the form
+     *
+     * @return Form
+     */
+    public function createForm($type, $data = null, array $options = array())
+    {
+        return $this->get('form.factory')->create($type, $data, $options);
     }
 }

--- a/src/Frontend/Core/Engine/Base/Widget.php
+++ b/src/Frontend/Core/Engine/Base/Widget.php
@@ -10,6 +10,8 @@ namespace Frontend\Core\Engine\Base;
  */
 
 use Frontend\Core\Engine\Header;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -275,5 +277,19 @@ class Widget extends Object
     protected function setTemplatePath($path)
     {
         $this->templatePath = (string) $path;
+    }
+
+    /**
+     * Creates and returns a Form instance from the type of the form.
+     *
+     * @param string|FormTypeInterface $type The built type of the form
+     * @param mixed $data The initial data for the form
+     * @param array $options Options for the form
+     *
+     * @return Form
+     */
+    public function createForm($type, $data = null, array $options = array())
+    {
+        return $this->get('form.factory')->create($type, $data, $options);
     }
 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

the `createForm` method had been added in the backend but not in the frontend