### PR TITLE
Fix RedirectException not working in template modifiers

### DIFF
--- a/app/routing.php
+++ b/app/routing.php
@@ -153,6 +153,12 @@ class ApplicationRouting extends Controller
             return $application->display();
         } catch (RedirectException $ex) {
             return $ex->getResponse();
+        } catch (Twig_Error $twigError) {
+            if ($twigError->getPrevious() instanceof RedirectException) {
+                return $twigError->getPrevious()->getResponse();
+            }
+
+            throw $twigError;
         }
     }
 

--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -9,6 +9,7 @@ namespace Frontend\Core\Engine;
  * file that was distributed with this source code.
  */
 
+use Common\Exception\RedirectException;
 use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Core\Engine\Block\Widget as FrontendBlockWidget;
 use Frontend\Core\Language\Locale;
@@ -406,6 +407,8 @@ class TemplateModifiers extends BaseTwigModifiers
             FrontendModel::getContainer()->set('parseWidget', null);
 
             return $content;
+        } catch (RedirectException $redirectException) {
+            throw new \Twig_Error('redirect fix from template modifier', null, null, $redirectException);
         } catch (Exception $e) {
             // if we are debugging, we want to see the exception
             if (FrontendModel::getContainer()->getParameter('kernel.debug')) {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #1965

## Pull request description
RedirectExceptions didn't work in twig modifiers, now they do

