### PR TITLE
Fix mailmotor when not installed [5.0.0-dev branch]

### DIFF
--- a/src/Backend/Modules/Mailmotor/DependencyInjection/Compiler/MailmotorCompilerPass.php
+++ b/src/Backend/Modules/Mailmotor/DependencyInjection/Compiler/MailmotorCompilerPass.php
@@ -15,7 +15,7 @@ class MailmotorCompilerPass implements CompilerPassInterface
                 // we must set these parameters to be usable
                 $container->setParameter(
                     'mailmotor.mail_engine',
-                    $container->get('fork.settings')->get('Mailmotor', 'mail_engine')
+                    $container->get('fork.settings')->get('Mailmotor', 'mail_engine', 'not_implemented')
                 );
                 $container->setParameter(
                     'mailmotor.api_key',


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

> Fixes #2131 in 5.0.0 dev branch

## Pull request description

> Fixes the installation of Fork CMS when Mailmotor isn't installed
