### PR TITLE
Fix meta id comperasion with null

### DIFF
--- a/src/Backend/Form/Type/MetaType.php
+++ b/src/Backend/Form/Type/MetaType.php
@@ -260,7 +260,7 @@ class MetaType extends AbstractType
     private function getMetaReverseTransformFunction()
     {
         return function ($metaData) {
-            $metaId = null ? null : (int) $metaData['id'];
+            $metaId = $metaData['id'] === null ? null : (int) $metaData['id'];
 
             if ($metaId === null || !$this->meta[$metaId] instanceof Meta) {
                 return new Meta(


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues & ## Pull request description
The comparison for meta id is wrong.

