### PR TITLE
Locale added for msg.MoveMediaFoldersNotPossible

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Installer/Data/locale.xml
+++ b/src/Backend/Modules/MediaLibrary/Installer/Data/locale.xml
@@ -418,6 +418,10 @@
         <translation language="en"><![CDATA[move media]]></translation>
         <translation language="nl"><![CDATA[media verplaatsen]]></translation>
       </item>
+      <item type="message" name="MoveMediaFoldersNotPossible">
+        <translation language="en"><![CDATA[It's not possible to move media folders.]]></translation>
+        <translation language="nl"><![CDATA[Het is niet mogelijk om media folders te verplaatsen.]]></translation>
+      </item>
       <item type="message" name="MoveMediaToFolder">
         <translation language="en"><![CDATA[Move media to this folder:]]></translation>
         <translation language="nl"><![CDATA[Verplaats deze media naar volgende map:]]></translation>

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
@@ -4,7 +4,7 @@
   <div class="sub-navigation">
     <div id="mediaTree" class="pages-tree">
       <div class="alert alert-warning visible-xs visible-sm">
-        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MovePagesNotPossible'|trans|ucfirst }}</p>
+        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
       <div id="tree">
         {{ tree|raw }}

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
@@ -4,7 +4,7 @@
   <div class="sub-navigation">
     <div id="mediaTree" class="pages-tree">
       <div class="alert alert-warning visible-xs visible-sm">
-        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MovePagesNotPossible'|trans|ucfirst }}</p>
+        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
       <div id="tree">
         {{ tree|raw }}

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
@@ -4,7 +4,7 @@
   <div class="sub-navigation">
     <div id="mediaTree" class="pages-tree">
       <div class="alert alert-warning visible-xs visible-sm">
-        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MovePagesNotPossible'|trans|ucfirst }}</p>
+        <p><span class="fa fa-exclamation-triangle"></span>{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
       <div id="tree">
         {{ tree|raw }}


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

* Missing locale for MovePagesNotPossible on mobile phone
![screenshot_20170714-133601_1024](https://user-images.githubusercontent.com/588616/28227130-f11e2c62-68d8-11e7-85db-77ce1519ddfb.png)

## Pull request description

* Renamed msg.MovePagesNotPossible to msg.MoveMediaFoldersNotPossible
* Added locale

