### PR TITLE
The label is already inside the media group widget

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -339,6 +339,10 @@
   {% endspaceless %}
 {% endblock bootstrap_collection_row %}
 
+{% block media_group_row %}
+  {{ form_widget(form) }}
+{% endblock %}
+
 {% block media_group_widget %}
   {% include "MediaLibrary/Resources/views/FormLayout.html.twig" %}
 {% endblock media_group_widget %}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
When using form_rest or form_row on a media group it was double wrapped
Before:
<img width="968" alt="screen shot 2017-09-13 at 16 10 23" src="https://user-images.githubusercontent.com/3634654/30381981-3e39b18e-989e-11e7-860b-c15261e591c5.png">
After:
<img width="962" alt="screen shot 2017-09-13 at 16 10 36" src="https://user-images.githubusercontent.com/3634654/30381992-43652ed6-989e-11e7-92c6-4c98402716d0.png">

