### PR TITLE
Fix content block revision issue with time and user

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Actions/Edit.php
+++ b/src/Backend/Modules/ContentBlocks/Actions/Edit.php
@@ -62,6 +62,7 @@ class Edit extends BackendBaseActionEdit
 
         /** @var UpdateContentBlock $updateContentBlock */
         $updateContentBlock = $form->getData();
+        $updateContentBlock->userId = Authentication::getUser()->getUserId();
 
         // The command bus will handle the saving of the content block in the database.
         $this->get('command_bus')->handle($updateContentBlock);

--- a/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlock.php
@@ -39,6 +39,11 @@ final class UpdateContentBlock
     public $contentBlock;
 
     /**
+     * @var int
+     */
+    public $userId;
+
+    /**
      * @param ContentBlock $contentBlock
      */
     public function __construct(ContentBlock $contentBlock)
@@ -49,5 +54,6 @@ final class UpdateContentBlock
         $this->title = $contentBlock->getTitle();
         $this->text = $contentBlock->getText();
         $this->template = $contentBlock->getTemplate();
+        $this->userId = $contentBlock->getUserId();
     }
 }

--- a/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlockHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Command/UpdateContentBlockHandler.php
@@ -29,7 +29,8 @@ final class UpdateContentBlockHandler
             $updateContentBlock->title,
             $updateContentBlock->text,
             !$updateContentBlock->isVisible,
-            $updateContentBlock->template
+            $updateContentBlock->template,
+            $updateContentBlock->userId
         );
 
         $this->contentBlockRepository->add($updateContentBlock->contentBlock);

--- a/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
@@ -284,14 +284,6 @@ class ContentBlock
     }
 
     /**
-     * @ORM\PreUpdate
-     */
-    public function preUpdate()
-    {
-        $this->editedOn = new DateTime();
-    }
-
-    /**
      * Update the widget so it shows the correct title and has the correct template
      */
     private function updateWidget()

--- a/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
+++ b/src/Backend/Modules/ContentBlocks/Entity/ContentBlock.php
@@ -313,16 +313,17 @@ class ContentBlock
      * @param string $text
      * @param bool $isHidden
      * @param string $template
+     * @param int $userId
      *
      * @return ContentBlock
      */
-    public function update($title, $text, $isHidden, $template)
+    public function update($title, $text, $isHidden, $template, $userId)
     {
         $this->status = ContentBlockStatus::archived();
 
         return self::create(
             $this->id,
-            $this->userId,
+            $userId,
             $this->extraId,
             $this->locale,
             $title,


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

> Describe what your pull request will fix / add / …

- Content block revisions updated their last updated time while it should have stayed fixed
- If a different user than the original creator updated a content block it didn't show up in the revision datagrid and kept using the original creator