### PR TITLE
Fix serialize bug in meta entity SEOFollow and SEOIndex

### DIFF
--- a/src/Common/Doctrine/Entity/Meta.php
+++ b/src/Common/Doctrine/Entity/Meta.php
@@ -175,8 +175,12 @@ class Meta
     public function serialiseData()
     {
         if (!empty($this->data)) {
-            $this->data['seo_index'] = (string) $this->data['seo_index'];
-            $this->data['seo_follow'] = (string) $this->data['seo_follow'];
+            if (array_key_exists('seo_index', $this->data)) {
+                $this->data['seo_index'] = (string) $this->data['seo_index'];
+            }
+            if (array_key_exists('seo_follow', $this->data)) {
+                $this->data['seo_follow'] = (string) $this->data['seo_follow'];
+            }
             $this->data = serialize($this->data);
 
             return;
@@ -201,8 +205,12 @@ class Meta
                 $this->data
             );
             $this->data = unserialize($this->data);
-            $this->data['seo_index'] = SEOIndex::fromString($this->data['seo_index']);
-            $this->data['seo_follow'] = SEOFollow::fromString($this->data['seo_follow']);
+            if (array_key_exists('seo_index', $this->data)) {
+                $this->data['seo_index'] = SEOIndex::fromString($this->data['seo_index']);
+            }
+            if (array_key_exists('seo_follow', $this->data)) {
+                $this->data['seo_follow'] = SEOFollow::fromString($this->data['seo_follow']);
+            }
 
             return;
         }
@@ -355,10 +363,14 @@ class Meta
     }
 
     /**
-     * @return SEOIndex
+     * @return SEOIndex|null
      */
     public function getSEOIndex()
     {
+        if (!$this->hasSEOIndex()) {
+            return;
+        }
+
         return SEOIndex::fromString($this->data['seo_index']);
     }
 
@@ -368,10 +380,14 @@ class Meta
     }
 
     /**
-     * @return SEOFollow
+     * @return SEOFollow|null
      */
     public function getSEOFollow()
     {
+        if (!$this->hasSEOFollow()) {
+            return;
+        }
+
         return SEOFollow::fromString($this->data['seo_follow']);
     }
 }

--- a/src/Common/Doctrine/Entity/Meta.php
+++ b/src/Common/Doctrine/Entity/Meta.php
@@ -175,6 +175,8 @@ class Meta
     public function serialiseData()
     {
         if (!empty($this->data)) {
+            $this->data['seo_index'] = (string) $this->data['seo_index'];
+            $this->data['seo_follow'] = (string) $this->data['seo_follow'];
             $this->data = serialize($this->data);
 
             return;
@@ -191,7 +193,16 @@ class Meta
     public function unSerialiseData()
     {
         if ($this->data !== null) {
+            // backwards compatible fix for when the seo is saved with the serialized value objects
+            // @TODO remove this for fork 5
+            $this->data = preg_replace(
+                '$O\\:3[67]\\:"Common\\\\Doctrine\\\\ValueObject\\\\(?:(?:SEOIndex)|(?:SEOFollow))"\\:1\\:{s\\:4[68]\\:"\\x00Common\\\\Doctrine\\\\ValueObject\\\\(?:(?:SEOIndex)|(?:SEOFollow))\\x00(?:(?:SEOIndex)|(?:SEOFollow))";(s\\:\d+\\:".+?";)}$',
+                '$1',
+                $this->data
+            );
             $this->data = unserialize($this->data);
+            $this->data['seo_index'] = SEOIndex::fromString($this->data['seo_index']);
+            $this->data['seo_follow'] = SEOFollow::fromString($this->data['seo_follow']);
 
             return;
         }

--- a/src/Common/Doctrine/ValueObject/SEOFollow.php
+++ b/src/Common/Doctrine/ValueObject/SEOFollow.php
@@ -2,6 +2,8 @@
 
 namespace Common\Doctrine\ValueObject;
 
+use Serializable;
+
 final class SEOFollow
 {
     const NONE = 'none';

--- a/src/Common/Doctrine/ValueObject/SEOFollow.php
+++ b/src/Common/Doctrine/ValueObject/SEOFollow.php
@@ -2,8 +2,6 @@
 
 namespace Common\Doctrine\ValueObject;
 
-use Serializable;
-
 final class SEOFollow
 {
     const NONE = 'none';


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

The meta entity saved the SEOFollow and SEOIndex value objects wrong in the database

For backwards compatibility I added a regex replace that fixes the issue when loading the meta entity.

After saving it once the database should be ok.


