### PR TITLE
Correctly indent comments

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
@@ -56,7 +56,7 @@ class Unsubscribe extends FrontendBaseBlock
         try {
             // The command bus will handle the unsubscription
             $this->get('command_bus')->handle($unsubscription);
-        // fallback for when no mail-engine is chosen in the Backend
+            // fallback for when no mail-engine is chosen in the Backend
         } catch (NotImplementedException $e) {
             $this->get('event_dispatcher')->dispatch(
                 NotImplementedUnsubscribedEvent::EVENT_NAME,

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/SubscriptionHandler.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/SubscriptionHandler.php
@@ -58,7 +58,7 @@ final class SubscriptionHandler
                     $interests[$checkedInterestId] = true;
                 }
             }
-        // Fallback for when no mail-engine is chosen in the Backend
+            // Fallback for when no mail-engine is chosen in the Backend
         } catch (NotImplementedException $e) {
         }
 

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
@@ -110,7 +110,7 @@ class SubscribeType extends AbstractType
                     $interests[$categoryChildTitle] = $categoryChildId;
                 }
             }
-        // Fallback for when no mail-engine is chosen in the Backend
+            // Fallback for when no mail-engine is chosen in the Backend
         } catch (NotImplementedException $e) {
         }
 

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
@@ -41,7 +41,7 @@ class EmailUnsubscriptionValidator extends ConstraintValidator
             } elseif ($this->subscriber->isUnsubscribed($value)) {
                 $this->context->buildViolation($constraint->alreadyUnsubscribedMessage)->addViolation();
             }
-        // fallback for when no mail-engine is chosen in the Backend
+            // fallback for when no mail-engine is chosen in the Backend
         } catch (NotImplementedException $e) {
             // do nothing
         }


### PR DESCRIPTION
## Type
- Non Critical bugfix

## Pull request description
Some comments had the wrong indentation causing the style-ci to fail

