### PR TITLE
Replace &amp; by & as parameter query divider

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -96,7 +96,7 @@ class Model extends \Common\Core\Model
             $parameters['sort'] = $queryParameterBag->get('sort');
         }
 
-        $queryString = '?' . http_build_query($parameters, null, '&');
+        $queryString = '?' . http_build_query($parameters);
 
         if (!$encodeSquareBrackets) {
             // we use things like [id] to parse database column data in so we need to unescape those

--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -96,7 +96,7 @@ class Model extends \Common\Core\Model
             $parameters['sort'] = $queryParameterBag->get('sort');
         }
 
-        $queryString = '?' . http_build_query($parameters, null, '&amp;');
+        $queryString = '?' . http_build_query($parameters, null, '&');
 
         if (!$encodeSquareBrackets) {
             // we use things like [id] to parse database column data in so we need to unescape those

--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -46,7 +46,7 @@ class Model extends \Common\Core\Model
         }
 
         // build query string
-        $queryString = http_build_query($parameters, null, '&amp;', PHP_QUERY_RFC3986);
+        $queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
         if (mb_strpos($url, '?') !== false) {
             return $url . '&' . $queryString . $hash;
         }

--- a/src/Frontend/Core/Engine/Navigation.php
+++ b/src/Frontend/Core/Engine/Navigation.php
@@ -73,7 +73,7 @@ class Navigation extends FrontendBaseObject
             array_walk($parameters, 'rawurlencode');
         }
 
-        $queryString = '?' . http_build_query($parameters, null, '&amp;');
+        $queryString = '?' . http_build_query($parameters);
 
         // build the URL and return it
         return FrontendModel::get('router')->generate(


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
Using &amp; will resolve in the following queryString: index?foo=test&amp;bar=test&amp;token=x - which will resolve in the following parameters: foo = test, amp;=bar = test, amp;token = x
Replacing it by & will resolve this issue.

