### PR TITLE
Prevent errors when clear text is passed to the trans function becaus…

### DIFF
--- a/src/Common/Language.php
+++ b/src/Common/Language.php
@@ -127,6 +127,10 @@ final class Language extends IdentityTranslator
             return parent::trans($id, $parameters, $domain, $locale);
         }
 
+        if (!strpos($id, '.')) {
+            return parent::trans($id, $parameters, $domain, $locale);
+        }
+
         list($action, $string) = explode('.', $id, 2);
 
         if (!in_array($action, $possibleActions)) {


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

cleartext as labels can cause the translation service to throw exceptions


…e of the missing .