### PR TITLE
Updated "Extensions" installer

### DIFF
--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -85,6 +85,7 @@ class Installer extends ModuleInstaller
     private function configureBackendRights(): void
     {
         $this->setModuleRights(1, $this->getModule());
+
         $this->configureBackendActionRightsForModules();
         $this->configureBackendActionRightsForTemplates();
         $this->configureBackendActionRightsForThemes();

--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -15,10 +15,10 @@ class Installer extends ModuleInstaller
         $this->addModule('Extensions');
         $this->importSQL(__DIR__ . '/Data/install.sql');
         $this->importLocale(__DIR__ . '/Data/locale.xml');
+        $this->configureBackendNavigation();
         $this->configureBackendRights();
         $this->configureFrontendExtras();
         $this->configureFrontendForkTheme();
-        $this->configureBackendNavigation();
     }
 
     private function configureBackendActionRightsForModules(): void

--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -67,8 +67,8 @@ class Installer extends ModuleInstaller
             'ThemesSelection',
             'extensions/themes',
             [
-                'extensions/upload_theme',
                 'extensions/detail_theme',
+                'extensions/upload_theme',
             ]
         );
         $this->setNavigation(

--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -23,25 +23,25 @@ class Installer extends ModuleInstaller
 
     private function configureBackendActionRightsForModules(): void
     {
-        $this->setActionRights(1, $this->getModule(), 'Modules');
         $this->setActionRights(1, $this->getModule(), 'DetailModule');
         $this->setActionRights(1, $this->getModule(), 'InstallModule');
+        $this->setActionRights(1, $this->getModule(), 'Modules');
         $this->setActionRights(1, $this->getModule(), 'UploadModule');
     }
 
     private function configureBackendActionRightsForTemplates(): void
     {
-        $this->setActionRights(1, $this->getModule(), 'ThemeTemplates');
         $this->setActionRights(1, $this->getModule(), 'AddThemeTemplate');
-        $this->setActionRights(1, $this->getModule(), 'EditThemeTemplate');
         $this->setActionRights(1, $this->getModule(), 'DeleteThemeTemplate');
+        $this->setActionRights(1, $this->getModule(), 'EditThemeTemplate');
+        $this->setActionRights(1, $this->getModule(), 'ThemeTemplates');
     }
 
     private function configureBackendActionRightsForThemes(): void
     {
-        $this->setActionRights(1, $this->getModule(), 'Themes');
         $this->setActionRights(1, $this->getModule(), 'DetailTheme');
         $this->setActionRights(1, $this->getModule(), 'InstallTheme');
+        $this->setActionRights(1, $this->getModule(), 'Themes');
         $this->setActionRights(1, $this->getModule(), 'UploadTheme');
     }
 

--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -47,7 +47,7 @@ class Installer extends ModuleInstaller
 
     private function configureBackendNavigation(): void
     {
-        // Set navigation for "settings"
+        // Set navigation for "Settings"
         $navigationSettingsId = $this->setNavigation(null, 'Settings');
         $navigationModulesId = $this->setNavigation($navigationSettingsId, 'Modules');
         $this->setNavigation(
@@ -60,7 +60,7 @@ class Installer extends ModuleInstaller
             ]
         );
 
-        // Set navigation for "settings > themes"
+        // Set navigation for "Settings > Themes"
         $navigationThemesId = $this->setNavigation($navigationSettingsId, 'Themes');
         $this->setNavigation(
             $navigationThemesId,


### PR DESCRIPTION
Changes:
- Moved functionality "Extensions" to separate methods
- Fixed bug: using Search “Form” instead of “form”
- Removed "Core" theme (since the only theme remaining in fork cms 5 is "Fork")

## Type

- Enhancement

## Pull request description

> In the Extensions module, restructured installer functionality into properly named methods.

