### PR TITLE
Fix html5 file input revalidation not working

### DIFF
--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -343,8 +343,7 @@
         var $input = $(this),
             errorMessage = '',
             type = '',
-            defaults =
-            {
+            defaults = {
                 required: jsFrontend.locale.err('FieldIsRequired'),
                 email: 	  jsFrontend.locale.err('EmailIsInvalid'),
                 date: 	  jsFrontend.locale.err('DateIsInvalid'),
@@ -369,7 +368,7 @@
 
             e.target.setCustomValidity(errorMessage);
 
-            $input.on('input', function(e) {
+            $input.on('input change', function(e) {
                 e.target.setCustomValidity('');
             });
         });

--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -345,16 +345,15 @@
             type = '',
             defaults = {
                 required: jsFrontend.locale.err('FieldIsRequired'),
-                email: 	  jsFrontend.locale.err('EmailIsInvalid'),
-                date: 	  jsFrontend.locale.err('DateIsInvalid'),
-                number:   jsFrontend.locale.err('NumberIsInvalid'),
-                value:    jsFrontend.locale.err('InvalidValue')
+                email: jsFrontend.locale.err('EmailIsInvalid'),
+                date: jsFrontend.locale.err('DateIsInvalid'),
+                number: jsFrontend.locale.err('NumberIsInvalid'),
+                value: jsFrontend.locale.err('InvalidValue')
             };
 
         options = $.extend(defaults, options);
 
         $input.on('invalid', function(e) {
-
             if ($input.context.validity.valueMissing) {
                 errorMessage = options.required;
             } else if (!$input.context.validity.valid) {

--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -337,41 +337,41 @@
  */
 (function($)
 {
-	$.fn.html5validation = function(options)
-	{
-		// define defaults
-		var $input = $(this),
-			errorMessage = '',
-			type = '',
-			defaults =
-			{
-				required: jsFrontend.locale.err('FieldIsRequired'),
-				email: 	  jsFrontend.locale.err('EmailIsInvalid'),
-				date: 	  jsFrontend.locale.err('DateIsInvalid'),
-				number:   jsFrontend.locale.err('NumberIsInvalid'),
-				value:    jsFrontend.locale.err('InvalidValue')
-			};
+    $.fn.html5validation = function(options)
+    {
+        // define defaults
+        var $input = $(this),
+            errorMessage = '',
+            type = '',
+            defaults =
+            {
+                required: jsFrontend.locale.err('FieldIsRequired'),
+                email: 	  jsFrontend.locale.err('EmailIsInvalid'),
+                date: 	  jsFrontend.locale.err('DateIsInvalid'),
+                number:   jsFrontend.locale.err('NumberIsInvalid'),
+                value:    jsFrontend.locale.err('InvalidValue')
+            };
 
-		options = $.extend(defaults, options);
+        options = $.extend(defaults, options);
 
-		$input.on('invalid', function(e) {
+        $input.on('invalid', function(e) {
 
-			if ($input.context.validity.valueMissing) {
-				errorMessage = options.required;
-			} else if (!$input.context.validity.valid) {
-				type = $input.context.type;
-				errorMessage = options.value;
+            if ($input.context.validity.valueMissing) {
+                errorMessage = options.required;
+            } else if (!$input.context.validity.valid) {
+                type = $input.context.type;
+                errorMessage = options.value;
 
-				if (options[type]) {
-					errorMessage = options[type];
-				}
-			}
+                if (options[type]) {
+                    errorMessage = options[type];
+                }
+            }
 
-			e.target.setCustomValidity(errorMessage);
+            e.target.setCustomValidity(errorMessage);
 
-			$input.on('input', function(e) {
-				e.target.setCustomValidity('');
-			});
-		});
-	};
+            $input.on('input', function(e) {
+                e.target.setCustomValidity('');
+            });
+        });
+    };
 })(jQuery);


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

Selecting a new file doesn't trigger the input event but it does trigger the change event.
Because the input event wasn't triggered the custom event wasn't reset and therefore keeping the form in a permanent invalid state

