### PR TITLE
Fix clear cache command.

### DIFF
--- a/src/Console/Core/CacheClearCommand.php
+++ b/src/Console/Core/CacheClearCommand.php
@@ -51,7 +51,7 @@ class CacheClearCommand extends Command
         $fullPath = realpath(__DIR__ . '/../../..' . $path);
 
         // I use a rm-command because this is much faster then using the finder/filesystem-component
-        $command = 'rm -f `find %1$s ! -name ".gitignore" -type f ! -path *.svn/* -type f`';
+        $command = 'find %1$s ! -name ".gitignore" -type f ! -path *.svn/* -type f | xargs rm -f';
         shell_exec(sprintf($command, $fullPath));
         $io->comment(sprintf('Removed %1$s', $name));
     }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

During the cache clear process several Fork cache files are removed (CSS, Javascript, etc) from their folders. This is being done by using the unix user command `rm`, but this command, as many other on unix, have a limited amount of arguments they can receive as an argument resulting in the following error message: `sh: /bin/rm: Argument list too long`, and also not all files being removed.

This PR suggests the usage of `xargs` together with `find` and `rm` to remove all cache files.