### PR TITLE
Fix meta errors when SEO Index or Follow is none

### DIFF
--- a/src/Backend/Form/Type/MetaType.php
+++ b/src/Backend/Form/Type/MetaType.php
@@ -248,8 +248,8 @@ class MetaType extends AbstractType
                 'custom' => $meta->getCustom(),
                 'url' => $meta->getUrl(),
                 'urlOverwrite' => $meta->isUrlOverwrite(),
-                'SEOIndex' => $meta->getSEOIndex(),
-                'SEOFollow' => $meta->getSEOFollow(),
+                'SEOIndex' => $meta->getSEOIndex() === null ? SEOIndex::none() : $meta->getSEOIndex(),
+                'SEOFollow' => $meta->getSEOFollow() === null ? SEOFollow::none() : $meta->getSEOFollow(),
             ];
         };
     }


### PR DESCRIPTION
We need none to mean that there isn't one, but I forgot to add none then as the default when it is null

## Type

- Non critical bugfix

## Pull request description
Fixes regression with SEOFollow and SEOIndex in the new meta type

