### PR TITLE
Fix determining language for single language website

### DIFF
--- a/src/Frontend/Core/Engine/Url.php
+++ b/src/Frontend/Core/Engine/Url.php
@@ -238,7 +238,7 @@ class Url extends KernelLoader
 
     private function determineLanguage(string $queryString): string
     {
-        if ($this->getContainer()->getParameter('site.multilanguage')) {
+        if (!$this->getContainer()->getParameter('site.multilanguage')) {
             return $this->get('fork.settings')->get('Core', 'default_language', SITE_DEFAULT_LANGUAGE);
         }
 


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
After a clean install of a single language website, all the frontend pages give a 404, as described in https://github.com/forkcms/forkcms/issues/2044#issuecomment-306817211

## Pull request description
Will fix the determination of the language for a single language website

