### PR TITLE
Locale fixes

### DIFF
--- a/src/Backend/Modules/Locale/Ajax/SaveTranslation.php
+++ b/src/Backend/Modules/Locale/Ajax/SaveTranslation.php
@@ -45,7 +45,7 @@ class SaveTranslation extends BackendBaseAJAXAction
         }
         $name = $this->getRequest()->request->get('name', '');
         $type = $this->getRequest()->request->get('type');
-        if (!in_array($type, BackendModel::get('database')->getEnumValues('locale', 'type'))) {
+        if (!in_array($type, BackendModel::get('database')->getColumn('SELECT type FROM locale GROUP BY type'))) {
             $type = '';
         }
         $application = $this->getRequest()->request->get('application');

--- a/src/Backend/Modules/Locale/Engine/Model.php
+++ b/src/Backend/Modules/Locale/Engine/Model.php
@@ -193,7 +193,7 @@ class Model
         string $module,
         string $language,
         string $application
-    ): bool {
+    ): int {
         return BackendModel::getContainer()->get('database')->getVar(
             'SELECT l.id
              FROM locale AS l


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

fixes #2186

## Pull request description

The `type` field of the locale is no longer an ENUM in the database so `getEnumValues` doesn't work anymore. I've decided to replace it with a query that basically does the same but ideally it should be rewritten as a ValueObject that's used throughout Fork.

In addition to that, there was an incorrect return type in `getByName` which caused the id to always be `1`
