### PR TITLE
Fix cookiebar hidden check always resulted in a hidden cookiebar

### DIFF
--- a/src/Common/Core/Cookie.php
+++ b/src/Common/Core/Cookie.php
@@ -156,7 +156,7 @@ final class Cookie
      */
     public function hasHiddenCookieBar(): bool
     {
-        return $this->get('cookie_bar_hide', 'N') === 'N';
+        return $this->get('cookie_bar_hide', 'N') === 'Y';
     }
 
     public function attachToResponse(Response $response): void


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The cookiebar never showed up

