### PR TITLE
Fix dump in twig templates and related issues when debug sometimes isn't enabled when it should

### DIFF
--- a/src/Backend/Core/Engine/TwigTemplate.php
+++ b/src/Backend/Core/Engine/TwigTemplate.php
@@ -39,6 +39,8 @@ class TwigTemplate extends BaseTwigTemplate
     public function __construct(bool $addToReference = true)
     {
         $container = Model::getContainer();
+        $this->debugMode = $container->getParameter('kernel.debug');
+
         parent::__construct(
             $this->buildTwigEnvironmentForTheBackend(),
             $container->get('templating.name_parser'),
@@ -50,7 +52,6 @@ class TwigTemplate extends BaseTwigTemplate
         }
 
         $this->forkSettings = $container->get('fork.settings');
-        $this->debugMode = $container->getParameter('kernel.debug');
         if ($this->debugMode) {
             $this->environment->enableAutoReload();
             $this->environment->setCache(false);

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -36,10 +36,11 @@ class TwigTemplate extends BaseTwigTemplate
         TemplateNameParserInterface $parser,
         FileLocatorInterface $locator
     ) {
-        parent::__construct($environment, $parser, $locator);
-
         $container = Model::getContainer();
         $this->forkSettings = $container->get('fork.settings');
+
+        parent::__construct($environment, $parser, $locator);
+
         $this->debugMode = $container->getParameter('kernel.debug');
         if ($this->debugMode) {
             $this->environment->enableAutoReload();


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Twig didn't always go into debug mode when it should because the parent constructor was called before we made sure that the debug parameter was correct
