### PR TITLE
getGroupsForDropdown expects an integer, we've sent null

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/Import.php
+++ b/src/Backend/Modules/Profiles/Actions/Import.php
@@ -21,11 +21,6 @@ use Backend\Core\Engine\Csv;
  */
 class Import extends BackendBaseActionAdd
 {
-    /**
-     * @var int
-     */
-    private $id;
-
     public function execute(): void
     {
         parent::execute();
@@ -38,7 +33,7 @@ class Import extends BackendBaseActionAdd
     private function loadForm(): void
     {
         // get group values for dropdown
-        $ddmValues = BackendProfilesModel::getGroupsForDropDown($this->id);
+        $ddmValues = BackendProfilesModel::getGroupsForDropDown(0);
 
         // create form and elements
         $this->form = new BackendForm('import');


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

There was a private variable `$id` which wasn't used in any way so it stayed null. We then used that variable to request the profile groups for a dropdown which expects an integer to be sent, PHP 7 does not like this. Therefor i've just sent `0` to the method so it works as it used to but the ideal solution would be to rewrite the method so it doesn't required a profile id.

