### PR TITLE
Avoid duplicate slash in canonical URL.

### DIFF
--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -898,7 +898,7 @@ class Header extends FrontendBaseObject
                 $url .= ':' . $urlChunks['port'];
             }
             if (isset($urlChunks['path'])) {
-                $url .= '/' . $urlChunks['path'];
+                $url .= $urlChunks['path'];
             }
 
             // any items provided through GET?


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description

Returns `fork-cms.com/en`, `fork-cms/en/blog` instead of `fork-cms/en`,
`fork-cms//en/blog`.