### PR TITLE
Fix error when saving form builder fields

### DIFF
--- a/src/Backend/Core/Engine/Form.php
+++ b/src/Backend/Core/Engine/Form.php
@@ -14,6 +14,7 @@ use Backend\Core\Language\Language as BackendLanguage;
 use SpoonFormButton;
 use SpoonFormFile;
 use SpoonFormTextarea;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * This is our extended version of \SpoonForm
@@ -67,6 +68,10 @@ class Form extends \Common\Core\Form
      */
     public function addEditor($name, $value = null, $class = null, $classError = null, $HTML = true): SpoonFormTextarea
     {
+        if (!$this->header instanceof Header) {
+            throw new ServiceNotFoundException('header');
+        }
+
         $name = (string) $name;
         $value = ($value !== null) ? (string) $value : null;
         $class = 'inputEditor ' . (string) $class;

--- a/src/Backend/Modules/FormBuilder/Engine/Helper.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Helper.php
@@ -16,8 +16,6 @@ use Backend\Core\Engine\TwigTemplate as BackendTemplate;
 /**
  * Helper class for the form_builder module.
  *
- * @todo this class should be in helper.php like the other modules do
- *
  * Dieter Vanden Eynde <dieter.vandeneynde@netlash.com>
  */
 class Helper

--- a/src/Common/Core/Form.php
+++ b/src/Common/Core/Form.php
@@ -58,7 +58,9 @@ class Form extends \SpoonForm
         bool $useToken = true
     ) {
         $this->url = Model::getContainer()->get('url');
-        $this->header = Model::getContainer()->get('header');
+        if (Model::getContainer()->has('header')) {
+            $this->header = Model::getContainer()->get('header');
+        }
 
         $action = ($action === null) ? rtrim(Model::getRequest()->getRequestUri(), '/') : (string) $action;
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

When adding new form fields with formbuilder you got an error while the field was actually added.
The header service is only used for editor fields but it is not available in ajax calls, the form constructor didn't take this into account and we use a form to render the fields

