### PR TITLE
'Invalid value' when retrieving SEO value objects from database

### DIFF
--- a/src/Common/Doctrine/Type/SEOFollowType.php
+++ b/src/Common/Doctrine/Type/SEOFollowType.php
@@ -16,13 +16,21 @@ final class SEOFollowType extends StringType
      *
      * @return string
      */
-    public function convertToDatabaseValue($seoFollow, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($seoFollow, AbstractPlatform $platform): ?string
     {
+        if ($seoFollow === null) {
+            return null;
+        }
+
         return (string) $seoFollow;
     }
 
-    public function convertToPHPValue($seoFollow, AbstractPlatform $platform): SEOFollow
+    public function convertToPHPValue($seoFollow, AbstractPlatform $platform): ?SEOFollow
     {
+        if ($seoFollow === null) {
+            return null;
+        }
+
         return SEOFollow::fromString($seoFollow);
     }
 

--- a/src/Common/Doctrine/Type/SEOIndexType.php
+++ b/src/Common/Doctrine/Type/SEOIndexType.php
@@ -16,13 +16,21 @@ final class SEOIndexType extends StringType
      *
      * @return string
      */
-    public function convertToDatabaseValue($seoIndex, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($seoIndex, AbstractPlatform $platform): ?string
     {
+        if ($seoIndex === null) {
+            return null;
+        }
+
         return (string) $seoIndex;
     }
 
-    public function convertToPHPValue($seoIndex, AbstractPlatform $platform): SEOIndex
+    public function convertToPHPValue($seoIndex, AbstractPlatform $platform): ?SEOIndex
     {
+        if ($seoIndex === null) {
+            return null;
+        }
+
         return SEOIndex::fromString($seoIndex);
     }
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

When creating Meta objects, if the user doesn't provide values for SEOIndex and SEOFollow, Fork persists these values as null values. Which is ok, the problem is when these meta objects need to be read from the database and converted to proper Value Objects. This conversion throws an `InvalidArgumentException` with the message 'Invalid value'. So we better just avoid the conversion and return immediately `null` so that Fork can override these values with the page default ones. 
