### PR TITLE
Remove annotations from documentation in comments

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -10,15 +10,15 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * You need to implement the method getUploadDir.
  * When using this class in an entity certain life cycle callbacks should be called
- * prepareToUpload for [at]orm\PrePersist() and [at]orm\PreUpdate()
- * upload for [at]orm\PostPersist() and [at]orm\PostUpdate()
- * remove for [at]orm\PostRemove()
+ * prepareToUpload for PrePersist() and PreUpdate()
+ * upload for PostPersist() and PostUpdate()
+ * remove for PostRemove()
  */
 abstract class AbstractFile
 {
     /**
      * @var string
-     * [at]orm\Column(type="string", length=255, nullable=true)
+     * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $fileName;
 
@@ -143,7 +143,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events [at]orm\PrePersist() and [at]orm\PreUpdate()
+     * This function should be called for the life cycle events PrePersist() and PreUpdate()
      */
     public function prepareToUpload()
     {
@@ -157,7 +157,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events [at]orm\PostPersist() and [at]orm\PostUpdate()
+     * This function should be called for the life cycle events PostPersist() and PostUpdate()
      */
     public function upload()
     {
@@ -200,7 +200,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle event [at]orm\PostRemove()
+     * This function should be called for the life cycle event PostRemove()
      */
     public function remove()
     {

--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -10,15 +10,15 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * You need to implement the method getUploadDir.
  * When using this class in an entity certain life cycle callbacks should be called
- * prepareToUpload for @ORM\PrePersist() and @ORM\PreUpdate()
- * upload for @ORM\PostPersist() and @ORM\PostUpdate()
- * remove for @ORM\PostRemove()
+ * prepareToUpload for [at]orm\PrePersist() and [at]orm\PreUpdate()
+ * upload for [at]orm\PostPersist() and [at]orm\PostUpdate()
+ * remove for [at]orm\PostRemove()
  */
 abstract class AbstractFile
 {
     /**
      * @var string
-     * @ORM\Column(type="string", length=255, nullable=true)
+     * [at]orm\Column(type="string", length=255, nullable=true)
      */
     protected $fileName;
 
@@ -143,7 +143,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events @ORM\PrePersist() and @ORM\PreUpdate()
+     * This function should be called for the life cycle events [at]orm\PrePersist() and [at]orm\PreUpdate()
      */
     public function prepareToUpload()
     {
@@ -157,7 +157,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events @ORM\PostPersist() and @ORM\PostUpdate()
+     * This function should be called for the life cycle events [at]orm\PostPersist() and [at]orm\PostUpdate()
      */
     public function upload()
     {
@@ -200,7 +200,7 @@ abstract class AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle event @ORM\PostRemove()
+     * This function should be called for the life cycle event [at]orm\PostRemove()
      */
     public function remove()
     {

--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * You need to implement the method getUploadDir.
  * When using this class in an entity certain life cycle callbacks should be called
- * prepareToUpload for @ORM\PrePersist() and @ORM\PreUpdate()
- * upload for @ORM\PostPersist() and @ORM\PostUpdate()
- * remove for @ORM\PostRemove()
+ * prepareToUpload for [at]orm\PrePersist() and [at]orm\PreUpdate()
+ * upload for [at]orm\PostPersist() and [at]orm\PostUpdate()
+ * remove for [at]orm\PostRemove()
  *
  * The following things are optional
  * A fallback image can be set by setting the full path of the image to the FALLBACK_IMAGE constant
@@ -91,7 +91,7 @@ abstract class AbstractImage extends AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events @ORM\PostPersist() and @ORM\PostUpdate()
+     * This function should be called for the life cycle events [at]orm\PostPersist() and [at]orm\PostUpdate()
      */
     public function upload()
     {
@@ -121,7 +121,7 @@ abstract class AbstractImage extends AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle event @ORM\PostRemove()
+     * This function should be called for the life cycle event [at]orm\PostRemove()
      */
     public function remove()
     {

--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  *
  * You need to implement the method getUploadDir.
  * When using this class in an entity certain life cycle callbacks should be called
- * prepareToUpload for [at]orm\PrePersist() and [at]orm\PreUpdate()
- * upload for [at]orm\PostPersist() and [at]orm\PostUpdate()
- * remove for [at]orm\PostRemove()
+ * prepareToUpload for PrePersist() and PreUpdate()
+ * upload for PostPersist() and PostUpdate()
+ * remove for PostRemove()
  *
  * The following things are optional
  * A fallback image can be set by setting the full path of the image to the FALLBACK_IMAGE constant
@@ -91,7 +91,7 @@ abstract class AbstractImage extends AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle events [at]orm\PostPersist() and [at]orm\PostUpdate()
+     * This function should be called for the life cycle events PostPersist() and PostUpdate()
      */
     public function upload()
     {
@@ -121,7 +121,7 @@ abstract class AbstractImage extends AbstractFile
     }
 
     /**
-     * This function should be called for the life cycle event [at]orm\PostRemove()
+     * This function should be called for the life cycle event PostRemove()
      */
     public function remove()
     {


### PR DESCRIPTION
When validating the value object this gives an error since it tries to parse them as an annotation

## Type

- Critical bugfix

## Resolves the following issues

## Pull request description

When validating the value object this gives an error since it tries to parse them as an annotation
