### PR TITLE
Transform numeric to number because it is stored in the database that way

### DIFF
--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -348,7 +348,7 @@
 				required: jsFrontend.locale.err('FieldIsRequired'),
 				email: 	  jsFrontend.locale.err('EmailIsInvalid'),
 				date: 	  jsFrontend.locale.err('DateIsInvalid'),
-				numeric:  jsFrontend.locale.err('NumberIsInvalid'),
+				number:   jsFrontend.locale.err('NumberIsInvalid'),
 				value:    jsFrontend.locale.err('InvalidValue')
 			};
 
@@ -362,7 +362,7 @@
 				type = $input.context.type;
 				errorMessage = options.value;
 
-				if(options[type]) {
+				if (options[type]) {
 					errorMessage = options[type];
 				}
 			}

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -321,6 +321,7 @@ class Form extends FrontendBaseWidget
     private function setCustomHTML5ErrorMessages(array $item, SpoonFormAttributes $formField)
     {
         foreach ($item['validations'] as $validation) {
+            // @deprecated
             // we need to change it here since it is saved like this in the database and we can't change that for now.
             if ($validation['type'] === 'numeric') {
                 $validation['type'] = 'number';

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -151,7 +151,6 @@ class Form extends FrontendBaseWidget
 
         // exists and has fields
         if (!empty($this->item) && !empty($this->item['fields'])) {
-            //dump($this->item['fields'] );die;
             // loop fields
             foreach ($this->item['fields'] as $field) {
                 // init
@@ -322,6 +321,11 @@ class Form extends FrontendBaseWidget
     private function setCustomHTML5ErrorMessages(array $item, SpoonFormAttributes $formField)
     {
         foreach ($item['validations'] as $validation) {
+            // we need to change it here since it is saved like this in the database and we can't change that for now.
+            if ($validation['type'] === 'numeric') {
+                $validation['type'] = 'number';
+            }
+
             $formField->setAttribute(
                 'data-error-' . $validation['type'],
                 $validation['error_message']


### PR DESCRIPTION
## Type

> remove the types that don't apply
- Enhancement

## Pull request description

In js, we'd like to use type 'number' as it is more correct than 'numeric'. We need to change this in formbuilder, because in the database the fields are stored as type 'numeric'.

