### PR TITLE
Fix formbuilder data action

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Data.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Data.php
@@ -221,7 +221,8 @@ class Data extends BackendBaseActionIndex
             }
         }
 
-        $this->form = new BackendForm('filter', BackendModel::createUrlForAction() . '&amp;id=' . $this->id, 'get');
+        $this->form = new BackendForm('filter', BackendModel::createUrlForAction(), 'get');
+        $this->form->addText('id', $this->id, 255, 'hidden');
         $this->form->addDate('start_date', $startDate);
         $this->form->addDate('end_date', $endDate);
 

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Data.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Data.html.twig
@@ -20,6 +20,7 @@
       {% form filter %}
       <div class="panel panel-default">
         <div class="panel-body">
+          {% form_field id %}
           <div class="row">
             <div class="col-md-4">
               <div class="form-group">

--- a/src/Common/Core/Form.php
+++ b/src/Common/Core/Form.php
@@ -133,7 +133,7 @@ class Form extends \SpoonForm
         $classError = null
     ): FormDate {
         $name = (string) $name;
-        $value = ($value !== null) ? (($value !== '') ? (int) $value : '') : null;
+        $value = ($value === null || $value === '') ? null : (int) $value;
         $type = SpoonFilter::getValue($type, ['from', 'till', 'range'], 'none');
         $date = ($date !== null) ? (int) $date : null;
         $date2 = ($date2 !== null) ? (int) $date2 : null;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The default value for a date could be an empty string, this resulted in errors

Apart from that updating the filter resulted in a redirect to the index page because the id was lost

