### PR TITLE
Multiple RSS Fixes

### DIFF
--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -28,10 +28,11 @@ class Model extends \Common\Core\Model
      *
      * @param string $url The URL to append the parameters too.
      * @param array $parameters The parameters as key-value-pairs.
+     * @param string $separator Defaults to &
      *
      * @return string
      */
-    public static function addUrlParameters(string $url, array $parameters): string
+    public static function addUrlParameters(string $url, array $parameters, string $separator = '&'): string
     {
         if (empty($parameters)) {
             return $url;
@@ -45,9 +46,9 @@ class Model extends \Common\Core\Model
         }
 
         // build query string
-        $queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
+        $queryString = http_build_query($parameters, null, $separator, PHP_QUERY_RFC3986);
         if (mb_strpos($url, '?') !== false) {
-            return $url . '&' . $queryString . $hash;
+            return $url . $separator . $queryString . $hash;
         }
 
         return $url . '?' . $queryString . $hash;

--- a/src/Frontend/Core/Engine/Rss.php
+++ b/src/Frontend/Core/Engine/Rss.php
@@ -25,9 +25,14 @@ class Rss extends \SpoonFeedRSS
         // call the parent
         parent::__construct(
             $title,
-            Model::addUrlParameters(
-                $link,
-                ['utm_source' => 'feed', 'utm_medium' => 'rss', 'utm_campaign' => CommonUri::getUrl($title)]
+            str_replace(
+                '&',
+                '&amp;',
+                Model::addUrlParameters(
+                    $link,
+                    ['utm_source' => 'feed', 'utm_medium' => 'rss', 'utm_campaign' => CommonUri::getUrl($title)],
+                    '&amp;'
+                )
             ),
             $description,
             $items
@@ -71,7 +76,8 @@ class Rss extends \SpoonFeedRSS
                 'utm_source' => 'feed',
                 'utm_medium' => 'rss',
                 'utm_campaign' => CommonUri::getUrl($this->getTitle()),
-            ]
+            ],
+            '&amp;'
         );
 
         // call the parent

--- a/src/Frontend/Core/Engine/RssItem.php
+++ b/src/Frontend/Core/Engine/RssItem.php
@@ -33,7 +33,7 @@ class RssItem extends \SpoonFeedRSSItem
         $this->utm['utm_campaign'] = CommonUri::getUrl($title);
 
         // call parent
-        parent::__construct($title, Model::addUrlParameters($link, $this->utm), $content);
+        parent::__construct($title, Model::addUrlParameters($link, $this->utm, '&amp;'), $content);
 
         // set some properties
         $this->setGuid($link, true);
@@ -72,7 +72,7 @@ class RssItem extends \SpoonFeedRSSItem
         // loop old links
         foreach ((array) $matches[1] as $i => $link) {
             $searchLinks[] = $matches[0][$i];
-            $replaceLinks[] = 'href="' . Model::addUrlParameters($link, $this->utm) . '"';
+            $replaceLinks[] = 'href="' . Model::addUrlParameters($link, $this->utm, '&amp;') . '"';
         }
 
         // replace

--- a/src/Frontend/Core/Engine/RssItem.php
+++ b/src/Frontend/Core/Engine/RssItem.php
@@ -84,13 +84,9 @@ class RssItem extends \SpoonFeedRSSItem
         // remove special chars
         $author = (string) \SpoonFilter::htmlspecialcharsDecode($author);
 
-        // add fake-emailaddress
+        // add fake emailaddress
         if (!filter_var($author, FILTER_VALIDATE_EMAIL)) {
             $author = CommonUri::getUrl($author) . '@example.com (' . $author . ')';
-        }
-        // add fake email address
-        if (!filter_var($author, FILTER_VALIDATE_EMAIL)) {
-            $author = \SpoonFilter::urlise($author) . '@example.com (' . $author . ')';
         }
 
         // set author

--- a/src/Frontend/Modules/Blog/Actions/ArticleCommentsRss.php
+++ b/src/Frontend/Modules/Blog/Actions/ArticleCommentsRss.php
@@ -82,7 +82,7 @@ class ArticleCommentsRss extends FrontendBaseBlock
             $rssItem = new FrontendRSSItem($title, $link, $description);
 
             $rssItem->setPublicationDate($item['created_on']);
-            $rssItem->setAuthor($item['author']);
+            $rssItem->setAuthor(empty($item['email']) ? $item['author'] : $item['email']);
 
             $rss->addItem($rssItem);
         }

--- a/src/Frontend/Modules/Blog/Actions/ArticleCommentsRss.php
+++ b/src/Frontend/Modules/Blog/Actions/ArticleCommentsRss.php
@@ -68,7 +68,7 @@ class ArticleCommentsRss extends FrontendBaseBlock
         $link = SITE_URL . FrontendNavigation::getUrlForBlock('Blog', 'ArticleCommentsRss') .
                 '/' . $this->record['url'];
         $detailLink = SITE_URL . FrontendNavigation::getUrlForBlock('Blog', 'Detail');
-        $description = null;
+        $description = '';
 
         // create new rss instance
         $rss = new FrontendRSS($title, $link, $description);

--- a/src/Frontend/Modules/Blog/Actions/CommentsRss.php
+++ b/src/Frontend/Modules/Blog/Actions/CommentsRss.php
@@ -45,7 +45,7 @@ class CommentsRss extends FrontendBaseBlock
         $title = \SpoonFilter::ucfirst(FL::msg('BlogAllComments'));
         $link = SITE_URL . FrontendNavigation::getUrlForBlock('Blog');
         $detailLink = SITE_URL . FrontendNavigation::getUrlForBlock('Blog', 'Detail');
-        $description = null;
+        $description = '';
 
         $rss = new FrontendRSS($title, $link, $description);
 

--- a/src/Frontend/Modules/Blog/Actions/CommentsRss.php
+++ b/src/Frontend/Modules/Blog/Actions/CommentsRss.php
@@ -58,7 +58,7 @@ class CommentsRss extends FrontendBaseBlock
             $rssItem = new FrontendRSSItem($title, $link, $description);
 
             $rssItem->setPublicationDate($item['created_on']);
-            $rssItem->setAuthor($item['author']);
+            $rssItem->setAuthor(empty($item['email']) ? $item['author'] : $item['email']);
 
             $rss->addItem($rssItem);
         }

--- a/src/Frontend/Modules/Blog/Actions/Rss.php
+++ b/src/Frontend/Modules/Blog/Actions/Rss.php
@@ -112,7 +112,7 @@ class Rss extends FrontendBaseBlock
             // set item properties
             $rssItem->setPublicationDate($item['publish_on']);
             $rssItem->addCategory($item['category_title']);
-            $rssItem->setAuthor(FrontendUser::getBackendUser($item['user_id'])->getSetting('nickname'));
+            $rssItem->setAuthor(FrontendUser::getBackendUser($item['user_id'])->getEmail());
 
             // add item
             $rss->addItem($rssItem);


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description
The author tag in the rss feeds always contained @example.com since we didn't pass a valid email but the username instead
Rss comment actions were broken because we passed null when we needed to pass a string
Fixed invalid rss because the & should be &amp;

