### PR TITLE
Fix default value for hidden radio button

### DIFF
--- a/src/Backend/Modules/Faq/Actions/Add.php
+++ b/src/Backend/Modules/Faq/Actions/Add.php
@@ -51,7 +51,7 @@ class Add extends BackendBaseActionAdd
         // create elements
         $this->form->addText('title', null, null, 'form-control title', 'form-control danger title');
         $this->form->addEditor('answer');
-        $this->form->addRadiobutton('hidden', $rbtHiddenValues, false);
+        $this->form->addRadiobutton('hidden', $rbtHiddenValues, 0);
         $this->form->addDropdown('category_id', $categories);
         $this->form->addText('tags', null, null, 'form-control js-tags-input', 'form-control danger js-tags-input');
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

The default value was `false` but the actual value is `0`

