### PR TITLE
Make sure SpoonSession is initialised before starting symfony session

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -52,6 +52,8 @@ abstract class Kernel extends BaseKernel implements KernelInterface
         // boot if it hasn't booted yet
         $this->boot();
 
+        $this->fixSymfonySessions();
+
         return $this->getHttpKernel()->handle($request, $type, $catch);
     }
 
@@ -68,6 +70,21 @@ abstract class Kernel extends BaseKernel implements KernelInterface
 
         // define Fork constants
         $this->defineForkConstants();
+    }
+
+    /**
+     * We need to manually initialize SpoonSession for the Symfony sessions to work properly
+     */
+    private function fixSymfonySessions()
+    {
+        SpoonSession::start();
+
+        /** @var \Symfony\Component\HttpFoundation\Session\Session $session */
+        $session = $this->getContainer()->get('session');
+
+        if (!$session->isStarted()) {
+            $session->start();
+        }
     }
 
     /**

--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -52,8 +52,6 @@ abstract class Kernel extends BaseKernel implements KernelInterface
         // boot if it hasn't booted yet
         $this->boot();
 
-        $this->fixSymfonySessions();
-
         return $this->getHttpKernel()->handle($request, $type, $catch);
     }
 
@@ -70,21 +68,6 @@ abstract class Kernel extends BaseKernel implements KernelInterface
 
         // define Fork constants
         $this->defineForkConstants();
-    }
-
-    /**
-     * We need to manually initialize SpoonSession for the Symfony sessions to work properly
-     */
-    private function fixSymfonySessions()
-    {
-        SpoonSession::start();
-
-        /** @var \Symfony\Component\HttpFoundation\Session\Session $session */
-        $session = $this->getContainer()->get('session');
-
-        if (!$session->isStarted()) {
-            $session->start();
-        }
     }
 
     /**

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,6 +4,7 @@ imports:
 
 parameters:
     translator.identity.class: Common\Language
+    session.storage.php_bridge.class: Common\Core\Session\Storage\PhpBridgeSessionStorage
 
 framework:
     secret:          %kernel.secret%

--- a/src/Common/Core/Session/Storage/PhpBridgeSessionStorage.php
+++ b/src/Common/Core/Session/Storage/PhpBridgeSessionStorage.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Common\Core\Session\Storage;
+
+use SpoonSession;
+use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage as SymfonyPhpBridgeSessionStorage;
+
+/**
+ * In most cases we will only access the symfony sessions after SpoonSession has started. But in the cases where that
+ * is not the case the symfony sessions didn't work because of some stuff happening in SpoonSession.
+ * This will fix that issue by making sure that when we start the symfony sessions the SpoonSessions also have started.
+ */
+final class PhpBridgeSessionStorage extends SymfonyPhpBridgeSessionStorage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function start()
+    {
+        if ($this->started) {
+            return true;
+        }
+
+        SpoonSession::start();
+
+        return parent::start();
+    }
+}


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

Symfony sessions did not work if they where started before the spoon sessions

## Pull request description

In most cases we will only access the symfony sessions after SpoonSession has started. But in the cases where that is not the case the symfony sessions didn't work because of some stuff happening This will fix that issue by making sure that when we start the symfony sessions the SpoonSessions also have started.

