### PR TITLE
AbstractImage: fix. Thumbnails are generated again

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -79,11 +79,11 @@ abstract class AbstractImage extends AbstractFile
      */
     public function upload(): void
     {
-        parent::upload();
-
         if (!$this->hasFile()) {
             return;
         }
+
+        parent::upload();
 
         if (static::GENERATE_THUMBNAILS) {
             Model::generateThumbnails(


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When adding an image, the thumbnails weren't generated anymore. The bug has been introduced recently by https://github.com/forkcms/forkcms/pull/2234/files#diff-d6bf574c8bda004da4cdb54f46664adfL80
