### PR TITLE
Add missing generated_url_selector

### DIFF
--- a/src/Backend/Form/Type/MetaType.php
+++ b/src/Backend/Form/Type/MetaType.php
@@ -349,6 +349,7 @@ class MetaType extends AbstractType
         }
         $view->vars['base_field_selector'] = '#' . $view->parent->children[$options['base_field_name']]->vars['id'];
         $view->vars['custom_meta_tags'] = $options['custom_meta_tags'];
+        $view->vars['generated_url_selector'] = $options['generated_url_selector'];
         $view->vars['generate_url_callback_class'] = $options['generate_url_callback_class'];
         $view->vars['generate_url_callback_method'] = $options['generate_url_callback_method'];
         $view->vars['generate_url_callback_parameters'] = serialize($options['generate_url_callback_parameters']);


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues
When you have a generated url link on your module, it should create the url while you are typing in a name. The default value is #generatedUrl but if you look in the page source code, you'll see that the value is not set, so the selector isn't used in javascript. 

## Pull request description
Adding the generated url selector to the view variables, so it's not an empty string anymore and is set to the default value or the value you passed to the metatype. 

This was already fixed in v5 I believe, but just adding it back into master now

