### PR TITLE
Dont try to minify external urls

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -29,6 +29,7 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new \Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new \ForkCMS\Bundle\InstallerBundle\ForkCMSInstallerBundle(),
+            new \ForkCMS\Bundle\CoreBundle\ForkCMSCoreBundle(),
             new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new \SimpleBus\SymfonyBridge\SimpleBusCommandBusBundle(),
             new \SimpleBus\SymfonyBridge\DoctrineOrmBridgeBundle(),

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -162,7 +162,7 @@ final class Header extends KernelLoader
                 $addTimestamp,
                 $priority ?? ($overwritePath ? Priority::standard() : Priority::forModule($module))
             ),
-            $minify && !$this->getContainer()->getParameter('kernel.debug')
+            $minify
         );
     }
 

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -139,7 +139,7 @@ final class Header extends KernelLoader
      * @param string $module The module wherein the file is located.
      * @param bool $overwritePath Should we overwrite the full path?
      *                            An external url will always be handled with $overwritePath as true.
-     * @param bool $minify Should the CSS be minified? An external url will never be minified.
+     * @param bool $minify Should the CSS be minified?
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority $priority the files are added based on the priority
      *                           defaults to standard for full links or core or module for core or module css
@@ -174,7 +174,7 @@ final class Header extends KernelLoader
      *
      * @param string $file The file to load.
      * @param string $module The module wherein the file is located.
-     * @param bool $minify Should the module be minified? An external url will never be minified.
+     * @param bool $minify Should the javascript be minified?
      * @param bool $overwritePath Should we overwrite the full path?
      *                            An external url will always be handled with $overwritePath as true.
      * @param bool $addTimestamp May we add a timestamp for caching purposes?

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -184,7 +184,7 @@ final class Header extends KernelLoader
         Priority $priority = null
     ): void {
         $module = $module ?? $this->url->getModule();
-
+        $overwritePath = $overwritePath || strpos($file, 'http') === 0 || strpos($file, '//') === 0;
         $this->jsFiles->add(
             new Asset(
                 $overwritePath ? $file : $this->buildPathForModule($file, $module ?? $this->url->getModule(), 'Js'),

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -189,6 +189,7 @@ final class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
+        $module = $module ?? $this->url->getModule();
         $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
         $overwritePath = $overwritePath || $isExternalUrl;
         $minify = $minify && !$isExternalUrl;

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -140,7 +140,8 @@ final class Header extends KernelLoader
      * @param string $file The name of the file to load.
      * @param string $module The module wherein the file is located.
      * @param bool $overwritePath Should we overwrite the full path?
-     * @param bool $minify Should the CSS be minified?
+     *                            An external url will always be handled with $overwritePath as true.
+     * @param bool $minify Should the CSS be minified? An external url will never be minified.
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority $priority the files are added based on the priority
      *                           defaults to standard for full links or core or module for core or module css
@@ -173,7 +174,7 @@ final class Header extends KernelLoader
      *
      * @param string $file The file to load.
      * @param string $module The module wherein the file is located.
-     * @param bool $minify Should the module be minified?
+     * @param bool $minify Should the module be minified? An external url will never be minified.
      * @param bool $overwritePath Should we overwrite the full path?
      *                            An external url will always be handled with $overwritePath as true.
      * @param bool $addTimestamp May we add a timestamp for caching purposes?

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -155,7 +155,9 @@ final class Header extends KernelLoader
         Priority $priority = null
     ): void {
         $module = $module ?? $this->url->getModule();
-        $overwritePath = $overwritePath || $this->isExternalUrl($file);
+        $isExternalUrl = $this->isExternalUrl($file);
+        $overwritePath = $overwritePath || $isExternalUrl;
+        $minify = $minify && !$isExternalUrl;
 
         $this->cssFiles->add(
             new Asset(
@@ -189,8 +191,9 @@ final class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        $module = $module ?? $this->url->getModule();
-        $overwritePath = $overwritePath || $this->isExternalUrl($file);
+        $isExternalUrl = $this->isExternalUrl($file);
+        $overwritePath = $overwritePath || $isExternalUrl;
+        $minify = $minify && !$isExternalUrl;
 
         $this->jsFiles->add(
             new Asset(

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -154,7 +154,7 @@ final class Header extends KernelLoader
     ): void {
         $module = $module ?? $this->url->getModule();
         $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
-        $overwritePath = $overwritePath || $isExternalUrl;
+        $overwritePath = $overwritePath || $isExternalUrl; // external urls always overwrite the path
         $minify = $minify && !$isExternalUrl;
 
         $this->cssFiles->add(
@@ -191,7 +191,7 @@ final class Header extends KernelLoader
     ): void {
         $module = $module ?? $this->url->getModule();
         $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
-        $overwritePath = $overwritePath || $isExternalUrl;
+        $overwritePath = $overwritePath || $isExternalUrl; // external urls always overwrite the path
         $minify = $minify && !$isExternalUrl;
 
         $this->jsFiles->add(

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -154,6 +154,8 @@ final class Header extends KernelLoader
         Priority $priority = null
     ): void {
         $module = $module ?? $this->url->getModule();
+        $overwritePath = $overwritePath || $this->isExternalUrl($file);
+
         $this->cssFiles->add(
             new Asset(
                 $overwritePath ? $file : $this->buildPathForModule($file, $module, 'Layout/Css'),

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -17,8 +17,6 @@ use Common\Core\Header\Priority;
 use ForkCMS\App\KernelLoader;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Backend\Core\Language\Language as BL;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Validation;
 
 /**
  * This class will be used to alter the head-part of the HTML-document that will be created by he Backend
@@ -155,7 +153,7 @@ final class Header extends KernelLoader
         Priority $priority = null
     ): void {
         $module = $module ?? $this->url->getModule();
-        $isExternalUrl = $this->isExternalUrl($file);
+        $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
         $overwritePath = $overwritePath || $isExternalUrl;
         $minify = $minify && !$isExternalUrl;
 
@@ -191,7 +189,7 @@ final class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        $isExternalUrl = $this->isExternalUrl($file);
+        $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
         $overwritePath = $overwritePath || $isExternalUrl;
         $minify = $minify && !$isExternalUrl;
 
@@ -203,23 +201,6 @@ final class Header extends KernelLoader
             ),
             $minify
         );
-    }
-
-    private function isExternalUrl(string $url): bool
-    {
-        $violations = Validation::createValidator()->validate(
-            $url,
-            [
-                new Assert\Url(
-                    [
-                        'checkDNS' => true, // Just a crappy name to say that it will check the url has a valid hostname
-                    ]
-                ),
-            ]
-        );
-
-        // if there are no violations the url is a valid external url
-        return $violations->count() === 0;
     }
 
     /**

--- a/src/Backend/Modules/Location/Actions/Edit.php
+++ b/src/Backend/Modules/Location/Actions/Edit.php
@@ -54,7 +54,7 @@ class Edit extends BackendBaseActionEdit
             }
 
             // add js
-            $this->header->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey, null, false, true, false);
+            $this->header->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey);
 
             $this->loadData();
 

--- a/src/Backend/Modules/Location/Actions/Index.php
+++ b/src/Backend/Modules/Location/Actions/Index.php
@@ -50,7 +50,7 @@ class Index extends BackendBaseActionIndex
         }
 
         // add js
-        $this->header->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey, null, false, true, false);
+        $this->header->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey);
 
         $this->loadData();
 

--- a/src/Common/Core/Header/AssetCollection.php
+++ b/src/Common/Core/Header/AssetCollection.php
@@ -19,7 +19,7 @@ final class AssetCollection
 
     public function add(Asset $asset, bool $minify = true): void
     {
-        if ($minify) {
+        if ($minify && strpos($asset->getFile(), 'http') !== 0 && strpos($asset->getFile(), '//') !== 0) {
             $asset = $this->minifier->minify($asset);
         }
 

--- a/src/Common/Core/Header/AssetCollection.php
+++ b/src/Common/Core/Header/AssetCollection.php
@@ -19,7 +19,7 @@ final class AssetCollection
 
     public function add(Asset $asset, bool $minify = true): void
     {
-        if ($minify && strpos($asset->getFile(), 'http') !== 0 && strpos($asset->getFile(), '//') !== 0) {
+        if ($minify) {
             $asset = $this->minifier->minify($asset);
         }
 

--- a/src/ForkCMS/Bundle/CoreBundle/DependencyInjection/ForkCMSCoreExtension.php
+++ b/src/ForkCMS/Bundle/CoreBundle/DependencyInjection/ForkCMSCoreExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ForkCMS\Bundle\CoreBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class ForkCMSCoreExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/ForkCMS/Bundle/CoreBundle/ForkCMSCoreBundle.php
+++ b/src/ForkCMS/Bundle/CoreBundle/ForkCMSCoreBundle.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ForkCMS\Bundle\CoreBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Core bundle for Fork CMS
+ */
+class ForkCMSCoreBundle extends Bundle
+{
+}

--- a/src/ForkCMS/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/ForkCMS/Bundle/CoreBundle/Resources/config/services.yml
@@ -1,0 +1,1 @@
+services:

--- a/src/ForkCMS/Bundle/CoreBundle/Resources/config/services.yml
+++ b/src/ForkCMS/Bundle/CoreBundle/Resources/config/services.yml
@@ -1,1 +1,3 @@
 services:
+  fork.validator.url:
+    class: ForkCMS\Bundle\CoreBundle\Validator\UrlValidator

--- a/src/ForkCMS/Bundle/CoreBundle/Tests/Validator/UrlValidatorTest.php
+++ b/src/ForkCMS/Bundle/CoreBundle/Tests/Validator/UrlValidatorTest.php
@@ -7,21 +7,33 @@ use PHPUnit\Framework\TestCase;
 
 class UrlValidatorTest extends TestCase
 {
-    public function testExternalUrlValidation()
+    public function testValidExternalUrlValidation()
     {
         $urlValidator = new UrlValidator();
 
         $urls = [
-            'http://test.com/index.js' => true,
-            'https://test.com/index.js' => true,
-            '/index.js' => false,
-            'index.js' => false,
-            'dev/index.js' => false,
-            '/dev/index.js' => false,
+            'http://test.com/index.js',
+            'https://test.com/index.js',
         ];
 
-        foreach ($urls as $url => $isExternal) {
-            $this->assertEquals($isExternal, $urlValidator->isExternalUrl($url), $url . ' was not validated correctly');
+        foreach ($urls as $url) {
+            $this->assertTrue($urlValidator->isExternalUrl($url), $url . ' was not validated correctly');
+        }
+    }
+
+    public function testInvalidExternalUrlValidation()
+    {
+        $urlValidator = new UrlValidator();
+
+        $urls = [
+            '/index.js',
+            'index.js',
+            'dev/index.js',
+            '/dev/index.js',
+        ];
+
+        foreach ($urls as $url) {
+            $this->assertFalse($urlValidator->isExternalUrl($url), $url . ' was not validated correctly');
         }
     }
 }

--- a/src/ForkCMS/Bundle/CoreBundle/Tests/Validator/UrlValidatorTest.php
+++ b/src/ForkCMS/Bundle/CoreBundle/Tests/Validator/UrlValidatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ForkCMS\Bundle\CoreBundle\Tests\Validator;
+
+use ForkCMS\Bundle\CoreBundle\Validator\UrlValidator;
+use PHPUnit\Framework\TestCase;
+
+class UrlValidatorTest extends TestCase
+{
+    public function testExternalUrlValidation()
+    {
+        $urlValidator = new UrlValidator();
+
+        $urls = [
+            'http://test.com/index.js' => true,
+            'https://test.com/index.js' => true,
+            '/index.js' => false,
+            'index.js' => false,
+            'dev/index.js' => false,
+            '/dev/index.js' => false,
+        ];
+
+        foreach ($urls as $url => $isExternal) {
+            $this->assertEquals($isExternal, $urlValidator->isExternalUrl($url), $url . ' was not validated correctly');
+        }
+    }
+}

--- a/src/ForkCMS/Bundle/CoreBundle/Validator/UrlValidator.php
+++ b/src/ForkCMS/Bundle/CoreBundle/Validator/UrlValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ForkCMS\Bundle\CoreBundle\Validator;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
+
+final class UrlValidator
+{
+    public function isExternalUrl(string $url): bool
+    {
+        $violations = Validation::createValidator()->validate(
+            $url,
+            [
+                new Assert\Url(
+                    [
+                        'checkDNS' => true, // Just a crappy name to say that it will check the url has a valid hostname
+                    ]
+                ),
+            ]
+        );
+
+        // if there are no violations the url is a valid external url
+        return $violations->count() === 0;
+    }
+}

--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -137,6 +137,8 @@ class Block extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
+
         // use module path
         if (!$overwritePath) {
             $file = '/src/Frontend/Modules/' . $this->getModule() . '/Layout/Css/' . $file;
@@ -165,6 +167,8 @@ class Block extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
+
         // use module path
         if (!$overwritePath) {
             $file = '/src/Frontend/Modules/' . $this->getModule() . '/Js/' . $file;

--- a/src/Frontend/Core/Engine/Base/Block.php
+++ b/src/Frontend/Core/Engine/Base/Block.php
@@ -137,6 +137,7 @@ class Block extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        // external urls always overwrite the path
         $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
 
         // use module path
@@ -167,6 +168,7 @@ class Block extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        // external urls always overwrite the path
         $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
 
         // use module path

--- a/src/Frontend/Core/Engine/Base/Widget.php
+++ b/src/Frontend/Core/Engine/Base/Widget.php
@@ -112,6 +112,8 @@ class Widget extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
+
         if (!$overwritePath) {
             $file = '/src/Frontend/Modules/' . $this->getModule() . '/Layout/Css/' . $file;
         }
@@ -133,6 +135,8 @@ class Widget extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
+
         if (!$overwritePath) {
             $file = '/src/Frontend/Modules/' . $this->getModule() . '/Js/' . $file;
         }

--- a/src/Frontend/Core/Engine/Base/Widget.php
+++ b/src/Frontend/Core/Engine/Base/Widget.php
@@ -112,6 +112,7 @@ class Widget extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        // external urls always overwrite the path
         $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
 
         if (!$overwritePath) {
@@ -135,6 +136,7 @@ class Widget extends KernelLoader
         bool $minify = true,
         bool $addTimestamp = false
     ): void {
+        // external urls always overwrite the path
         $overwritePath = $overwritePath || $this->get('fork.validator.url')->isExternalUrl($file);
 
         if (!$overwritePath) {

--- a/src/Frontend/Core/Engine/RssItem.php
+++ b/src/Frontend/Core/Engine/RssItem.php
@@ -124,7 +124,7 @@ class RssItem extends \SpoonFeedRSSItem
     private function prependWithSiteUrlIfHttpIsMissing(string $link): string
     {
         // if link doesn't start with http(s), we prepend the URL of the site
-        if (mb_stripos($link, 'http://') !== 0 || mb_stripos($link, 'https://')) {
+        if (!Model::getContainer()->get('fork.validator.url')->isExternalUrl($link)) {
             return SITE_URL . $link;
         }
 

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -144,7 +144,7 @@ class Header extends KernelLoader
      * Add a CSS file into the array
      *
      * @param string $file The path for the CSS-file that should be loaded.
-     * @param bool $minify Should the CSS be minified? An external url will never be minified.
+     * @param bool $minify Should the CSS be minified?
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority|null $priority Provides a way to change the order that things are loaded
      */
@@ -165,7 +165,7 @@ class Header extends KernelLoader
      * Add a javascript file into the array
      *
      * @param string $file The path to the javascript-file that should be loaded.
-     * @param bool $minify Should the file be minified? An external url will never be minified.
+     * @param bool $minify Should the javascript be minified?
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority|null $priority Provides a way to change the order that things are loaded
      */

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -21,8 +21,6 @@ use Frontend\Core\Engine\TwigTemplate;
 use Frontend\Core\Engine\Url;
 use Frontend\Core\Language\Locale;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Validation;
 
 /**
  * This class will be used to alter the head-part of the HTML-document that will be created by the frontend
@@ -156,7 +154,7 @@ class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        $isExternalUrl = $this->isExternalUrl($file);
+        $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
         $file = $isExternalUrl ? $file : Theme::getPath($file);
         $minify = $minify && !$isExternalUrl;
 
@@ -177,28 +175,11 @@ class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        $isExternalUrl = $this->isExternalUrl($file);
+        $isExternalUrl = $this->get('fork.validator.url')->isExternalUrl($file);
         $file = $isExternalUrl ? $file : Theme::getPath($file);
         $minify = $minify && !$isExternalUrl;
 
         $this->jsFiles->add(new Asset($file, $addTimestamp, $priority), $minify);
-    }
-
-    private function isExternalUrl(string $url): bool
-    {
-        $violations = Validation::createValidator()->validate(
-            $url,
-            [
-                new Assert\Url(
-                    [
-                        'checkDNS' => true, // Just a crappy name to say that it will check the url has a valid hostname
-                    ]
-                ),
-            ]
-        );
-
-        // if there are no violations the url is a valid external url
-        return $violations->count() === 0;
     }
 
     /**

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -276,7 +276,7 @@ class Header extends KernelLoader
         $image = str_replace(SITE_URL, '', $image);
 
         // check if it no longer points to an absolute uri
-        if (strpos($image, 'http://') !== 0 && strpos($image, 'https://') !== 0) {
+        if (!$this->getContainer()->get('fork.validator.url')->isExternalUrl($image)) {
             if (!is_file(PATH_WWW . strtok($image, '?'))) {
                 return;
             }

--- a/src/Frontend/Core/Header/Header.php
+++ b/src/Frontend/Core/Header/Header.php
@@ -21,6 +21,8 @@ use Frontend\Core\Engine\TwigTemplate;
 use Frontend\Core\Engine\Url;
 use Frontend\Core\Language\Locale;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
 
 /**
  * This class will be used to alter the head-part of the HTML-document that will be created by the frontend
@@ -144,7 +146,7 @@ class Header extends KernelLoader
      * Add a CSS file into the array
      *
      * @param string $file The path for the CSS-file that should be loaded.
-     * @param bool $minify Should the CSS be minified?
+     * @param bool $minify Should the CSS be minified? An external url will never be minified.
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority|null $priority Provides a way to change the order that things are loaded
      */
@@ -154,9 +156,9 @@ class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        if (mb_strpos($file, 'http') !== 0) {
-            $file = Theme::getPath($file);
-        }
+        $isExternalUrl = $this->isExternalUrl($file);
+        $file = $isExternalUrl ? $file : Theme::getPath($file);
+        $minify = $minify && !$isExternalUrl;
 
         $this->cssFiles->add(new Asset($file, $addTimestamp, $priority), $minify);
     }
@@ -165,7 +167,7 @@ class Header extends KernelLoader
      * Add a javascript file into the array
      *
      * @param string $file The path to the javascript-file that should be loaded.
-     * @param bool $minify Should the file be minified?
+     * @param bool $minify Should the file be minified? An external url will never be minified.
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority|null $priority Provides a way to change the order that things are loaded
      */
@@ -175,11 +177,28 @@ class Header extends KernelLoader
         bool $addTimestamp = false,
         Priority $priority = null
     ): void {
-        if (mb_strpos($file, 'http') !== 0) {
-            $file = Theme::getPath($file);
-        }
+        $isExternalUrl = $this->isExternalUrl($file);
+        $file = $isExternalUrl ? $file : Theme::getPath($file);
+        $minify = $minify && !$isExternalUrl;
 
         $this->jsFiles->add(new Asset($file, $addTimestamp, $priority), $minify);
+    }
+
+    private function isExternalUrl(string $url): bool
+    {
+        $violations = Validation::createValidator()->validate(
+            $url,
+            [
+                new Assert\Url(
+                    [
+                        'checkDNS' => true, // Just a crappy name to say that it will check the url has a valid hostname
+                    ]
+                ),
+            ]
+        );
+
+        // if there are no violations the url is a valid external url
+        return $violations->count() === 0;
     }
 
     /**

--- a/src/Frontend/Modules/Location/Actions/Index.php
+++ b/src/Frontend/Modules/Location/Actions/Index.php
@@ -36,7 +36,7 @@ class Index extends FrontendBaseBlock
         if ($apikey == null) {
             trigger_error('Please provide a Google Maps API key.');
         }
-        $this->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey, true, false);
+        $this->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey);
         $this->addJS(FrontendLocationModel::getPathToMapStyles(false), true);
 
         parent::execute();

--- a/src/Frontend/Modules/Location/Widgets/Location.php
+++ b/src/Frontend/Modules/Location/Widgets/Location.php
@@ -41,7 +41,7 @@ class Location extends FrontendBaseWidget
         if ($apikey == null) {
             trigger_error('Please provide a Google Maps API key.');
         }
-        $this->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey, true, false);
+        $this->addJS('https://maps.googleapis.com/maps/api/js?key=' . $apikey);
         $this->addJS(FrontendLocationModel::getPathToMapStyles(false), true);
 
         parent::execute();


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Developers needed to manually disable `minify` and enable `overwritePath` even when it was clear it was an external asset. This resulted in unexpected behaviour when the developer didn't pay attention to it since the assets don't minify in debug mode

After this fix you will be able to do the following without extra effort or parameters and it will work as expected
```
        $this->header->addJS('//text.com/test.js');
        $this->header->addJS('http://text.com/test.js');
        $this->header->addJS('https://text.com/test.js');
```

