### PR TITLE
Fix unpublished posts showing up in the pager of blog detail

### DIFF
--- a/src/Frontend/Modules/Blog/Engine/Model.php
+++ b/src/Frontend/Modules/Blog/Engine/Model.php
@@ -687,10 +687,10 @@ class Model implements FrontendTagsInterface
              FROM blog_posts AS i
              INNER JOIN meta AS m ON i.meta_id = m.id
              WHERE i.id != ? AND i.status = ? AND i.hidden = ? AND i.language = ? AND
-                ((i.publish_on = ? AND i.id > ?) OR i.publish_on > ?)
+                ((i.publish_on = ? AND i.id > ?) OR (i.publish_on > ? AND i.publish_on <= ?))
              ORDER BY i.publish_on ASC, i.id ASC
              LIMIT 1',
-            array($detailLink, $id, 'active', 'N', LANGUAGE, $date, $id, $date)
+            array($detailLink, $id, 'active', 'N', LANGUAGE, $date, $id, $date, FrontendModel::getUTCDate('Y-m-d H:i'))
         );
 
         // if empty, unset it


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

when a post was not yet published it did show up in the pager as the next item on blog detail

## Pull request description

it has been fixed :)

