### PR TITLE
Add missing entries for gulp and npm/yarn to htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -56,6 +56,8 @@ deny from env=stayout
 	RewriteRule .*\.gitignore - [F]
 	RewriteRule \.editorconfig - [F]
 	RewriteRule \.travis.yml - [F]
+	RewriteRule gulpfile\.js - [F]
+	RewriteRule package\.json - [F]
 	RewriteRule bower\.json - [F]
 	RewriteRule composer\.json - [F]
 	RewriteRule composer\.lock - [F]


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Make sure the config for gulp and npm/yarn isn't accessible from the browser

