### PR TITLE
Send a proper response when the ajax call is unauthenticated

### DIFF
--- a/src/Backend/Core/Engine/Ajax.php
+++ b/src/Backend/Core/Engine/Ajax.php
@@ -14,6 +14,7 @@ use ForkCMS\App\KernelLoader;
 use Symfony\Component\HttpFoundation\Response;
 use Backend\Core\Engine\Base\AjaxAction as BackendBaseAJAXAction;
 use Backend\Core\Language\Language as BackendLanguage;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * This class will handle AJAX-related stuff
@@ -36,8 +37,15 @@ class Ajax extends KernelLoader implements ApplicationInterface
 
     public function initialize(): void
     {
-        // check if the user is logged in
-        $this->validateLogin();
+        try {
+            // check if the user is logged in
+            $this->validateLogin();
+        } catch (UnauthorizedHttpException $e) {
+            $this->ajaxAction = new BackendBaseAJAXAction($this->getKernel());
+            $this->ajaxAction->output(Response::HTTP_UNAUTHORIZED, null, $e->getMessage());
+
+            return;
+        }
 
         // named application
         if (!defined('NAMED_APPLICATION')) {
@@ -64,7 +72,7 @@ class Ajax extends KernelLoader implements ApplicationInterface
     {
         // check if the user is logged on, if not he shouldn't load any JS-file
         if (!Authentication::isLoggedIn()) {
-            throw new Exception('Not logged in.');
+            throw new UnauthorizedHttpException('Backend', 'Not logged in.');
         }
 
         // set interface language

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -87,8 +87,8 @@ var jsBackend =
 
         // global error handler
         $(document).ajaxError(function (e, XMLHttpRequest, ajaxOptions) {
-            // 403 means we aren't authenticated anymore, so reload the page
-            if (XMLHttpRequest.status == 403) window.location.reload();
+            // 401 means we aren't authenticated anymore, so reload the page
+            if (XMLHttpRequest.status == 401) window.location.reload();
 
             // check if a custom errorhandler is used
             if (typeof ajaxOptions.error == 'undefined') {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Ajax calls should give a proper response mentioning that the call was unauthenticated instead of throwing exceptions

