### PR TITLE
We can't be sure the json field isn't null

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -863,7 +863,7 @@ class Edit extends BackendBaseActionEdit
         $this->template->assign('deleteForm', $deleteForm->createView());
     }
 
-    private function getHiddenJsonField(string $name, ?string $json = null): SpoonFormHidden
+    private function getHiddenJsonField(string $name, ?string $json): SpoonFormHidden
     {
         return new class($name, htmlspecialchars($json)) extends SpoonFormHidden {
             public function getValue($allowHTML = null)

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -863,7 +863,7 @@ class Edit extends BackendBaseActionEdit
         $this->template->assign('deleteForm', $deleteForm->createView());
     }
 
-    private function getHiddenJsonField(string $name, string $json): SpoonFormHidden
+    private function getHiddenJsonField(string $name, ?string $json = null): SpoonFormHidden
     {
         return new class($name, htmlspecialchars($json)) extends SpoonFormHidden {
             public function getValue($allowHTML = null)


### PR DESCRIPTION
@ohvitorino found out the hard way, pages have `NULL` by default in extra_data, the code wasn't prepared for this. 