### PR TITLE
Require php 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.5
-    - php: 5.6
     - php: 7.0
     - php: 7.1
     - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "http://www.fork-cms.com/",
     "license": "MIT",
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.0",
         "tijsverkoyen/akismet": "1.1.*",
         "tijsverkoyen/css-to-inline-styles": "1.5.*",
         "matthiasmullie/minify": "~1.3",

--- a/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step1.html.twig
+++ b/src/ForkCMS/Bundle/InstallerBundle/Resources/views/Installer/step1.html.twig
@@ -26,7 +26,7 @@
                 <div class="list-group-item list-group-item-{{ checker.errors.phpVersion }}">
                   <h3 class="list-group-item-heading">PHP version</h3>
                   <p class="list-group-item-text">
-                    PHP version must be at least 5.5.0, Before using Fork CMS, upgrade your PHP installation, preferably to the latest version.
+                    PHP version must be at least 7.0.0, Before using Fork CMS, upgrade your PHP installation, preferably to the latest version.
                   </p>
                 </div>
                 <div class="list-group-item list-group-item-{{ checker.errors.subfolder }}">

--- a/src/ForkCMS/Bundle/InstallerBundle/Service/RequirementsChecker.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Service/RequirementsChecker.php
@@ -110,7 +110,7 @@ class RequirementsChecker
 
     /*
      * At first we're going to check to see if the PHP version meets the minimum
-     * requirements for Fork CMS. We require at least PHP 5.5.0, because we don't
+     * requirements for Fork CMS. We require at least PHP 7.0.0, because we don't
      * want to be responsible for security issues in PHP itself.
      *
      * We follow this timeline: http://php.net/supported-versions.php
@@ -119,7 +119,7 @@ class RequirementsChecker
     {
         $this->checkRequirement(
             'phpVersion',
-            version_compare(PHP_VERSION, '5.5.0', '>='),
+            version_compare(PHP_VERSION, '7.0.0', '>='),
             self::STATUS_ERROR
         );
     }


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

Since php 5.6 only gets security updates it is the perfect time to require php 7 when fork 5 is released

