### PR TITLE
Bugfix for SpoonFormException: The field "auth_required" does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+4.4.1 (2017-xx-yy)
+------------------
+
+Bugfixes:
+
+* Pages: Fix exception in Authentication option when profiles module is not installed
+
 4.4.0 (2016-12-02)
 ------------------
 
@@ -25,7 +32,7 @@ Features:
 
 * Core: Add redirect method to widgets
 * Core: Custom html5 validation
-* Page: Authentication options with the profiles module
+* Pages: Authentication options with the profiles module
 * MailMotor: Completely revamped module. Now also with MailChimp
 
 Deprecations:

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -654,7 +654,7 @@ class Edit extends BackendBaseActionEdit
                     $data['image'] = $this->getImage($this->templates[$templateId]['data']['image']);
                 }
 
-                if ($this->frm->getField('auth_required')->isChecked()) {
+                if ($this->frm->existsField('auth_required') && $this->frm->getField('auth_required')->isChecked()) {
                     $data['auth_required'] = true;
                     // check for groups
                     $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();


### PR DESCRIPTION
## Type

Critical bugfix

## Pull request description

Fix for SpoonFormException: The field "auth_required" does not exist. You will get this exception when the profiles module is not installed.
