### PR TITLE
Check if there are any auth groups.

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -659,7 +659,9 @@ class Edit extends BackendBaseActionEdit
                     // get all groups and parse them in key value pair
                     $groupItems = BackendProfilesModel::getGroups();
                     // check for groups
-                    if(!empty($groupItems)) $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();
+                    if(!empty($groupItems)) {
+                        $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();
+                    }
                 }
 
                 // build page record

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -659,7 +659,7 @@ class Edit extends BackendBaseActionEdit
                     // get all groups and parse them in key value pair
                     $groupItems = BackendProfilesModel::getGroups();
                     // check for groups
-                    if(!empty($groupItems)) {
+                    if (!empty($groupItems)) {
                         $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();
                     }
                 }

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -656,8 +656,10 @@ class Edit extends BackendBaseActionEdit
 
                 if (BackendModel::isModuleInstalled('Profiles') && $this->frm->getField('auth_required')->isChecked()) {
                     $data['auth_required'] = true;
+                    // get all groups and parse them in key value pair
+                    $groupItems = BackendProfilesModel::getGroups();
                     // check for groups
-                    $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();
+                    if(!empty($groupItems)) $data['auth_groups'] = $this->frm->getField('auth_groups')->getValue();
                 }
 
                 // build page record


### PR DESCRIPTION
## Type

- Critical bugfix


## Resolves the following issues

The fields to get aren't available when there are no BackendProfilesModel::getGroups()

## Pull request description

Check if there are any auth groups available after saving.

