### PR TITLE
Correctly use Sitemap template in Sitemap widget

### DIFF
--- a/src/Frontend/Modules/Pages/Layout/Widgets/Sitemap.html.twig
+++ b/src/Frontend/Modules/Pages/Layout/Widgets/Sitemap.html.twig
@@ -1,8 +1,8 @@
 <section id="sitemapIndex" class="mod">
   <div class="inner">
     <div class="bd content">
-      {{ getnavigation('page', 0, '/Modules/Pages/Layout/Templates/Sitemap.html.twig') }}
-      {{ getnavigation('meta', 0, '/Modules/Pages/Layout/Templates/Sitemap.html.twig') }}
+      {{ getnavigation('page', 0, null, null, '/Modules/Pages/Layout/Templates/Sitemap.html.twig') }}
+      {{ getnavigation('meta', 0, null, null, '/Modules/Pages/Layout/Templates/Sitemap.html.twig') }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Use the specified template in Sitemap widget.

## Pull request description

Put the template name as the 5th parameter instead of the 3rd.

