### PR TITLE
Style form elements in fork style by default

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -338,3 +338,35 @@
     </div>
   {% endspaceless %}
 {% endblock bootstrap_collection_row %}
+
+{% block form_row %}
+  <div class="panel form-group panel-default{% if (not compound or force_error|default(false)) and not valid %} panel-danger{% endif %}">
+    <div class="panel-heading">
+      {{- form_label(form) -}}
+    </div>
+    <div class="panel-body">
+      {{- form_widget(form) -}}
+    </div>
+    {% if (not compound or force_error|default(false)) and not valid %}
+      <div class="panel-footer">
+        {{- form_errors(form) -}}
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block editor_row %}
+  <div class="panel form-group panel-default panel-editor{% if (not compound or force_error|default(false)) and not valid %} panel-danger{% endif %}">
+    <div class="panel-heading">
+      {{- form_label(form) -}}
+    </div>
+    <div class="panel-body">
+      {{- form_widget(form) -}}
+    </div>
+    {% if (not compound or force_error|default(false)) and not valid %}
+      <div class="panel-footer">
+        {{- form_errors(form) -}}
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

Currently if you do form_rest on a symfony form the layout is different than the default layout used elsewhere in the backend.

## Pull request description

This themes form rows by default to match that style
<img width="1000" alt="screen shot 2017-02-01 at 14 08 42" src="https://cloud.githubusercontent.com/assets/3634654/22507910/f48145d2-e887-11e6-81a8-a06e1b7ab9f5.png">
<img width="989" alt="screen shot 2017-02-01 at 14 08 27" src="https://cloud.githubusercontent.com/assets/3634654/22507911/f481bdbe-e887-11e6-8ead-1c9e3e8e90f8.png">


