### PR TITLE
Location widget marker was missing the address

### DIFF
--- a/src/Frontend/Modules/Location/Js/Location.js
+++ b/src/Frontend/Modules/Location/Js/Location.js
@@ -123,7 +123,7 @@ jsFrontend.location =
         // show info window on click
         google.maps.event.addListener(marker, 'click', function()
         {
-            $markerText = $('*[data-role=fork-marker-text-container][data-map-id=' + marker.locationId + ']');
+            $markerText = $('*[data-role=fork-marker-data-container][data-map-id=' + marker.locationId + ']');
 
             // apparently JS goes bananas with multi line HTMl, so we grab it from the div, this seems like a good idea for SEO
             if($markerText.length > 0) text = $markerText.html();


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

In the location widgets, in the marker, the address was missing.
Because of a renamed data-attribute.

Before the fix
![schermafbeelding 2017-09-18 om 13 38 53](https://user-images.githubusercontent.com/588616/30540292-ceafc4de-9c76-11e7-83dc-32468304ea91.png)
After the fix
![schermafbeelding 2017-09-18 om 13 39 21](https://user-images.githubusercontent.com/588616/30540293-cf7f9bfa-9c76-11e7-8f49-c0738e1222c7.png)


