### PR TITLE
Use raw to display result.introduction in Results.html.twig

### DIFF
--- a/src/Frontend/Modules/Search/Layout/Templates/Results.html.twig
+++ b/src/Frontend/Modules/Search/Layout/Templates/Results.html.twig
@@ -25,7 +25,7 @@
                 </header>
                 <div class="bd content">
                   {% if not result.introduction %}{{ result.text|truncate(200) }}{% endif %}
-                  {% if result.introduction %}{{ result.introduction }}{% endif %}
+                  {% if result.introduction %}{{ result.introduction|raw }}{% endif %}
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Correctly display the item introduction.

## Pull request description

Use `raw` to properly handle the tags inside the `introduction` property.