### PR TITLE
Enable the cookie bar when the timezone is in europe

### DIFF
--- a/src/Backend/Core/Installer/CoreInstaller.php
+++ b/src/Backend/Core/Installer/CoreInstaller.php
@@ -215,5 +215,12 @@ class CoreInstaller extends ModuleInstaller
         // ckfinder
         $this->setSetting('Core', 'ckfinder_license_name', 'Fork CMS');
         $this->setSetting('Core', 'ckfinder_license_key', 'VNA6-BP17-T7D3-CP1B-EMJF-X7Q3-5THF');
+
+        // Enable the cookie bar by default when the timezone is in europe
+        $this->setSetting(
+            'Core',
+            'show_cookie_bar',
+            date_default_timezone_get() && strpos(mb_strtolower(date_default_timezone_get()), 'europe') === 0
+        );
     }
 }


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

Enable the cookie bar when the timezone is in Europe when installing fork