### PR TITLE
Profiles: fix avatar path in installer

### DIFF
--- a/src/Backend/Modules/Profiles/Installer/Installer.php
+++ b/src/Backend/Modules/Profiles/Installer/Installer.php
@@ -42,10 +42,10 @@ class Installer extends ModuleInstaller
 
         // add folders
         $filesystem = new Filesystem();
-        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/source/');
-        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/240x240/');
-        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/64x64/');
-        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/avatars/32x32/');
+        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/Avatars/source/');
+        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/Avatars/240x240/');
+        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/Avatars/64x64/');
+        $filesystem->mkdir(PATH_WWW . '/src/Frontend/Files/Profiles/Avatars/32x32/');
 
         // module rights
         $this->setModuleRights(1, 'Profiles');


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The profiles avatar path should be in CamelCase. The rest of the module seems to be using "Profiles/Avatars".
