### PR TITLE
Fix deletion of uploaded images not working for file and image types

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -260,4 +260,26 @@ abstract class AbstractFile
 
         return $this;
     }
+
+    /**
+     * @internal Used by the form types
+     *
+     * @param bool $isPendingDeletion
+     */
+    public function setPendingDeletion($isPendingDeletion)
+    {
+        if ($isPendingDeletion) {
+            $this->markForDeletion();
+        }
+    }
+
+    /**
+     * @internal Used by the form types
+     *
+     * @return bool
+     */
+    public function isPendingDeletion()
+    {
+        return strlen($this->oldFileName) > 0 && $this->fileName === null;
+    }
 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
If you had more than one image type in a form and or its subforms the deletion of an uploaded file/image didn't work.
This fixes it

