### PR TITLE
Fix textareas in ckeditor popups not working inside bootstrap modals

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -548,7 +548,11 @@ jsBackend.ckeditor =
             var modal_this;
             modal_this = this;
             $(document).on('focusin.modal', function(e) {
-                if (modal_this.$element[0] !== e.target && !modal_this.$element.has(e.target).length && !$(e.target.parentNode).hasClass('cke_dialog_ui_input_select') && !$(e.target.parentNode).hasClass('cke_dialog_ui_input_text')) {
+                if (modal_this.$element[0] !== e.target
+                    && !modal_this.$element.has(e.target).length
+                    && !$(e.target.parentNode).hasClass('cke_dialog_ui_input_select')
+                    && !$(e.target.parentNode).hasClass('cke_dialog_ui_input_text')
+                    && !$(e.target.parentNode).hasClass('cke_dialog_ui_input_textarea')) {
                     modal_this.$element.focus();
                 }
             });


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

 	Fix textareas in ckeditor popups not working inside bootstrap modals

