### PR TITLE
Set the default CSV settings for our god user

### DIFF
--- a/src/Backend/Modules/Users/Installer/Installer.php
+++ b/src/Backend/Modules/Users/Installer/Installer.php
@@ -161,6 +161,10 @@ class Installer extends ModuleInstaller
             $settings['password_strength'] = $this->getPasswordStrength();
             $settings['current_password_change'] = time();
             $settings['avatar'] = 'god.jpg';
+            $possibleCSVSplitCharacters = BackendUsersModel::getCSVSplitCharacters();
+            $settings['csv_split_character'] = reset($possibleCSVSplitCharacters);
+            $possibleCSVLineEndings = BackendUsersModel::getCSVLineEndings();
+            $settings['csv_line_ending'] = reset($possibleCSVLineEndings);
 
             // build user
             $user = [];


### PR DESCRIPTION
## Type

- Bugfix

## Pull request description

When doing a fresh install of Fork, the god user's default CSV settings would be `NULL`. As there is no fallback when fetching these settings in the `Csv` class, an error would be thrown. Instead of setting a fallback, the correct default settings should've been set. I did this by fetching the possible settings to choose from in the Add/Edit forms and simply selecting the first options. 

