### PR TITLE
2021 fix formbuilder problem with label and checkbox

### DIFF
--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Field.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Field.html.twig
@@ -8,7 +8,7 @@
     {% if simple %}
       <div class="col-md-3">
         <label for="field{{ id }}">
-          {{ label }}
+          {{ label|raw }}
           {% if required %}
             {{ macro.required }}
           {% endif %}
@@ -21,7 +21,7 @@
     {% if multiple %}
       <div class="col-md-3">
         <label for="field{{ id }}">
-          {{ label }}
+          {{ label|raw }}
           {% if required %}
             {{ macro.required }}
           {% endif %}
@@ -31,7 +31,7 @@
         <ul class="list-unstyled">
           {% for item in items %}
             <li class="checkbox">
-              <label for="{{ item.id }}">{{ item.field|raw }} {{ item.label }}</label>
+              <label for="{{ item.id }}">{{ item.field|raw }} {{ item.label|raw }}</label>
             </li>
           {% endfor %}
         </ul>

--- a/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
+++ b/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
@@ -28,7 +28,7 @@
             {% if field.simple %}
               <p{% if field.error %} class="errorArea"{% endif %}>
                 <label for="{{ field.name }}">
-                  {{ field.label }}{% if field.required %}
+                  {{ field.label|raw }}{% if field.required %}
                     <abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr>{% endif %}
                 </label>
                 {{ field.html|raw }}
@@ -40,7 +40,7 @@
             {% if field.multiple %}
               <div class="inputList{% if field.error %} errorArea{% endif %}">
                 <p class="label">
-                  {{ field.label }}{% if field.required %}
+                  {{ field.label|raw }}{% if field.required %}
                     <abbr title="{{ 'lbl.RequiredField'|trans }}">*</abbr>{% endif %}
                 </p>
                 <ul>
@@ -54,7 +54,7 @@
           {% endfor %}
 
           <p>
-            <input type="submit" value="{{ submitValue }}" name="submit" class="inputSubmit" />
+            <input type="submit" value="{{ submitValue|raw }}" name="submit" class="inputSubmit" />
           </p>
         </form>
       {% endif %}

--- a/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
+++ b/src/Frontend/Modules/FormBuilder/Layout/Widgets/Form.html.twig
@@ -45,7 +45,7 @@
                 </p>
                 <ul>
                   {% for html in field.html %}
-                    <li><label for="{{ html.id }}">{{ html.field|raw }} {{ html.label|raw }}</label></li>
+                    <li><label for="{{ html.id|raw }}">{{ html.field|raw }} {{ html.label|raw }}</label></li>
                   {% endfor %}
                 </ul>
                 {% if field.error %}<span class="formError inlineError">{{ field.error }}</span>{% endif %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When using special chars in the formbuilder like `>` the encoded versions showed up and in case of the checkboxes clicking on the label didn't work to check the checkbox

## Pull request description

Labels are now shown correctly and the checkboxes can be checked by clicking on the label

