### PR TITLE
Fix live suggest ajax call

### DIFF
--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -107,7 +107,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         // output
         $this->output(
             self::OK,
-            $this->tpl->renderTemplate(FRONTEND_PATH . '/Modules/Search/Layout/Templates/Results.html.twig')
+            $this->tpl->render(FRONTEND_PATH . '/Modules/Search/Layout/Templates/Results.html.twig')
         );
     }
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Live suggest ajax call tries to call renderTemplate on TwigTemplate, but that doesn't exists, should be render, which exists.


Method renderTemplate() doesn't exist, it should be render().