### PR TITLE
Fork 4 doesn't work on php 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "http://www.fork-cms.com/",
     "license": "MIT",
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.5 || >=7.0 < 7.2",
         "tijsverkoyen/akismet": "1.1.*",
         "tijsverkoyen/css-to-inline-styles": "1.5.*",
         "matthiasmullie/minify": "~1.3",


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

From the changelog's list of backward incompatible changes: object (in any case) can no longer be used as a class name.
https://github.com/php/php-src/blob/php-7.2.0beta1/UPGRADING#L44

This is already fixed in fork 5

