### PR TITLE
Upgrade_5 guide: Fixed wrong namespace for "DataGridDatabase"

### DIFF
--- a/UPGRADE_5.0.md
+++ b/UPGRADE_5.0.md
@@ -416,7 +416,7 @@ We did add helper getters so you can keep doing `$this->getAction()` and `$this-
 
 | Old classname                                 | New classname                                   |
 |-----------------------------------------------|-------------------------------------------------|
-| `\Backend\Core\Engine\Model\DataGridDB`       | `\Backend\Core\Engine\Model\DataGridDatabase`   |
+| `\Backend\Core\Engine\Model\DataGridDB`       | `\Backend\Core\Engine\DataGridDatabase`   |
 
 ## Bye bye enums
 


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

> Fixed wrong namespace for "DataGridDatabse" in the "UPGRADE_5.md" guide.

