### PR TITLE
Fix type errors when trying to get the uploaded file when there is non

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -123,12 +123,17 @@ abstract class AbstractFile
         return $this->file;
     }
 
+    final public function hasFile(): bool
+    {
+        return $this->file instanceof UploadedFile;
+    }
+
     /**
      * This function should be called for the life cycle events PrePersist() and PreUpdate()
      */
     public function prepareToUpload(): void
     {
-        if ($this->getFile() === null) {
+        if (!$this->hasFile()) {
             return;
         }
 
@@ -150,7 +155,7 @@ abstract class AbstractFile
             $this->removeOldFile();
         }
 
-        if ($this->getFile() === null) {
+        if (!$this->hasFile()) {
             return;
         }
 

--- a/src/Common/Doctrine/ValueObject/AbstractFile.php
+++ b/src/Common/Doctrine/ValueObject/AbstractFile.php
@@ -118,7 +118,7 @@ abstract class AbstractFile
         return $file;
     }
 
-    public function getFile(): UploadedFile
+    public function getFile(): ?UploadedFile
     {
         return $this->file;
     }

--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -79,10 +79,13 @@ abstract class AbstractImage extends AbstractFile
      */
     public function upload(): void
     {
-        $file = $this->getFile();
         parent::upload();
 
-        if (static::GENERATE_THUMBNAILS && $file instanceof UploadedFile) {
+        if (!$this->hasFile()) {
+            return;
+        }
+
+        if (static::GENERATE_THUMBNAILS) {
             Model::generateThumbnails(
                 FRONTEND_FILES_PATH . '/' . $this->getTrimmedUploadDir(),
                 $this->getAbsolutePath('source')


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
Sometimes when you didn't upload a file you can get a type error when we try to get the uploaded file when there is non, this pr fixes that

