### PR TITLE
Add default value as backup

### DIFF
--- a/src/Backend/Core/Engine/Csv.php
+++ b/src/Backend/Core/Engine/Csv.php
@@ -63,7 +63,7 @@ class Csv extends \SpoonFileCSV
 
     private static function getLineEnding(): string
     {
-        $lineEnding = Authentication::getUser()->getSetting('csv_line_ending');
+        $lineEnding = Authentication::getUser()->getSetting('csv_line_ending', '\n');
 
         // reformat
         if ($lineEnding === '\n') {


### PR DESCRIPTION
When the user has not saved his profile before the $lineEnding value is null

## Type

- Non critical bugfix


