### PR TITLE
Fix https rewrite in htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -74,7 +74,7 @@ deny from env=stayout
 
 	# redirect all trafic to https
 	# Header set Strict-Transport-Security "max-age=31536000; includeSubDomains" env=HTTPS
-	# RewriteCond %{HTTPS} != on
+	# RewriteCond %{HTTPS} !=on
 	# RewriteCond %{HTTP_HOST} !.*\.dev [NC]
 	# RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description

In the placeholder https rewrite config in htaccess, the space should not be there.
With space => you get a 500. Without space => https rewrite works

Apache ¯\_(ツ)_/¯

