### PR TITLE
Hide analytics widgets when no internet connection is found

### DIFF
--- a/src/Backend/Modules/Analytics/Widgets/RecentVisits.php
+++ b/src/Backend/Modules/Analytics/Widgets/RecentVisits.php
@@ -4,6 +4,7 @@ namespace Backend\Modules\Analytics\Widgets;
 
 use Backend\Core\Engine\Base\Widget;
 use Google_Auth_Exception;
+use Google_IO_Exception;
 
 /**
  * This widget will show recent visits
@@ -31,6 +32,8 @@ class RecentVisits extends Widget
             $this->display();
         } catch (Google_Auth_Exception $e) {
             // do nothing, analyticis is probably not set up yet.
+        } catch (Google_IO_Exception $e) {
+            // do nothing, probably no internet connection.
         }
     }
 }

--- a/src/Backend/Modules/Analytics/Widgets/TraficSources.php
+++ b/src/Backend/Modules/Analytics/Widgets/TraficSources.php
@@ -4,6 +4,7 @@ namespace Backend\Modules\Analytics\Widgets;
 
 use Backend\Core\Engine\Base\Widget;
 use Google_Auth_Exception;
+use Google_IO_Exception;
 
 /**
  * This widget will show a trafic sources graph for the last week
@@ -31,6 +32,8 @@ class TraficSources extends Widget
             $this->display();
         } catch (Google_Auth_Exception $e) {
             // do nothing, analyticis is probably not set up yet.
+        } catch (Google_IO_Exception $e) {
+            // do nothing, probably no internet connection.
         }
     }
 }


### PR DESCRIPTION
Don't show widget when there is no internet connection

## Type
- Non critical bugfix

## Resolves the following issues

fixes #1977

## Pull request description

When logging to the back-end while Internet connection is down don't show the analytics widgets

