### PR TITLE
Fix media-group errors not showing up properly

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroupType.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroupType.php
@@ -102,6 +102,7 @@ class MediaGroupType extends AbstractType
             [
                 'label' => Language::lbl('MediaConnected'),
                 'aspect_ratio' => null,
+                'error_bubbling' => false,
             ]
         );
 

--- a/src/Backend/Modules/MediaLibrary/Resources/views/FormLayout.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/FormLayout.html.twig
@@ -80,6 +80,11 @@
             {{ form_row(form.type) }}
           </div>
         </div>
+        {% if not form.vars.valid %}
+          <div class="panel-footer">
+            {{- form_errors(form) -}}
+          </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The media group errors didn't show up properly, this fixes that (tested in combination with #2242 

