### PR TITLE
fix the double serialising of the user settings

### DIFF
--- a/src/Backend/Modules/Users/Installer/Installer.php
+++ b/src/Backend/Modules/Users/Installer/Installer.php
@@ -150,20 +150,18 @@ class Installer extends ModuleInstaller
 
             // build settings
             $settings = [];
-            $settings['nickname'] = serialize('Fork CMS');
-            $settings['name'] = serialize('Fork');
-            $settings['surname'] = serialize('CMS');
-            $settings['interface_language'] = serialize($this->getVariable('default_interface_language'));
-            $settings['date_format'] = serialize('j F Y');
-            $settings['time_format'] = serialize('H:i');
-            $settings['datetime_format'] = serialize(
-                unserialize($settings['date_format']) . ' ' . unserialize($settings['time_format'])
-            );
-            $settings['number_format'] = serialize('dot_nothing');
-            $settings['password_key'] = serialize(uniqid('', true));
-            $settings['password_strength'] = serialize($this->getPasswordStrength());
-            $settings['current_password_change'] = serialize(time());
-            $settings['avatar'] = serialize('god.jpg');
+            $settings['nickname'] = 'Fork CMS';
+            $settings['name'] = 'Fork';
+            $settings['surname'] = 'CMS';
+            $settings['interface_language'] = $this->getVariable('default_interface_language');
+            $settings['date_format'] = 'j F Y';
+            $settings['time_format'] = 'H:i';
+            $settings['datetime_format'] = $settings['date_format'] . ' ' . $settings['time_format'];
+            $settings['number_format'] = 'dot_nothing';
+            $settings['password_key'] = uniqid('', true);
+            $settings['password_strength'] = $this->getPasswordStrength();
+            $settings['current_password_change'] = time();
+            $settings['avatar'] = 'god.jpg';
 
             // build user
             $user = [];


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description
The usersettings are dubble serialised at the moment.
I removed the serialising in the installer class since it already happens in the model

