### PR TITLE
Add debouncer to generatedUrl

### DIFF
--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -49,7 +49,7 @@
             var $urlOverwrite = $(options.urlOverwriteSelector);
 
             // bind keypress
-            $element.bind('keyup', calculateMeta);
+            $element.bind('keyup input', utils.events.debounce(calculateMeta, 400));
 
             // bind change on the checkboxes
             if($pageTitle.length > 0 && $pageTitleOverwrite.length > 0)

--- a/src/Backend/Core/Js/utils.js
+++ b/src/Backend/Core/Js/utils.js
@@ -482,3 +482,31 @@ utils.url =
         return getValue;
     }
 };
+
+/**
+ * Functions related to the events
+ */
+utils.events =
+{
+    /**
+     * http://davidwalsh.name/javascript-debounce-function
+     * @param func
+     * @param wait
+     * @param immediate
+     * @returns {Function}
+     */
+    debounce: function(func, wait, immediate) {
+        var timeout;
+        return function() {
+            var context = this, args = arguments;
+            var later = function () {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    },
+};


### PR DESCRIPTION
## Type

- Enhancement
- Bugfix

## Resolves the following issues

When filling in a title or name in a module, per character you type an ajax call gets fired away. In general, such keyevents need a debouncer so it waits a few hundred ms before executing. If you type a word, it'll only fire one ajax event. It's a general performance boost. If you type a long word, it can easily fire off 20-30 ajax calls (=and database calls most of the time). Using a debounce it'll do it when you stop typing

## Pull request description

Added a debouncer function to utils, and using it in the backend meta javascript. 
We could also start using http://underscorejs.org/ which contains a _.debounce function... Then we don't need it in utils. 
http://underscorejs.org/#debounce


Also, I snuck in the input event to catch additional changes like copy/paste in addition to keystrokes (in modern browsers)

