### PR TITLE
The generated url selector wasn't passed on to the template

### DIFF
--- a/src/Backend/Form/Type/MetaType.php
+++ b/src/Backend/Form/Type/MetaType.php
@@ -351,6 +351,7 @@ class MetaType extends AbstractType
         $view->vars['custom_meta_tags'] = $options['custom_meta_tags'];
         $view->vars['generate_url_callback_class'] = $options['generate_url_callback_class'];
         $view->vars['generate_url_callback_method'] = $options['generate_url_callback_method'];
+        $view->vars['generated_url_selector'] = $options['generated_url_selector'];
         $view->vars['generate_url_callback_parameters'] = serialize($options['generate_url_callback_parameters']);
     }
 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The generated url selector wasn't passed on to the template
Because of that the url underneath the title wasn't updated

