### PR TITLE
Parse custom meta tags for a blogpost in the frontend

### DIFF
--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -208,7 +208,7 @@ class Detail extends FrontendBaseBlock
             $this->record['meta_keywords'],
             ($this->record['meta_keywords_overwrite'] == 'Y')
         );
-		$this->header->setMetaCustom($this->record['meta_custom']);
+        $this->header->setMetaCustom($this->record['meta_custom']);
 
         // advanced SEO-attributes
         if (isset($this->record['meta_data']['seo_index'])) {

--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -208,6 +208,7 @@ class Detail extends FrontendBaseBlock
             $this->record['meta_keywords'],
             ($this->record['meta_keywords_overwrite'] == 'Y')
         );
+		$this->header->setMetaCustom($this->record['meta_custom']);
 
         // advanced SEO-attributes
         if (isset($this->record['meta_data']['seo_index'])) {

--- a/src/Frontend/Modules/Blog/Engine/Model.php
+++ b/src/Frontend/Modules/Blog/Engine/Model.php
@@ -38,7 +38,7 @@ class Model implements FrontendTagsInterface
              i.allow_comments,
              m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,
              m.description AS meta_description, m.description_overwrite AS meta_description_overwrite,
-             m.title AS meta_title, m.title_overwrite AS meta_title_overwrite,
+             m.title AS meta_title, m.title_overwrite AS meta_title_overwrite, m.custom AS meta_custom,
              m.url,
              m.data AS meta_data
              FROM blog_posts AS i
@@ -814,7 +814,7 @@ class Model implements FrontendTagsInterface
              i.allow_comments,
              m.keywords AS meta_keywords, m.keywords_overwrite AS meta_keywords_overwrite,
              m.description AS meta_description, m.description_overwrite AS meta_description_overwrite,
-             m.title AS meta_title, m.title_overwrite AS meta_title_overwrite,
+             m.title AS meta_title, m.title_overwrite AS meta_title_overwrite, m.custom AS meta_custom,
              m.url,
              m.data AS meta_data
              FROM blog_posts AS i


### PR DESCRIPTION
## Type

- Non critical bug

## Pull request description

This PR adds support for custom meta tags for the blog module. Seems this was activated in the backend but never parsed in the frontend

