### PR TITLE
The locale should be serialized to a string when it is used in a json

### DIFF
--- a/src/Common/Locale.php
+++ b/src/Common/Locale.php
@@ -3,9 +3,10 @@
 namespace Common;
 
 use InvalidArgumentException;
+use JsonSerializable;
 use Serializable;
 
-abstract class Locale implements Serializable
+abstract class Locale implements Serializable, JsonSerializable
 {
     /**
      * @var string
@@ -63,5 +64,10 @@ abstract class Locale implements Serializable
     public function equals(Locale $locale): bool
     {
         return $this->locale === $locale->locale;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->locale;
     }
 }


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

the Locale used in the jsData wasn't serialized correctly

