### PR TITLE
Add Composer merge plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "simple-bus/doctrine-orm-bridge": "^4.0",
         "mailmotor/mailchimp-bundle": "^2.0",
         "mailmotor/campaignmonitor-bundle": "^1.0",
-        "mailmotor/mailmotor-bundle": "^2.0"
+        "mailmotor/mailmotor-bundle": "^2.0",
+        "wikimedia/composer-merge-plugin": "^1.3"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",
@@ -66,5 +67,12 @@
             "**/tests/",
             "**/Test/"
         ]
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "src/Backend/Modules/*/composer.json"
+            ]
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fa0ad0e3a86125199641b390fb36abae",
-    "content-hash": "29502a2429235cf8a047e673fc5f5e63",
+    "hash": "cc911e72144d2657e22bc05d175e1475",
+    "content-hash": "899cd11e05550740a479128429c5499a",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3387,6 +3387,55 @@
                 "templating"
             ],
             "time": "2016-11-23 18:41:40"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "0bdf8543d445ee067c9ba7d5d4a5dde70b9785f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/0bdf8543d445ee067c9ba7d5d4a5dde70b9785f4",
+                "reference": "0bdf8543d445ee067c9ba7d5d4a5dde70b9785f4",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "jakub-onderka/php-parallel-lint": "~0.8",
+                "phpunit/phpunit": "~4.8|~5.0",
+                "squizlabs/php_codesniffer": "~2.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                },
+                "class": "Wikimedia\\Composer\\MergePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "time": "2016-03-08 17:11:37"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Type

- Feature

## Resolves the following issues

When you install a Fork CMS module that uses some external php dependencies/libraries, we either have to include the external php files in the module folder (oldschool), or add instructions in the Readme file to let the user do `composer require vendor/package` in the root forkcms directory, before he can use the module in his project. This could be improved...

## Pull request description

What if we add a composer.json file in our src/Backend/Modules/modulename folder that has the external dependencies. We need our main composer.json to parse this and install those dependencies. Thanks to https://github.com/wikimedia/composer-merge-plugin this is possible. 

To test this:

* Use this branch
* Do a `composer install` to install wikimedia/composer-merge-plugin
* Create e.g. a `src/Backend/Modules/Blog/composer.json` file with the following example packages:

```
{
    "require": {
        "tinify/tinify": "^1.3",
        "aws/aws-sdk-php": "3.20.12"
    }
}
```

* Do a `composer update` in  your forkcms root
* The composer-merge-plugin will find your module composer.json file and merge the contents into the lockfile and install the dependencies into the vendor/ folder. You can use your module! 

Note that `composer update` will also update your other dependencies minor versions (normally). If we already have a lockfile in our project, then wikimedia/composer-merge-plugin won't do anything I noticed when doing a normal composer install. Only if you do composer update, it will update the lockfile with the merge of the new dependencies from the module's composer.json