### PR TITLE
Add page image to subpages widget

### DIFF
--- a/src/Frontend/Modules/Pages/Engine/Model.php
+++ b/src/Frontend/Modules/Pages/Engine/Model.php
@@ -75,7 +75,7 @@ class Model implements FrontendTagsInterface
     {
         // fetch items
         $items = (array) FrontendModel::getContainer()->get('database')->getRecords(
-            'SELECT i.id, i.title, m.description, i.parent_id
+            'SELECT i.id, i.title, m.description, i.parent_id, i.data
              FROM pages AS i
              INNER JOIN meta AS m ON m.id = i.meta_id
              WHERE i.parent_id = ? AND i.status = ? AND i.hidden = ?
@@ -86,9 +86,14 @@ class Model implements FrontendTagsInterface
 
         // has items
         if (!empty($items)) {
-            // reset url
             foreach ($items as &$row) {
+                // reset url
                 $row['full_url'] = FrontendNavigation::getURL($row['id'], LANGUAGE);
+
+                // unserialize page data and template data
+                if (!empty($row['data'])) {
+                    $row['data'] = unserialize($row['data']);
+                }
             }
         }
 


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
On a page you can do `page.data.image` to retrieve the page image.
But when you create a parent page that just displays his children, like:
* http://www.trainworld.be/nl/praktische-informatie
* http://www.lathu.be/nl/mobiliteit-thuis
* http://www.deltalight.com/nl/we-are-delta-light

then it's not possible to retrieve the data image without modifying the core Page module. Not bad to include this by default. 

## Pull request description
When fetching subpages, also fetch the `data` field from the page table and unserialize it. So we can use it in `SubpagesDefault.html.twig` to display a grid of subpages with their photo. 

