### PR TITLE
Fix false positive because it is never actually just an object

### DIFF
--- a/app/KernelLoader.php
+++ b/app/KernelLoader.php
@@ -37,7 +37,7 @@ class KernelLoader
      *
      * @param string $reference The service id
      *
-     * @return object The service
+     * @return mixed The service
      */
     public function get(string $reference)
     {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

I always get warnings that the type is wrong when I use `$this->get` in an action
This pr fixes that false positive because of the phpdoc

Before:
![screen shot 2017-09-15 at 11 43 26](https://user-images.githubusercontent.com/3634654/30476799-6ec2d5f6-9a0b-11e7-988d-82551c5ada38.png)
After:
![screen shot 2017-09-15 at 11 43 39](https://user-images.githubusercontent.com/3634654/30476807-746cde70-9a0b-11e7-8887-a045bb68d178.png)



