### PR TITLE
Fix exception message when a css or js file isn't found in the theme and core

### DIFF
--- a/src/Frontend/Core/Engine/Theme.php
+++ b/src/Frontend/Core/Engine/Theme.php
@@ -33,7 +33,7 @@ class Theme
      */
     public static function getPath(string $filePath): string
     {
-        $filePath = self::getFilePathForcurrentTheme(self::getTheme(), $filePath);
+        $filePath = self::getFilePathForCurrentTheme(self::getTheme(), $filePath);
 
         // check if the file exists
         if (!is_file(PATH_WWW . str_replace(PATH_WWW, '', $filePath))) {

--- a/src/Frontend/Core/Engine/Theme.php
+++ b/src/Frontend/Core/Engine/Theme.php
@@ -37,7 +37,7 @@ class Theme
 
         // check if the file exists
         if (!is_file(PATH_WWW . str_replace(PATH_WWW, '', $filePath))) {
-            throw new Exception('The template (' . $filePath . ') does not exist.');
+            throw new Exception('The file (' . $filePath . ') does not exist.');
         }
 
         return $filePath;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
The exception message now states that it is a template also when it is a js or css file

