### PR TITLE
Fix for LiipImagineBundle with a Fork CMS deployment with symlinks

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -65,6 +65,7 @@ liip_imagine:
         default:
             filesystem:
                 data_root: "%kernel.project_dir%/"
+                locator: filesystem_insecure
     cache: default
     data_loader: default
 


### PR DESCRIPTION
## Type

- (Non) Critical bugfix when using deployment tools like f.e.: Capistrano

## Problem description

Deploying Fork CMS using Capistrano breaks LiipImagineBundle.
Because symlinks are not supported by default.

## Pull request description

There was an issue open in LiipImagineBundle with exactly the same problem, https://github.com/liip/LiipImagineBundle/issues/780. Luckily LiipImagineBundle has done a PR to allow symlinks.
