### PR TITLE
Switch the upload and download icons to match the import button

### DIFF
--- a/src/Backend/Modules/Locale/Layout/Templates/Import.html.twig
+++ b/src/Backend/Modules/Locale/Layout/Templates/Import.html.twig
@@ -30,7 +30,7 @@
       <div class="btn-toolbar">
         <div class="btn-group pull-right" role="group">
           <button id="importButton" type="submit" name="add" class="btn btn-primary">
-            <span class="fa fa-download"></span>{{ 'lbl.Import'|trans|ucfirst }}
+            <span class="fa fa-upload"></span>{{ 'lbl.Import'|trans|ucfirst }}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The import button in the locale has a download icon (http://demo.fork-cms.com/private/en/locale/import?token=ri1dar0dm&type%5B0%5D=lbl&language%5B0%5D=en) but the one on the index has an upload icon. I think the download icon (while not in name) makes more sense than the upload icon so I changed it to match.

