### PR TITLE
Correctly assign the languages to our arrays

### DIFF
--- a/src/Backend/Modules/Settings/Actions/Index.php
+++ b/src/Backend/Modules/Settings/Actions/Index.php
@@ -197,19 +197,17 @@ class Index extends BackendBaseActionIndex
             }
 
             // add to the list
-            $activeLanguages = [
-                [
-                    'label' => $label,
-                    'value' => $abbreviation,
-                    'attributes' => $activeAttributes,
-                    'variables' => ['default' => $defaultLanguage],
-                ],
-                $redirectLanguages[] = [
-                    'label' => $label,
-                    'value' => $abbreviation,
-                    'attributes' => $redirectAttributes,
-                    'variables' => ['default' => $defaultLanguage],
-                ],
+            $activeLanguages[] = [
+                'label' => $label,
+                'value' => $abbreviation,
+                'attributes' => $activeAttributes,
+                'variables' => ['default' => $defaultLanguage],
+            ];
+            $redirectLanguages[] = [
+                'label' => $label,
+                'value' => $abbreviation,
+                'attributes' => $redirectAttributes,
+                'variables' => ['default' => $defaultLanguage],
             ];
         }
 


### PR DESCRIPTION
Something went wrong in @carakas's PR  https://github.com/forkcms/forkcms/pull/2001 which caused only the last language to be assigned to the active languages array. Due to this, saving settings would cause pretty catastrophic disabling of languages.