### PR TITLE
Add missing translations for extensions module

### DIFF
--- a/src/Backend/Modules/Extensions/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Extensions/Installer/Data/locale.xml
@@ -391,6 +391,10 @@
         <translation language="sv"><![CDATA[lägg till position]]></translation>
         <translation language="el"><![CDATA[Προσθήκη θέσης]]></translation>
       </item>
+      <item type="label" name="AddThemeTemplate">
+        <translation language="nl"><![CDATA[thema template toevoegen]]></translation>
+        <translation language="en"><![CDATA[add theme template]]></translation>
+      </item>
       <item type="label" name="Authors">
         <translation language="nl"><![CDATA[auteurs]]></translation>
         <translation language="en"><![CDATA[authors]]></translation>
@@ -418,6 +422,10 @@
         <translation language="sv"><![CDATA[ta bort position]]></translation>
         <translation language="lt"><![CDATA[trinti poziciją]]></translation>
         <translation language="el"><![CDATA[Διαγραφή θέσης]]></translation>
+      </item>
+      <item type="label" name="EditThemeTemplate">
+        <translation language="nl"><![CDATA[thema template bewerken]]></translation>
+        <translation language="en"><![CDATA[edit theme template]]></translation>
       </item>
       <item type="label" name="Events">
         <translation language="nl"><![CDATA[evenementen (hooks)]]></translation>
@@ -542,6 +550,10 @@
         <translation language="sv"><![CDATA[teman]]></translation>
         <translation language="el"><![CDATA[Θέμα]]></translation>
         <translation language="zh"><![CDATA[主题]]></translation>
+      </item>
+      <item type="label" name="ThemeTemplates">
+        <translation language="nl"><![CDATA[thema templates]]></translation>
+        <translation language="en"><![CDATA[theme templates]]></translation>
       </item>
       <item type="label" name="UploadModule">
         <translation language="nl"><![CDATA[module opladen]]></translation>


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Will add some missing translations for extensions module. 
Note I only translated the ones I know for sure. I didn't want to use Google Translate because that can be a bit wonky.

