### PR TITLE
Frontend js language is lowercase

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -9,7 +9,7 @@ var jsFrontend =
     // init, something like a constructor
     init: function()
     {
-        jsFrontend.current.language = jsFrontend.data.get('LANGUAGE');
+        jsFrontend.current.language = jsFrontend.data.get('language');
 
         // init stuff
         jsFrontend.initAjax();


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
The frontend js language is lowercase, as defined in https://github.com/forkcms/forkcms/blob/5.0.0-dev/src/Frontend/Core/Header/Header.php#L105 - this gives an JS-error in the frontend, which breaks the other JS.

