### PR TITLE
Also check if auth_groups is set

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -271,7 +271,7 @@ class Edit extends BackendBaseActionEdit
                 }
                 // set checked values
                 $checkedGroups = array();
-                if (is_array($this->record['data']['auth_groups'])) {
+                if (isset($this->record['data']['auth_groups']) && is_array($this->record['data']['auth_groups'])) {
                     foreach ($this->record['data']['auth_groups'] as $group) {
                         $checkedGroups[] = $group;
                     }


### PR DESCRIPTION
## Type

- Critical bugfix


## Resolves the following issues

After creating the page auth_groups is not save.
But when there are groups from the profile module it tries to access them but there are none.

## Pull request description

This will add a check for it.


