### PR TITLE
Fix error when radio button is not filled

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -494,7 +494,8 @@ class Form extends FrontendBaseWidget
                             $values[$value['value']] = $value['label'];
                         }
 
-                        $fieldData['value'] = $values[$fieldData['value']];
+                        $fieldData['value'] = array_key_exists($fieldData['value'], $values)
+                            ? $values[$fieldData['value']] : null;
                     }
 
                     // clean up


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

If a radio button isn't required and filled in the key won't be available in the values

