### PR TITLE
Move the raw conversion to the macro itself

### DIFF
--- a/src/Backend/Core/Layout/Templates/macros.html.twig
+++ b/src/Backend/Core/Layout/Templates/macros.html.twig
@@ -19,7 +19,7 @@
       {% else %}
         <p>
           {% if noItemsMessage %}
-            {{ noItemsMessage }}
+            {{ noItemsMessage|raw }}
           {% else %}
             {{ 'msg.NoItems'|trans|raw }}
           {% endif %}

--- a/src/Backend/Modules/Blog/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Index.html.twig
@@ -47,7 +47,7 @@
       <div class="content-title">
         <p>{{ 'lbl.RecentlyEdited'|trans|ucfirst }}</p>
       </div>
-      {{ macro.dataGrid(dgRecent, 'msg.NoItems'|trans|format(geturl('add'))|raw) }}
+      {{ macro.dataGrid(dgRecent, 'msg.NoItems'|trans|format(geturl('add'))) }}
     </div>
   {% endif %}
 
@@ -56,7 +56,7 @@
     <div class="content-title">
       <p>{{ 'lbl.Drafts'|trans|ucfirst }}</p>
     </div>
-    {{ macro.dataGrid(dgDrafts, 'msg.NoItems'|trans|format(geturl('add'))|raw) }}
+    {{ macro.dataGrid(dgDrafts, 'msg.NoItems'|trans|format(geturl('add'))) }}
   </div>
   {% endif %}
 
@@ -65,9 +65,9 @@
       <p>{{ 'lbl.PublishedArticles'|trans|ucfirst }}</p>
     </div>
     {% if filterCategory %}
-      {{ macro.dataGrid(dgPosts, 'msg.NoItems'|trans|format(geturl('add', null, '&category=#{filterCategory.id}'))|raw) }}
+      {{ macro.dataGrid(dgPosts, 'msg.NoItems'|trans|format(geturl('add', null, '&category=#{filterCategory.id}'))) }}
     {% else %}
-      {{ macro.dataGrid(dgPosts, 'msg.NoItems'|trans|format(geturl('add'))|raw) }}
+      {{ macro.dataGrid(dgPosts, 'msg.NoItems'|trans|format(geturl('add'))) }}
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

For some reason, twig converts the 'raw' data back to encoded data when sending it to a macro.
This causes the macro's in the blog module to display encoded html
I fixed this by applying the raw tag to the data in the datagrid itself

