### PR TITLE
Unset the linked contentblock when using data for new locale

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
@@ -31,7 +31,7 @@ final class CopyContentBlocksToOtherLocaleHandler
 
                 // Overwrite some variables
                 $dataTransferObject->forOtherLocale(
-                    $id ++,
+                    $id++,
                     $copyContentBlocksToOtherLocale->extraIdMap[$contentBlock->getExtraId()],
                     $copyContentBlocksToOtherLocale->toLocale
                 );

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/Command/CopyContentBlocksToOtherLocaleHandler.php
@@ -30,10 +30,11 @@ final class CopyContentBlocksToOtherLocaleHandler
                 $dataTransferObject = $contentBlock->getDataTransferObject();
 
                 // Overwrite some variables
-                $dataTransferObject->id = $id++;
-                $dataTransferObject->extraId = $copyContentBlocksToOtherLocale->extraIdMap[$contentBlock->getExtraId()];
-                $dataTransferObject->revisionId = null;
-                $dataTransferObject->locale = $copyContentBlocksToOtherLocale->toLocale;
+                $dataTransferObject->forOtherLocale(
+                    $id ++,
+                    $copyContentBlocksToOtherLocale->extraIdMap[$contentBlock->getExtraId()],
+                    $copyContentBlocksToOtherLocale->toLocale
+                );
 
                 $this->contentBlockRepository->add(ContentBlock::fromDataTransferObject($dataTransferObject));
             },

--- a/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/ContentBlockDataTransferObject.php
+++ b/src/Backend/Modules/ContentBlocks/Domain/ContentBlock/ContentBlockDataTransferObject.php
@@ -90,6 +90,15 @@ class ContentBlockDataTransferObject
         $this->revisionId = $contentBlock->getRevisionId();
     }
 
+    public function forOtherLocale(int $id, int $extraId, Locale $locale)
+    {
+        $this->id = $id;
+        $this->contentBlockEntity = null;
+        $this->revisionId = null;
+        $this->extraId = $extraId;
+        $this->locale = $locale;
+    }
+
     public function getContentBlockEntity(): ContentBlock
     {
         return $this->contentBlockEntity;


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues
fixes #2248

## Pull request description

Unsets the related contentblock when copying data over.

