### PR TITLE
Get correct module and action from request from backend url

### DIFF
--- a/src/Backend/Core/Engine/Url.php
+++ b/src/Backend/Core/Engine/Url.php
@@ -66,9 +66,9 @@ class Url extends Base\Object
 
     private function getLanguageFromUrl(): string
     {
-        if (!array_key_exists($this->request->get('_locale'), BackendLanguage::getWorkingLanguages())) {
+        if (!array_key_exists($this->request->attributes->get('_locale'), BackendLanguage::getWorkingLanguages())) {
             $url = $this->getBaseUrlForLanguage($this->getContainer()->getParameter('site.default_language'));
-            $url .= '/' . $this->request->get('module') . '/' . $this->request->get('action');
+            $url .= '/' . $this->request->attributes->get('module') . '/' . $this->request->attributes->get('action');
 
             if ($this->request->getQueryString() !== null) {
                 $url .= '?' . $this->request->getQueryString();
@@ -77,12 +77,12 @@ class Url extends Base\Object
             $this->redirect($url);
         }
 
-        return $this->request->get('_locale');
+        return $this->request->attributes->get('_locale');
     }
 
     private function getModuleFromRequest(): string
     {
-        $module = $this->request->get('module');
+        $module = $this->request->attributes->get('module');
         if (empty($module)) {
             return 'Dashboard';
         }
@@ -92,7 +92,7 @@ class Url extends Base\Object
 
     private function getActionFromRequest(string $module, string $language): string
     {
-        $action = $this->request->get('action');
+        $action = $this->request->attributes->get('action');
         if (!empty($action)) {
             return \SpoonFilter::toCamelCase($action);
         }
@@ -128,7 +128,7 @@ class Url extends Base\Object
 
     private function processQueryString(): void
     {
-        if ($this->request->get('_route') === 'backend_ajax') {
+        if ($this->request->attributes->get('_route') === 'backend_ajax') {
             $this->processAjaxRequest();
 
             return;
@@ -143,17 +143,15 @@ class Url extends Base\Object
 
     private function getForkData(): array
     {
-        $request = $this->getContainer()->get('request');
-
-        if ($request->request->has('fork')) {
-            return (array) $request->request->get('fork');
+        if ($this->request->request->has('fork')) {
+            return (array) $this->request->request->get('fork');
         }
 
-        if ($request->query->has('fork')) {
-            return (array) $request->query->get('fork');
+        if ($this->request->query->has('fork')) {
+            return (array) $this->request->query->get('fork');
         }
 
-        return (array) $request->query->all();
+        return (array) $this->request->query->all();
     }
 
     private function processAjaxRequest(): void


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
fixes #2059 

## Pull request description
Now you can override the module/action with get parameters. This change will prevent this and always use the module/action that is set in the url. 
(As set in the config:

    backend:
      path: /private/{_locale}/{module}/{action}
      defaults:
        _controller: \ForkCMS\App\ForkController::backendController
        _locale:     ~
        module:      ~
        action:      ~`
)
