### PR TITLE
Fix https mixed content warnings

### DIFF
--- a/src/Backend/Core/info.xml
+++ b/src/Backend/Core/info.xml
@@ -9,7 +9,7 @@
   <authors>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Matthias Mullie]]></name>

--- a/src/Backend/Modules/Blog/Installer/Installer.php
+++ b/src/Backend/Modules/Blog/Installer/Installer.php
@@ -321,7 +321,7 @@ class Installer extends ModuleInstaller
                     'created_on' => gmdate('Y-m-d H:i:00'),
                     'author' => 'Tijs Verkoyen',
                     'email' => 'forkcms-sample@sumocoders.be',
-                    'website' => 'http://www.sumocoders.be',
+                    'website' => 'https://www.sumocoders.be',
                     'text' => 'wicked!',
                     'type' => 'comment',
                     'status' => 'published',

--- a/src/Backend/Modules/Blog/info.xml
+++ b/src/Backend/Modules/Blog/info.xml
@@ -29,7 +29,7 @@
     </author>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Matthias Mullie]]></name>

--- a/src/Backend/Modules/ContentBlocks/info.xml
+++ b/src/Backend/Modules/ContentBlocks/info.xml
@@ -18,7 +18,7 @@
     </author>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Matthias Mullie]]></name>
@@ -26,7 +26,7 @@
     </author>
     <author>
       <name><![CDATA[Jelmer Prins]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
   </authors>
   <events>

--- a/src/Backend/Modules/Locale/info.xml
+++ b/src/Backend/Modules/Locale/info.xml
@@ -17,7 +17,7 @@
     </author>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Dieter Vanden Eynde]]></name>

--- a/src/Backend/Modules/Pages/info.xml
+++ b/src/Backend/Modules/Pages/info.xml
@@ -19,7 +19,7 @@
     </author>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Davy Hellemans]]></name>

--- a/src/Backend/Modules/Profiles/Engine/Model.php
+++ b/src/Backend/Modules/Profiles/Engine/Model.php
@@ -270,7 +270,7 @@ class Model
             $hash = md5(mb_strtolower(trim('d' . $email)));
 
             // define avatar url
-            $avatar = 'http://www.gravatar.com/avatar/' . $hash;
+            $avatar = 'https://www.gravatar.com/avatar/' . $hash;
 
             // when email not exists, it has to show our custom no-avatar image
             $avatar .= '?d=' . SITE_URL . $avatarPath . 'no-avatar.gif';

--- a/src/Backend/Modules/Users/info.xml
+++ b/src/Backend/Modules/Users/info.xml
@@ -14,7 +14,7 @@
   <authors>
     <author>
       <name><![CDATA[Tijs Verkoyen]]></name>
-      <url><![CDATA[http://www.sumocoders.be]]></url>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
     </author>
     <author>
       <name><![CDATA[Davy Hellemans]]></name>

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -405,7 +405,7 @@ jsFrontend.gravatar =
             if(gravatarId !== '')
             {
                 // build url
-                var url = 'http://www.gravatar.com/avatar/' + gravatarId + '?r=g&d=404';
+                var url = 'https://www.gravatar.com/avatar/' + gravatarId + '?r=g&d=404';
 
                 // add size if set before
                 if(size !== '') url += '&s=' + size;

--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -108,7 +108,7 @@
                         // Delicious
                         case 'delicious':
                             // build url
-                            var url = 'http://delicious.com/save?url=' + encodeURIComponent(link);
+                            var url = 'https://delicious.com/save?url=' + encodeURIComponent(link);
                             if(title !== '') url += '&title=' + title;
                             if(description !== '') url += '&notes=' + description;
 
@@ -124,7 +124,7 @@
                         // Digg
                         case 'digg':
                             // build url
-                            var url = 'http://digg.com/submit?url=' + encodeURIComponent(link);
+                            var url = 'https://digg.com/submit?url=' + encodeURIComponent(link);
                             if(title !== '') url += '&title=' + title;
 
                             // add html
@@ -147,7 +147,7 @@
                             // check if the FB-object is available
                             if(typeof FB != 'object')
                             {
-                                html += '<iframe src="http://www.facebook.com/plugins/like.php?href=' + link + '&amp;send=false&amp;layout=button_count&amp;width=' + options.facebook.width + '&amp;show_faces=false&amp;action=' + options.facebook.verb + '&amp;colorscheme=' + options.facebook.colorScheme + '&amp;font=' + options.facebook.font + '&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:' + options.facebook.width + 'px; height:21px;" allowTransparency="true"></iframe>';
+                                html += '<iframe src="https://www.facebook.com/plugins/like.php?href=' + link + '&amp;send=false&amp;layout=button_count&amp;width=' + options.facebook.width + '&amp;show_faces=false&amp;action=' + options.facebook.verb + '&amp;colorscheme=' + options.facebook.colorScheme + '&amp;font=' + options.facebook.font + '&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:' + options.facebook.width + 'px; height:21px;" allowTransparency="true"></iframe>';
                             }
                             else
                             {
@@ -165,7 +165,7 @@
                                 // loop all script to check if the Linkedin widget is already loaded
                                 $('script').each(function()
                                 {
-                                    if($(this).attr('src') == 'http://platform.linkedin.com/in.js') linkedInLoaded = true;
+                                    if($(this).attr('src') == 'https://platform.linkedin.com/in.js') linkedInLoaded = true;
                                 });
 
                                 // not loaded?
@@ -173,7 +173,7 @@
                                 {
                                     // create the script tag
                                     var script = document.createElement('script');
-                                    script.src = 'http://platform.linkedin.com/in.js';
+                                    script.src = 'https://platform.linkedin.com/in.js';
 
                                     // add into head
                                     $('head').after(script);
@@ -196,7 +196,7 @@
                                 // loop all script to check if the twitter-widget is already loaded
                                 $('script').each(function()
                                 {
-                                    if($(this).attr('src') == 'http://platform.twitter.com/widgets.js') twitterLoaded = true;
+                                    if($(this).attr('src') == 'https://platform.twitter.com/widgets.js') twitterLoaded = true;
                                 });
 
                                 // not loaded?
@@ -204,7 +204,7 @@
                                 {
                                     // create the script tag
                                     var script = document.createElement('script');
-                                    script.src = 'http://platform.twitter.com/widgets.js';
+                                    script.src = 'https://platform.twitter.com/widgets.js';
 
                                     // add into head
                                     $('head').after(script);
@@ -216,7 +216,7 @@
 
                             // build & add html
                             html += '<li class="shareMenuTwitter">' +
-                                    '    <a href="http://twitter.com/share" class="twitter-share-button" data-url="' + link + '"';
+                                    '    <a href="https://twitter.com/share" class="twitter-share-button" data-url="' + link + '"';
                             if(title !== '') html += ' data-text="' + title + '"';
                             html += ' data-lang="' + jsFrontend.current.language + '">' + options.twitter.label  + '</a>' +
                                     '</li>';
@@ -289,7 +289,7 @@
 
                                     // build & add html
                                     html += '<li class="shareMenuPinterest">' +
-                                            '    <a href="http://pinterest.com/pin/create/button/?url=' + encodeURIComponent(link) +
+                                            '    <a href="https://pinterest.com/pin/create/button/?url=' + encodeURIComponent(link) +
                                                     '&media=' + encodeURIComponent(image) +
                                                     '&description=' + encodeURIComponent(description) +
                                                     '" class="pin-it-button" count-layout="' + countLayout + '">' +

--- a/src/Frontend/Modules/Profiles/Engine/Model.php
+++ b/src/Frontend/Modules/Profiles/Engine/Model.php
@@ -136,7 +136,7 @@ class Model
             $hash = md5(mb_strtolower(trim('d' . $email)));
 
             // define avatar url
-            $avatar = 'http://www.gravatar.com/avatar/' . $hash;
+            $avatar = 'https://www.gravatar.com/avatar/' . $hash;
 
             // when email not exists, it has to show our custom no-avatar image
             $avatar .= '?d=' . rawurlencode(SITE_URL . $avatarPath) . 'no-avatar.gif';


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

When you visit a blog detail page on a https enabled website, you will get an orange icon in the chrome Security tab + warnings that you have mixed content on your site. You should always use https when possible. 

## Pull request description

Change http to https when appropriate. No errors anymore. Check on https://dokku.jessedobbelae.re/blog/detail/nunc-sediam-est for yourself

Fixes #1896 