### PR TITLE
Update Formbuilder mailing form: Form.html.twig

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Layout/Templates/Mails/Form.html.twig
+++ b/src/Frontend/Modules/FormBuilder/Layout/Templates/Mails/Form.html.twig
@@ -11,6 +11,6 @@
 
   <h3>{{ 'lbl.Content'|trans|ucfirst }}</h3>
   {% for field in fields %}
-    <p><strong>{{ field.label }}:</strong><br /> {{ field.value }}</p>
+    <p><strong>{{ field.label }}:</strong><br /> {{ field.value|raw }}</p>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1852 
html translations like "< br / >" stored in the DB will be sent in the mail as "enter"

## Pull request description

add |raw within the message content so html translations like "< br / >" are translated to "enter".
Issue mentioned within #1852 and solution proposed by @carakas 