### PR TITLE
Use raw to display navigation.children in Sitemap.html.twig

### DIFF
--- a/src/Frontend/Modules/Pages/Layout/Templates/Sitemap.html.twig
+++ b/src/Frontend/Modules/Pages/Layout/Templates/Sitemap.html.twig
@@ -3,7 +3,7 @@
     {% for navigation in navigation %}
       <li>
         <a href="{{ navigation.link }}" title="{{ navigation.navigation_title }}"{% if navigation.nofollow %} rel="nofollow"{% endif %}>{{ navigation.navigation_title }}</a>
-        {{ navigation.children }}
+        {{ navigation.children|raw }}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Correctly display the navigation children.

## Pull request description

Use `raw` to properly handle the tags inside the `children` property.

