### PR TITLE
Fix saving groups

### DIFF
--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -261,7 +261,7 @@
                     <label for="authRequired" class="control-label">{% form_field auth_required %} {{ 'msg.AuthRequired'|trans|ucfirst }}</label>
                   </li>
                   {% if authGroups %}
-                  <div class="js-authentication-groups" {% if not item.data.auth_required %} style="display: none;"{% endif %}>
+                  <div class="js-authentication-groups" {% if item.data.auth_required %} style="display: none;"{% endif %}>
                     <h4>{{ 'lbl.Groups'|trans|ucfirst }}</h4>
                     <ul class="list-unstyled">
                       {% for item in authGroups %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Fixes #2036 

## Description

If auth is required this field should be hidden. The logic was not correct. The field will be visible when the checkbox to authenticate the page is ticked.