### PR TITLE
Fix Doctrine AnnotationRegistry::registerLoader error

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -3,7 +3,7 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // use vendor generated autoloader
-$loader = require_once __DIR__ . '/vendor/autoload.php';
+$loader = require __DIR__ . '/vendor/autoload.php';
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 
 require_once __DIR__ . '/app/KernelLoader.php';


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When running `./bin/phpunit` in fork cms, I get the following error:

```
Fatal error: Uncaught InvalidArgumentException: A callable is expected in AnnotationRegistry::registerLoader(). in /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationRegistry.php on line 111

InvalidArgumentException: A callable is expected in AnnotationRegistry::registerLoader(). in /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationRegistry.php on line 111
```

<details>

```
Call Stack:
    0.0009     384144   1. {main}() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/phpunit:0
    0.0144    1348640   2. PHPUnit_TextUI_Command::main() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/phpunit:47
    0.0144    1348752   3. PHPUnit_TextUI_Command->run() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/TextUI/Command.php:100
    0.0144    1348752   4. PHPUnit_TextUI_Command->handleArguments() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/TextUI/Command.php:111
    0.0205    1736712   5. PHPUnit_TextUI_Command->handleBootstrap() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/TextUI/Command.php:598
    0.0207    1742200   6. PHPUnit_Util_Fileloader::checkAndLoad() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/TextUI/Command.php:779
    0.0207    1742312   7. PHPUnit_Util_Fileloader::load() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/Util/Fileloader.php:38
    0.0208    1745320   8. include_once('/Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/autoload.php') /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/vendor/phpunit/phpunit/src/Util/Fileloader.php:56
    0.0211    1759200   9. Doctrine\Common\Annotations\AnnotationRegistry::registerLoader() /Users/jessedobbelaere/Dropbox/www/fork-cms/fork-cms-github/autoload.php:7
```

</details>

## Pull request description
The only solutions I read was disabling eAccelerator or OPCache. But I explicitly turned off all PHP caching on my local dev machine.  I was checking and comparing other `autoload.php` files from other projects I worked on, and they all used `require` instead of `require_once` in the autoload.php. Seems that fixed my issue right away. PHPUnit now runs.

Symfony uses require so won't hurt: https://github.com/symfony/symfony-standard/blob/master/app/autoload.php

I tested the content blocks module and still works. 

