### PR TITLE
Fix sorting FAQ Categories

### DIFF
--- a/src/Backend/Modules/Faq/Engine/Model.php
+++ b/src/Backend/Modules/Faq/Engine/Model.php
@@ -436,6 +436,7 @@ class Model
 
     public static function updateCategory(array $item): void
     {
+        unset($item['url']);
         // update faq category
         BackendModel::getContainer()->get('database')->update('faq_categories', $item, 'id = ?', [$item['id']]);
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

Sorting FAQ Categories gave a 500 error because the the url field was passed on to the query

