### PR TITLE
Make JS language constant uppercase

### DIFF
--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -102,7 +102,7 @@ class Header extends Object
                 FRONTEND_CACHE_PATH . '/MinifiedJs/'
             )
         );
-        $this->jsData = new JsData(['language' => Locale::frontendLanguage()]);
+        $this->jsData = new JsData(['LANGUAGE' => Locale::frontendLanguage()]);
         $this->meta = new MetaCollection();
 
         // add some default CSS files


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
Alternative fix to #2102 

## Pull request description
This wil make the JS in frontend work again. This is used in https://github.com/jonasdekeukelaere/forkcms/blob/5.0.0-dev/src/Frontend/Core/Js/frontend.js#L12

