### PR TITLE
PHP version check added

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@ chdir(__DIR__);
 
 // PHP version check
 if (version_compare(phpversion(), '7.1.0', '<')) {
-    echo 'To be able to run Fork CMS you need ad least PHP 7.1.0';
+    echo 'To be able to run Fork CMS you need at least PHP 7.1.0';
 }
 
 // vendors not installed

--- a/index.php
+++ b/index.php
@@ -10,6 +10,11 @@
 // CLI/Nginx/Cron: We need to set the "current working directory" to this folder
 chdir(__DIR__);
 
+// PHP version check
+if (version_compare(phpversion(), '7.1.0', '<')) {
+    echo 'To be able to run Fork CMS you need ad least PHP 7.1.0';
+}
+
 // vendors not installed
 if (!is_dir(__DIR__ . '/vendor')) {
     echo 'Your install is missing some dependencies. If you have composer


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

> When installing Fork CMS using `composer create-project forkcms/forkcms .` on the command line. The PHP version there could be different then in your environment. This could happen unaware. Currently a white page is being shown, so you have totally no clue what's going on. That's why this PR gives you at least a decent warning.
