### PR TITLE
Fix wrong documentation about installation zip

### DIFF
--- a/docs/05. module guide/27. creating_a_module_zip_file.md
+++ b/docs/05. module guide/27. creating_a_module_zip_file.md
@@ -8,23 +8,23 @@ The zip file contains the absolute paths to the module, as you can see in the im
 
     src
     |-- Backend
-    |  |-- YourModule
-    |     |-- Actions
-    |     |  |-- Index.php
-    |     |-- Engine
-    |     |  |-- Model.php
-    |     |-- Config.php
-    |     |  ...
+    |  |-- Modules
+    |      |-- YourModule
+    |          |-- Actions
+    |          |  |-- Index.php
+    |          |-- Engine
+    |          |  |-- Model.php
+    |          |-- Config.php
+    |          |  ...
     |–– Frontend
-    |  |–– YourModule
-    |     |–– Actions
-    |     |  |–– Index.php
-    |     |–– Engine
-    |     |  |–– Model.php
-    |     |-- Config.php
-    |     |  ...
-    |-- Library
-       |-- ...
+    |  |-- Modules
+    |      |-- YourModule
+    |          |-- Actions
+    |          |  |-- Index.php
+    |          |-- Engine
+    |          |  |-- Model.php
+    |          |-- Config.php
+    |          |  ...
 
 ## Required files
 

--- a/src/Backend/Modules/Extensions/Actions/UploadModule.php
+++ b/src/Backend/Modules/Extensions/Actions/UploadModule.php
@@ -82,7 +82,6 @@ class UploadModule extends BackendBaseActionAdd
         $allowedDirectories = array(
             'src/Backend/Modules/',
             'src/Frontend/Modules/',
-            'library/external/',
         );
 
         // name of the module we are trying to upload
@@ -105,14 +104,6 @@ class UploadModule extends BackendBaseActionAdd
             foreach ($allowedDirectories as $directory) {
                 // yay, in a valid directory
                 if (mb_stripos($fileName, $prefix . $directory) === 0) {
-                    // we have a library file
-                    if ($directory == $prefix . 'library/external/') {
-                        if (!is_file($this->getContainer()->getParameter('site.path_www') . '/' . $fileName)) {
-                            $files[] = $fileName;
-                        }
-                        break;
-                    }
-
                     // extract the module name from the url
                     $tmpName = trim(str_ireplace($prefix . $directory, '', $fileName), '/');
                     if ($tmpName == '') {
@@ -210,7 +201,7 @@ class UploadModule extends BackendBaseActionAdd
         $prefix = array();
 
         foreach ($name as $element) {
-            if ($element == 'src' || $element == 'library') {
+            if ($element == 'src') {
                 return implode(PATH_SEPARATOR, $prefix);
             } else {
                 $prefix[] = $element;


### PR DESCRIPTION
## Type

> remove the types that don't apply


- Non critical bugfix

## Pull request description

The directory structure of a module inside a zip was wrong in the documentation
