### PR TITLE
Add collection with working add and remove implementation for bootstrap

### DIFF
--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1604,3 +1604,105 @@
         });
     };
 })(jQuery);
+
+/**
+ * Collection class
+ */
+(function($) {
+    var addField = '[data-addfield="collection"]',
+        removeField = '[data-removefield="collection"]',
+        CollectionAdd = function(el) {
+            $(el).on('click', addField, this.addField);
+        },
+        CollectionRemove = function(el) {
+            $(el).on('click', removeField, this.removeField);
+        };
+
+    CollectionAdd.prototype.addField = function(e) {
+        var $this = $(this),
+            selector = $this.attr('data-collection'),
+            prototypeName = $this.attr('data-prototype-name');
+
+        e && e.preventDefault();
+
+        var collection = $('#' + selector),
+            list = collection.find('ul.js-collection'),
+            count = list.find('> li').length;
+
+        var newWidget = collection.attr('data-prototype');
+
+        // Check if an element with this ID already exists.
+        // If it does, increase the count by one and try again
+        var newName = newWidget.match(/id="(.*?)"/);
+        var re = new RegExp(prototypeName, "g");
+        while ($('#' + newName[1].replace(re, count)).length > 0) {
+            count++;
+        }
+        newWidget = newWidget.replace(re, count);
+        newWidget = newWidget.replace(/__id__/g, newName[1].replace(re, count));
+        var newLi = $('<li class="list-group-item"></li>').html(newWidget);
+        newLi.appendTo(list);
+        $this.trigger('collection-field-added');
+    };
+
+    CollectionRemove.prototype.removeField = function(e) {
+        var $this = $(this),
+            parent = $this.closest('li').parent();
+
+        e && e.preventDefault();
+
+        $this.trigger('collection-field-removed');
+        $this.trigger('collection-field-removed-before');
+        $this.closest('li').remove();
+        parent.trigger('collection-field-removed-after');
+    };
+
+    // Extra jquery functions
+    // first get the old ones in case there is a conflict
+    var oldAdd = $.fn.addField;
+    var oldRemove = $.fn.removeField;
+
+    $.fn.addField = function(option) {
+        return this.each(function() {
+            var $this = $(this),
+                data = $this.data('addfield')
+                ;
+            if (!data) {
+                $this.data('addfield', (data = new CollectionAdd(this)));
+            }
+            if (typeof option == 'string') {
+                data[option].call($this);
+            }
+        });
+    };
+
+    $.fn.removeField = function(option) {
+        return this.each(function() {
+            var $this = $(this),
+                data = $this.data('removefield')
+                ;
+            if (!data) {
+                $this.data('removefield', (data = new CollectionRemove(this)));
+            }
+            if (typeof option == 'string') {
+                data[option].call($this);
+            }
+        });
+    };
+
+    $.fn.addField.Constructor = CollectionAdd;
+    $.fn.removeField.Constructor = CollectionRemove;
+
+    $.fn.addField.noConflict = function() {
+        $.fn.addField = oldAdd;
+        return this;
+    };
+    $.fn.removeField.noConflict = function() {
+        $.fn.removeField = oldRemove;
+        return this;
+    };
+
+    $(document).on('click.addfield.data-api', addField, CollectionAdd.prototype.addField);
+    $(document).on('click.removefield.data-api', removeField, CollectionRemove.prototype.removeField);
+
+})(jQuery);

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -241,3 +241,52 @@
   <input type="hidden" id="{{ parametersId }}" value="{{ generate_url_callback_parameters }}">
   {{ form_rest(form) }}
 {%- endblock meta_widget -%}
+
+
+{% block bootstrap_collection_row %}
+  {% spaceless %}
+    {% if prototype is defined %}
+      {% set prototype_vars = {} %}
+      {% if style is defined %}
+        {% set prototype_vars = prototype_vars|merge({'style': style}) %}
+      {% endif %}
+      {% set prototype_html = form_widget(prototype, prototype_vars) %}
+      {% if form.vars.allow_delete %}
+        {% set prototype_html = prototype_html ~ '<div class="btn-toolbar"><div class="btn-group pull-right"><a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="__id__">' ~ form.vars.delete_button_text|trans({}, translation_domain)|raw ~ '</a></div></div>' %}
+      {% endif %}
+
+      {% set attr = attr|merge({'data-prototype': prototype_html }) %}
+      {% set attr = attr|merge({'data-prototype-name': prototype_name }) %}
+    {% endif %}
+    <div {{ block('widget_container_attributes') }}>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          {{ form_label(form) }}
+        </div>
+        <ul class="list-group js-collection">
+          {% for field in form %}
+            <li class="list-group-item">
+              {{ form_widget(field) }}
+              {{ form_errors(field) }}
+              {% if form.vars.allow_delete %}
+                <div class="btn-toolbar">
+                  <div class="btn-group pull-right">
+                    <a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="{{ field.vars.id }}">{{ form.vars.delete_button_text|trans({}, translation_domain)|raw }}</a>
+                  </div>
+                </div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="panel-footer clearfix">
+          {% if form.vars.allow_add %}
+            <div class="btn-group pull-right">
+              <a href="#" class="btn btn-success btn-sm" data-addfield="collection" data-collection="{{ form.vars.id }}" data-prototype-name="{{ prototype_name }}">{{ form.vars.add_button_text|trans({}, translation_domain)|raw }}</a>
+            </div>
+          {% endif %}
+          {{ form_errors(form) }}
+        </div>
+      </div>
+    </div>
+  {% endspaceless %}
+{% endblock bootstrap_collection_row %}

--- a/src/Backend/Form/Type/CollectionType.php
+++ b/src/Backend/Form/Type/CollectionType.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Backend\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CollectionType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars = array_replace(
+            $view->vars,
+            [
+                'allow_add' => $options['allow_add'],
+                'allow_delete' => $options['allow_delete'],
+                'add_button_text' => $options['add_button_text'],
+                'delete_button_text' => $options['delete_button_text'],
+                'prototype_name' => $options['prototype_name'],
+            ]
+        );
+        if ($form->getConfig()->hasAttribute('prototype')) {
+            $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'allow_add' => false,
+                'allow_delete' => false,
+                'prototype' => true,
+                'prototype_name' => '__name__',
+                'add_button_text' => 'lbl.Add',
+                'delete_button_text' => 'lbl.Delete',
+                'options' => [],
+                'type' => TextType::class,
+            ]
+        );
+        $resolver->setNormalizer(
+            'options',
+            function (Options $options, $value) {
+                $value['block_name'] = 'entry';
+
+                return $value;
+            }
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return SymfonyCollectionType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'bootstrap_collection';
+    }
+
+    /**
+     * Backward compatibility for SF < 3.0
+     *
+     * @return null|string
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+}


### PR DESCRIPTION
## Type

- Feature

## Pull request description

adds a symfony form collection implementation to the backend that works with bootstrap and has implemented the add and remove functionality 

