### PR TITLE
Fix in parseWidget when a widget throws a RedirectException

### DIFF
--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -9,6 +9,7 @@ namespace Frontend\Core\Engine;
  * file that was distributed with this source code.
  */
 
+use Common\Exception\RedirectException;
 use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Core\Engine\Block\Widget as FrontendBlockWidget;
 use Frontend\Core\Language\Locale;
@@ -406,6 +407,8 @@ class TemplateModifiers extends BaseTwigModifiers
             FrontendModel::getContainer()->set('parseWidget', null);
 
             return $content;
+        } catch (RedirectException $e) {
+            return $e->getResponse();
         } catch (Exception $e) {
             // if we are debugging, we want to see the exception
             if (FrontendModel::getContainer()->getParameter('kernel.debug')) {


### PR DESCRIPTION
Fixes https://github.com/forkcms/forkcms/issues/1965

Solves the Exception being thrown. The redirect will work.
But... it first shows the same page, with a redirect text... (see screenshot 2)

<img width="702" alt="schermafbeelding 2017-02-01 om 11 01 48" src="https://cloud.githubusercontent.com/assets/588616/22502982/b8531148-e86f-11e6-8b9e-b7337de60fc6.png">
<img width="884" alt="schermafbeelding 2017-02-01 om 11 02 09" src="https://cloud.githubusercontent.com/assets/588616/22502980/b820c224-e86f-11e6-9243-e728e2f6cd01.png">
<img width="783" alt="schermafbeelding 2017-02-01 om 11 01 51" src="https://cloud.githubusercontent.com/assets/588616/22502981/b852b536-e86f-11e6-98f3-3d87e04ddd43.png">