### PR TITLE
Specifically state the widget action should be 'Location'

### DIFF
--- a/src/Backend/Modules/Location/Engine/Model.php
+++ b/src/Backend/Modules/Location/Engine/Model.php
@@ -217,6 +217,7 @@ class Model
         // insert extra
         $item['extra_id'] = BackendModel::insertExtra(
             ModuleExtraType::widget(),
+            'Location',
             'Location'
         );
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

A previous commit ( https://github.com/forkcms/forkcms/commit/8567d02acaa0acf975e5a5f114755420deba0403 ) caused the action of an extra type to be set to `null` if it wasn't specified. Well in the locations module it was still assumed it would take over the module's value so it received `null` as an action, causing it to be defaulted to `Index` which doesn't exist.

