### PR TITLE
Fix the htaccess so ckfinder works again

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -40,7 +40,12 @@ deny from env=stayout
 	RewriteEngine On
 	RewriteBase /
 
+    # allow the ck connector
+    RewriteRule ^index\.php$ - [L]
+    RewriteRule src/Backend/Core/Js/ckfinder/core/connector/php/connector\.php - [L]
+
 	# forbidden folders
+    RewriteRule .*\.php - [F]
 	RewriteRule \.git - [F]
 	RewriteRule vendor/.* - [F]
 	RewriteRule bin/.* - [F]
@@ -48,7 +53,6 @@ deny from env=stayout
 	RewriteRule .*\.gitignore - [F]
 	RewriteRule \.editorconfig - [F]
 	RewriteRule \.travis.yml - [F]
-	RewriteRule autoload\.php - [F]
 	RewriteRule bower\.json - [F]
 	RewriteRule composer\.json - [F]
 	RewriteRule composer\.lock - [F]
@@ -57,11 +61,8 @@ deny from env=stayout
 	RewriteRule app/logs - [F]
 	RewriteRule app/config - [F]
 	RewriteRule src/Frontend/Cache/CompiledTemplates - [F]
-	RewriteRule src/Frontend/Cache/Locale/.*\.php - [F]
-	RewriteRule src/Frontend/Cache/Navigation/.*\.php - [F]
 	RewriteRule src/Frontend/Cache/Search - [F]
 	RewriteRule src/Backend/Cache/CompiledTemplates - [F]
-	RewriteRule src/Backend/Cache/Locale/.*\.php - [F]
 
 	# redirect all trafic to https
 	# RewriteCond %{SERVER_PORT} 80

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,4 +1,0 @@
-<Files *.php>
-    Order Deny,Allow
-    deny from all
-</Files>


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

After the last security update ckfinder didn't work anymore.

## Pull request description

The htaccess has been changed. Now all php files are forbidden except for the connector of ckfinder and the index.php in the root of the project

