### PR TITLE
Allow null database values for images

### DIFF
--- a/src/Common/Doctrine/Type/AbstractFileType.php
+++ b/src/Common/Doctrine/Type/AbstractFileType.php
@@ -25,12 +25,12 @@ abstract class AbstractFileType extends Type
     }
 
     /**
-     * @param AbstractFile $file
+     * @param AbstractFile|null $file
      * @param AbstractPlatform $platform
      *
      * @return string|null
      */
-    public function convertToDatabaseValue($file, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue(?$file, AbstractPlatform $platform): ?string
     {
         return $file !== null ? (string) $file : null;
     }

--- a/src/Common/Doctrine/Type/AbstractFileType.php
+++ b/src/Common/Doctrine/Type/AbstractFileType.php
@@ -30,7 +30,7 @@ abstract class AbstractFileType extends Type
      *
      * @return string|null
      */
-    public function convertToDatabaseValue(?$file, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($file, AbstractPlatform $platform): ?string
     {
         return $file !== null ? (string) $file : null;
     }

--- a/src/Common/Doctrine/Type/AbstractFileType.php
+++ b/src/Common/Doctrine/Type/AbstractFileType.php
@@ -28,11 +28,11 @@ abstract class AbstractFileType extends Type
      * @param AbstractFile $file
      * @param AbstractPlatform $platform
      *
-     * @return string
+     * @return string|null
      */
-    public function convertToDatabaseValue($file, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($file, AbstractPlatform $platform): ?string
     {
-        return (string) $file;
+        return $file ? (string) $file : null;
     }
 
     abstract protected function createFromString(string $fileName): AbstractFile;

--- a/src/Common/Doctrine/Type/AbstractFileType.php
+++ b/src/Common/Doctrine/Type/AbstractFileType.php
@@ -32,7 +32,7 @@ abstract class AbstractFileType extends Type
      */
     public function convertToDatabaseValue($file, AbstractPlatform $platform): ?string
     {
-        return $file ? (string) $file : null;
+        return $file !== null ? (string) $file : null;
     }
 
     abstract protected function createFromString(string $fileName): AbstractFile;

--- a/src/Common/Doctrine/Type/AbstractImageType.php
+++ b/src/Common/Doctrine/Type/AbstractImageType.php
@@ -25,12 +25,12 @@ abstract class AbstractImageType extends Type
     }
 
     /**
-     * @param AbstractImage $image
+     * @param AbstractImage|null $image
      * @param AbstractPlatform $platform
      *
      * @return string|null
      */
-    public function convertToDatabaseValue($image, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue(?$image, AbstractPlatform $platform): ?string
     {
         return $image !== null ? (string) $image : null;
     }

--- a/src/Common/Doctrine/Type/AbstractImageType.php
+++ b/src/Common/Doctrine/Type/AbstractImageType.php
@@ -28,11 +28,11 @@ abstract class AbstractImageType extends Type
      * @param AbstractImage $image
      * @param AbstractPlatform $platform
      *
-     * @return string
+     * @return string|null
      */
-    public function convertToDatabaseValue($image, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($image, AbstractPlatform $platform): ?string
     {
-        return (string) $image;
+        return $image ? (string) $image : null;
     }
 
     abstract protected function createFromString(string $imageFileName): AbstractImage;

--- a/src/Common/Doctrine/Type/AbstractImageType.php
+++ b/src/Common/Doctrine/Type/AbstractImageType.php
@@ -30,7 +30,7 @@ abstract class AbstractImageType extends Type
      *
      * @return string|null
      */
-    public function convertToDatabaseValue(?$image, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($image, AbstractPlatform $platform): ?string
     {
         return $image !== null ? (string) $image : null;
     }

--- a/src/Common/Doctrine/Type/AbstractImageType.php
+++ b/src/Common/Doctrine/Type/AbstractImageType.php
@@ -32,7 +32,7 @@ abstract class AbstractImageType extends Type
      */
     public function convertToDatabaseValue($image, AbstractPlatform $platform): ?string
     {
-        return $image ? (string) $image : null;
+        return $image !== null ? (string) $image : null;
     }
 
     abstract protected function createFromString(string $imageFileName): AbstractImage;

--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -201,7 +201,7 @@ abstract class AbstractFile
         return (string) $this->fileName;
     }
 
-    public static function fromString(string $fileName): ?self
+    public static function fromString(?string $fileName): ?self
     {
         return $fileName !== null ? new static($fileName) : null;
     }

--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -201,9 +201,9 @@ abstract class AbstractFile
         return (string) $this->fileName;
     }
 
-    public static function fromString(string $fileName): self
+    public static function fromString(string $fileName): ?self
     {
-        return new static($fileName);
+        return $fileName ? new static($fileName) : null;
     }
 
     /**

--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -203,7 +203,7 @@ abstract class AbstractFile
 
     public static function fromString(string $fileName): ?self
     {
-        return $fileName ? new static($fileName) : null;
+        return $fileName !== null ? new static($fileName) : null;
     }
 
     /**


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Using an ImageDbalType and the underlying AbstractImageType and AbstractFile, it's impossible to store NULL to the database when the user doesn't upload an image in his module. Should be fixed with this.

## Pull request description
* When a user doesnt upload an image in the module, my entity object contains null for my image field, and when it's persisted, it goes through `convertToDatabaseValue`. In there, the null is typecasted to a string ==> end result is `""` in the database (empty string). Not sure if that's intended? 

To fix it we have to do a bit of ugly null checking, but otherwise we're storing empty strings in the database instead of null. Harder to query to find users without image etc if you also need to check for empty strings in those fields instead of `WHERE image IS NULL`....

Let me know if it can be solved more elegantly

