### PR TITLE
Fixes installer when you want mailmotor + example data

### DIFF
--- a/src/Backend/Modules/Pages/Installer/Installer.php
+++ b/src/Backend/Modules/Pages/Installer/Installer.php
@@ -93,7 +93,7 @@ class Installer extends ModuleInstaller
         if (in_array('Faq', $this->getVariable('selected_modules'))) {
             $extras['faq_block'] = $this->insertExtra('Faq', ModuleExtraType::block(), 'Faq');
         }
-        if (in_array('Faq', $this->getVariable('selected_modules'))) {
+        if (in_array('Mailmotor', $this->getVariable('selected_modules'))) {
             $extras['mailmotor_subscribe'] = $this->insertExtra(
                 'Mailmotor',
                 ModuleExtraType::block(),


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

> When installing fork cms 5 + mailmotor module + example data, the installer crashes because of a module typo

