### PR TITLE
FormLayout: added "help text" to a form text field

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -350,11 +350,7 @@
     </div>
     <div class="panel-body">
       {{- form_widget(form) -}}
-
-      {% for attributeName, attributeValue in attr %}
-        {% if attributeName == 'help' %}
-          <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
-      {% endfor %}
+      {{- block('help_text') -}}
     </div>
     {% if (not compound or force_error|default(false)) and not valid %}
       <div class="panel-footer">
@@ -378,4 +374,11 @@
       </div>
     {% endif %}
   </div>
+{% endblock %}
+
+{% block help_text %}
+  {% for attributeName, attributeValue in attr %}
+    {% if attributeName == 'help' %}
+      <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
+  {% endfor %}
 {% endblock %}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -385,8 +385,4 @@
   {% for attributeName, attributeValue in attr %}
     {% if attributeName == 'help' %}<span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
   {% endfor %}
-
-  {% if help is defined %}
-    <span class="help-block">{{ help }}</span>
-  {% endif %}
 {% endblock %}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -2,8 +2,8 @@
 {% use 'bootstrap_3_layout.html.twig' with form_widget_simple as base_form_widget_simple %}
 
 {% block form_widget_simple %}
-  {{- block('base_form_widget_simple') -}}
-  {{- block('help') -}}
+  {{ block('base_form_widget_simple') }}
+  {{ block('help') }}
 {% endblock %}
 
 {% block form_label %}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -1,4 +1,10 @@
 {% extends 'bootstrap_3_layout.html.twig' %}
+{% use 'bootstrap_3_layout.html.twig' with form_widget_simple as base_form_widget_simple %}
+
+{% block form_widget_simple %}
+  {{- block('base_form_widget_simple') -}}
+  {{- block('help') -}}
+{% endblock %}
 
 {% block form_label %}
   {% if 'checkbox' not in block_prefixes or widget_checkbox_label in ['label', 'both'] %}
@@ -350,7 +356,6 @@
     </div>
     <div class="panel-body">
       {{- form_widget(form) -}}
-      {{- block('help_text') -}}
     </div>
     {% if (not compound or force_error|default(false)) and not valid %}
       <div class="panel-footer">
@@ -376,7 +381,7 @@
   </div>
 {% endblock %}
 
-{% block help_text %}
+{% block help %}
   {% for attributeName, attributeValue in attr %}
     {% if attributeName == 'help' %}
       <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -383,8 +383,7 @@
 
 {% block help %}
   {% for attributeName, attributeValue in attr %}
-    {% if attributeName == 'help' %}
-      <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
+    {% if attributeName == 'help' %}<span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
   {% endfor %}
 
   {% if help is defined %}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -350,6 +350,11 @@
     </div>
     <div class="panel-body">
       {{- form_widget(form) -}}
+
+      {% for attributeName, attributeValue in attr %}
+        {% if attributeName == 'help' %}
+          <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
+      {% endfor %}
     </div>
     {% if (not compound or force_error|default(false)) and not valid %}
       <div class="panel-footer">

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -386,4 +386,8 @@
     {% if attributeName == 'help' %}
       <span class="help-block">{{ attributeValue|trans }}</span>{% endif %}
   {% endfor %}
+
+  {% if help is defined %}
+    <span class="help-block">{{ help }}</span>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Type

- Feature

## Pull request description

> Allows you to add "help text" to a form text field.

Adding the attribute help, will now create a ".help-block" class span just below the text field.
```
$builder->add(
    'name',
    TextType::class,
    [
        'label' => 'lbl.Naming',
        'attr' => [
            'help' => 'msg.NamingHelp',
        ],
    ]
)
```
Before:
<img width="776" alt="schermafbeelding 2017-08-24 om 11 10 27" src="https://user-images.githubusercontent.com/588616/29658906-e1d6c440-88bc-11e7-86cf-8839fe0ef1d9.png">

After:
<img width="783" alt="schermafbeelding 2017-08-24 om 11 07 48" src="https://user-images.githubusercontent.com/588616/29658873-c43ed22e-88bc-11e7-8dc2-5cf32a2e7170.png">

Updated: You can also use the following in your template:
```
{{ form_widget(form.name, {'attr.help': 'msg.NamingHelp'|trans}) }}
```
> Which will do the same thing.