### PR TITLE
Remove module as default for module extra on module install

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -707,7 +707,7 @@ class Model extends \Common\Core\Model
                 'module' => $module,
                 'type' => $type,
                 'label' => $label ?? $module, // if label is empty, fallback to module
-                'action' => $action ?? $module, // if action is empty, fallback to module
+                'action' => $action ?? null,
                 'data' => $data ===  null ? null : serialize($data),
                 'hidden' => $hidden ? 'Y' : 'N',
                 'sequence' => $sequence ?? self::getNextModuleExtraSequenceForModule($module),


### PR DESCRIPTION
As some modules have not always specific block for each action, this is breaking those module.
For example blog module, where detail etc is called through the translation actions.

## Type
- Critical bugfix

## Pull request description
Making modules with no specific block for each action work again, for example blog.

