### PR TITLE
Remove action pages from children navigation

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -867,7 +867,11 @@ class Model
              INNER JOIN meta AS m ON i.meta_id = m.id
              LEFT OUTER JOIN pages_blocks AS b ON b.revision_id = i.revision_id
              LEFT OUTER JOIN modules_extras AS e ON e.id = b.extra_id AND e.type = ?
-             LEFT OUTER JOIN pages AS p ON p.parent_id = i.id AND p.status = "active" AND p.hidden = "N"
+             LEFT OUTER JOIN pages AS p
+                ON p.parent_id = i.id
+                AND p.status = "active"
+                AND p.hidden = "N"
+                AND p.data NOT LIKE "%s:9:\"is_action\";b:1;%"
              AND p.language = i.language
              WHERE i.parent_id IN (' . implode(', ', $ids) . ')
                  AND i.status = ? AND i.language = ?


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues & Pull request description
When you have pages as a module action subpage, they won't be shown in the children array of the page, but the has_children variable is set to true. By filtering on "is_action" those subpages won't be counted in the has_children variable.

![pasted image at 2017_03_15 14_13](https://cloud.githubusercontent.com/assets/4092903/23990564/640d97da-0a2e-11e7-8fea-ea68d053803c.png)


