### PR TITLE
Fix required indication missing in form builder

### DIFF
--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Field.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Field.html.twig
@@ -1,3 +1,5 @@
+{% import "/Layout/Templates/macros.html.twig" as macro %}
+
 <div id="fieldHolder-{{ id }}" class="form-group field jsField">
   <div class="row">
     {% if plaintext %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

fixes #2130 

## Pull request description

We tried to show a macro that wasn't loaded so the * was not shown

