### PR TITLE
Throw error when template syntax is faulty

### DIFF
--- a/src/Backend/Modules/Extensions/Actions/EditThemeTemplate.php
+++ b/src/Backend/Modules/Extensions/Actions/EditThemeTemplate.php
@@ -274,7 +274,7 @@ class EditThemeTemplate extends BackendBaseActionEdit
             $table = BackendExtensionsModel::templateSyntaxToArray($syntax);
 
             // validate the syntax
-            if ($table === false) {
+            if (empty($table)) {
                 $this->form->getField('format')->addError(BL::err('InvalidTemplateSyntax'));
             } else {
                 $html = BackendExtensionsModel::buildTemplateHTML($syntax);


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

When editing the template structure for the pages module you could enter faulty data without getting an error.
This was the result of fixing things for fork 5 and was updated in the add but not in the edit action

