### PR TITLE
Fix profile settings missing in toArray

### DIFF
--- a/src/Frontend/Modules/Profiles/Engine/Profile.php
+++ b/src/Frontend/Modules/Profiles/Engine/Profile.php
@@ -383,7 +383,7 @@ class Profile
         $return['registered_on'] = $this->getRegisteredOn();
 
         // add settings
-        foreach ($this->settings as $key => $value) {
+        foreach ($this->getSettings() as $key => $value) {
             $return['settings'][$key] = $value;
         }
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

If you hadn't loaded the profile settings manually before calling the toArray they where empty

