### PR TITLE
Fix blog image path

### DIFF
--- a/src/Frontend/Modules/Blog/Engine/Model.php
+++ b/src/Frontend/Modules/Blog/Engine/Model.php
@@ -57,7 +57,7 @@ class Model implements FrontendTagsInterface
 
         // image?
         if (isset($return['image'])) {
-            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
             foreach ($folders as $folder) {
                 $return['image_' . $folder['dirname']] = $folder['url'] . '/' . $folder['dirname'] . '/' . $return['image'];
@@ -109,7 +109,7 @@ class Model implements FrontendTagsInterface
         // init var
         $link = FrontendNavigation::getURLForBlock('Blog', 'Detail');
         $categoryLink = FrontendNavigation::getURLForBlock('Blog', 'Category');
-        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
         // loop
         foreach ($items as $key => $row) {
@@ -274,7 +274,7 @@ class Model implements FrontendTagsInterface
         // init var
         $link = FrontendNavigation::getURLForBlock('Blog', 'Detail');
         $categoryLink = FrontendNavigation::getURLForBlock('Blog', 'Category');
-        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
         // loop
         foreach ($items as $key => $row) {
@@ -387,7 +387,7 @@ class Model implements FrontendTagsInterface
 
         // init var
         $link = FrontendNavigation::getURLForBlock('Blog', 'Detail');
-        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+        $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
         // loop
         foreach ($items as $key => $row) {
@@ -600,7 +600,7 @@ class Model implements FrontendTagsInterface
         if (!empty($items)) {
             // init var
             $link = FrontendNavigation::getURLForBlock('Blog', 'Detail');
-            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
             // reset url
             foreach ($items as &$row) {
@@ -833,7 +833,7 @@ class Model implements FrontendTagsInterface
 
         // image?
         if (isset($return['image'])) {
-            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/Blog/Images', true);
+            $folders = FrontendModel::getThumbnailFolders(FRONTEND_FILES_PATH . '/blog/images', true);
 
             foreach ($folders as $folder) {
                 $return['image_' . $folder['dirname']] = $folder['url'] . '/' . $folder['dirname'] . '/' . $return['image'];


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Blog post items did not return the `image_AAxBB` fields.
As you can see in `src/Backend/Modules/Blog/Actions/Add.php` the image path is in lowercase, not CamelCase.
