### PR TITLE
Add missing alternate tags and fix redirect loop on 404 page

### DIFF
--- a/src/Frontend/Core/Engine/Header.php
+++ b/src/Frontend/Core/Engine/Header.php
@@ -223,7 +223,7 @@ class Header extends FrontendBaseObject
         $uniqueKeys = (array) $uniqueKeys;
 
         if ($uniqueKeys == null) {
-            $uniqueKeys = array('rel', 'type', 'title');
+            $uniqueKeys = array('rel', 'hreflang', 'type', 'title');
         }
 
         // stop if the content is empty

--- a/src/Frontend/Core/Engine/Navigation.php
+++ b/src/Frontend/Core/Engine/Navigation.php
@@ -482,14 +482,16 @@ class Navigation extends FrontendBaseObject
         $keys = self::getKeys($language);
 
         // get the URL, if it doesn't exist return 404
-        if (!isset($keys[$pageId])) {
+        if (!isset($keys[$pageId]) && $pageId !== 404) {
             return self::getURL(404, $language);
-        } else {
-            $url .= $keys[$pageId];
+        }
+
+        if (empty($keys)) {
+            return urldecode($url . 404);
         }
 
         // return the URL
-        return urldecode($url);
+        return urldecode($url . $keys[$pageId]);
     }
 
     /**

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -493,6 +493,42 @@ class Page extends FrontendBaseObject
         // create navigation instance
         new Navigation($this->getKernel());
 
+        // Multi language is activated
+        if ($this->getContainer()->getParameter('site.multilanguage')) {
+            $links = array();
+
+            // Get languages
+            $activeLanguages = Language::getActiveLanguages();
+
+            // Loop active languages
+            foreach ($activeLanguages as $language) {
+                // Define url
+                $url = Navigation::getURL($this->pageId, $language);
+
+                // Ignore 404 links
+                if (($this->pageId !== 404) && ($url === Navigation::getURL(404, $language))) {
+                    continue;
+                }
+
+                // Convert relative to absolute url
+                if (substr($url, 0, 1) == '/') {
+                    $url = SITE_URL . $url;
+                }
+
+                $links[$language] = $url;
+            }
+
+            // We must only add links if we have more then one
+            if (count($links) > 1) {
+                foreach ($links as $language => $url) {
+                    // Add hreflang
+                    $this->header->addLink(
+                        array('rel' => 'alternate', 'hreflang' => $language, 'href' => $url)
+                    );
+                }
+            }
+        }
+
         // assign content
         $pageInfo = Navigation::getPageInfo($this->record['id']);
         $this->record['has_children'] = $pageInfo['has_children'];

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -502,6 +502,10 @@ class Page extends FrontendBaseObject
 
             // Loop active languages
             foreach ($activeLanguages as $language) {
+                if ($language === LANGUAGE) {
+                    continue;
+                }
+
                 // Define url
                 $url = Navigation::getURL($this->pageId, $language);
 


### PR DESCRIPTION
## Type

- Bug Fix

## Resolves the following issues

fixes #1866

## Pull request description

Adds missing alternate tags to pages when we have them in an other language.

Also fixes the redirect loop on a 404

