### PR TITLE
Bugfix in Pages: clicking "save draft" deleted the page instead of saving it as draft

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -20,8 +20,8 @@ jsBackend.pages =
         // button to save to draft
         $('#saveAsDraft').on('click', function(e)
         {
-            $('form').append('<input type="hidden" name="status" value="draft" />');
-            $('form').submit();
+            $('form#edit').append('<input type="hidden" name="status" value="draft" />');
+            $('form#edit').submit();
         });
 
         // show / hide the remove from search index checkbox on change


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

Because there were two forms (edit and delete), fork cms used “delete”
instead of “edit”
