### PR TITLE
Move some formtypes to common

### DIFF
--- a/UPGRADE_5.0.md
+++ b/UPGRADE_5.0.md
@@ -508,3 +508,12 @@ ALTER TABLE users MODIFY deleted TINYINT(1) NOT NULL DEFAULT '0' COMMENT 'is the
 UPDATE users SET is_god = CASE WHEN is_god= "Y" THEN 1 ELSE 0 END;
 ALTER TABLE users MODIFY is_god TINYINT(1) NOT NULL DEFAULT '0';
 ```
+
+## Move some form types to the common namespace so that they also can be used in the frontend
+
+Now that the frontend is also bootstrap we won't need to maintain duplicate form templates.
+The following form types have been moved
+
+| Old classname                       | New classname                 |
+|-------------------------------------|-------------------------------|
+| `\Backend\Form\Type\FileType`       | `\Common\Form\FileType`       |

--- a/UPGRADE_5.0.md
+++ b/UPGRADE_5.0.md
@@ -518,3 +518,4 @@ The following form types have been moved
 |-------------------------------------|-------------------------------|
 | `\Backend\Form\Type\FileType`       | `\Common\Form\FileType`       |
 | `\Backend\Form\Type\ImageType`      | `\Common\Form\ImageType`      |
+| `\Backend\Form\Type\CollectionType` | `\Common\Form\CollectionType` |

--- a/UPGRADE_5.0.md
+++ b/UPGRADE_5.0.md
@@ -517,3 +517,4 @@ The following form types have been moved
 | Old classname                       | New classname                 |
 |-------------------------------------|-------------------------------|
 | `\Backend\Form\Type\FileType`       | `\Common\Form\FileType`       |
+| `\Backend\Form\Type\ImageType`      | `\Common\Form\ImageType`      |

--- a/docs/05. module guide/29. symfony_form_file.md
+++ b/docs/05. module guide/29. symfony_form_file.md
@@ -2,7 +2,7 @@
 
 You can find a base value object that you can use to upload files.
 
-It can be used in combination with the form type `Backend\Form\Type\FileType`
+It can be used in combination with the form type `Common\Form\FileType`
 
 While most of the things you need to do are already written for you, you will still need to add some configuration for each implementation.
 
@@ -177,7 +177,7 @@ class User
 
 For the last step you need to add your file to your form.
 
-* Use `Backend\Form\Type\FileType` as the form type
+* Use `Common\Form\FileType` as the form type
 * Set the fully qualified class name (FQCN) of your value object in the option `file_class` (tip: you can use `MyFile::class` for that)
 
 #### Example
@@ -187,7 +187,7 @@ For the last step you need to add your file to your form.
 
 namespace Backend\Modules\Users\Form;
 
-use Backend\Form\Type\FileType;
+use Common\Form\FileType;
 use Backend\Modules\Users\ValueObject\CV;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/docs/05. module guide/30. symfony_form_image.md
+++ b/docs/05. module guide/30. symfony_form_image.md
@@ -2,7 +2,7 @@
 
 You can find a base value object that you can use to upload images.
 
-It can be used in combination with the form type `Backend\Form\Type\ImageType`
+It can be used in combination with the form type `Common\Form\ImageType`
 
 While most of the things you need to do are already written for you, you will still need to add some configuration for each implementation.
 
@@ -181,7 +181,7 @@ class User
 
 For the last step you need to add your file to your form.
 
-* Use `Backend\Form\Type\ImageType` as the form type
+* Use `Common\Form\ImageType` as the form type
 * Set the fully qualified class name (FQCN) of your value object in the option `image_class` (tip: you can use `MyImage::class` for that)
 
 #### Example
@@ -191,7 +191,7 @@ For the last step you need to add your file to your form.
 
 namespace Backend\Modules\Users\Form;
 
-use Backend\Form\Type\ImageType;
+use Common\Form\ImageType;
 use Backend\Modules\Users\ValueObject\Avatar;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/Common/Form/CollectionType.php
+++ b/src/Common/Form/CollectionType.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Backend\Form\Type;
+namespace Common\Form;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType as SymfonyCollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Backend\Form\Type;
+namespace Common\Form;
 
 use Common\Doctrine\ValueObject\AbstractFile;
 use stdClass;

--- a/src/Common/Form/ImageType.php
+++ b/src/Common/Form/ImageType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Backend\Form\Type;
+namespace Common\Form;
 
 use Common\Doctrine\ValueObject\AbstractImage;
 use stdClass;

--- a/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
@@ -37,3 +37,29 @@
     {% if form.parent %}</span>{% else %}</div>{% endif %}
   {%- endif %}
 {%- endblock form_errors %}
+
+{% block fork_file_widget %}
+  {% spaceless %}
+    <div class="form-group">
+      {{ form_widget(form.file) }}
+      {% if help_text_message %}
+        <div class="help-text">{{ help_text_message|trans|format(help_text_argument) }}</div>
+      {% endif %}
+      {{ form_errors(form.file) }}
+    </div>
+    {% set show_preview = show_preview and data is not null and data.fileName is not empty %}
+    {% if show_preview or show_remove_file %}
+      <div class="form-group">
+        {% if show_preview and preview_url %}
+          <a href="{{ preview_url }}" class="btn btn-xs btn-default" target="_blank">
+            <i class="fa fa-eye"></i>
+            {{ preview_label|trans|ucfirst }}
+          </a>
+        {% endif %}
+        {% if show_remove_file %}
+          {{ form_widget(form.remove) }}
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock %}

--- a/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
@@ -38,6 +38,29 @@
   {%- endif %}
 {%- endblock form_errors %}
 
+{% block fork_image_widget %}
+  {% spaceless %}
+    <div class="form-group">
+      {{ form_widget(form.file) }}
+      {% if help_text_message %}
+        <div class="help-text">{{ help_text_message|trans|format(help_text_argument) }}</div>
+      {% endif %}
+      {{ form_errors(form.file) }}
+    </div>
+    {% set show_preview = show_preview and data is not null and data.fileName is not empty %}
+    {% if show_preview or show_remove_image %}
+      <div class="form-group">
+        {% if show_preview and preview_url %}
+          <img class="{% if preview_class is defined and preview_class is not empty %}{{ preview_class }}{% endif %}" src="{{ preview_url }}">
+        {% endif %}
+        {% if show_remove_image %}
+          {{ form_widget(form.remove) }}
+        {% endif %}
+      </div>
+    {% endif %}
+  {% endspaceless %}
+{% endblock %}
+
 {% block fork_file_widget %}
   {% spaceless %}
     <div class="form-group">

--- a/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Core/Layout/Templates/FormLayout.html.twig
@@ -86,3 +86,51 @@
     {% endif %}
   {% endspaceless %}
 {% endblock %}
+
+{% block bootstrap_collection_row %}
+  {% spaceless %}
+    {% if prototype is defined %}
+      {% set prototype_vars = {} %}
+      {% if style is defined %}
+        {% set prototype_vars = prototype_vars|merge({'style': style}) %}
+      {% endif %}
+      {% set prototype_html = form_widget(prototype, prototype_vars) %}
+      {% if form.vars.allow_delete %}
+        {% set prototype_html = prototype_html ~ '<div class="btn-toolbar"><div class="btn-group pull-right"><a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="__id__">' ~ form.vars.delete_button_text|trans({}, translation_domain)|raw ~ '</a></div></div>' %}
+      {% endif %}
+
+      {% set attr = attr|merge({'data-prototype': prototype_html }) %}
+      {% set attr = attr|merge({'data-prototype-name': prototype_name }) %}
+    {% endif %}
+    <div {{ block('widget_container_attributes') }}>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          {{ form_label(form) }}
+        </div>
+        <ul class="list-group js-collection">
+          {% for field in form %}
+            <li class="list-group-item">
+              {{ form_widget(field) }}
+              {{ form_errors(field) }}
+              {% if form.vars.allow_delete %}
+                <div class="btn-toolbar">
+                  <div class="btn-group pull-right">
+                    <a href="#" class="btn btn-danger btn-sm" data-removefield="collection" data-field="{{ field.vars.id }}">{{ form.vars.delete_button_text|trans({}, translation_domain)|raw }}</a>
+                  </div>
+                </div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="panel-footer clearfix">
+          {% if form.vars.allow_add %}
+            <div class="btn-group pull-right">
+              <a href="#" class="btn btn-success btn-sm" data-addfield="collection" data-collection="{{ form.vars.id }}" data-prototype-name="{{ prototype_name }}">{{ form.vars.add_button_text|trans({}, translation_domain)|raw }}</a>
+            </div>
+          {% endif %}
+          {{ form_errors(form) }}
+        </div>
+      </div>
+    </div>
+  {% endspaceless %}
+{% endblock bootstrap_collection_row %}


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

Moves the ImageType, FileType, and CollectionType to the common namespace because we can just copy over the form templates since the frontend is now also bootstrap


