### PR TITLE
Fix notifying admin on blog commment

### DIFF
--- a/src/Frontend/Core/Engine/Navigation.php
+++ b/src/Frontend/Core/Engine/Navigation.php
@@ -70,7 +70,7 @@ class Navigation extends FrontendBaseObject
         }
 
         if ($urlencode) {
-            array_walk($parameters, 'rawurlencode');
+            $parameters = array_map('rawurlencode', $parameters);
         }
 
         $queryString = '?' . http_build_query($parameters, null, '&amp;');


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
The function array_walk sends 2 parameters to the callback, the actual value and the key/index. Because of this
the rawurlencode function is not so happy and throws a warning that the function only accepts 1 parameter. Using
array_map, which only send 1 parameter (the value) to the callback, will fix this issue.
