### PR TITLE
Removed deprecated "'choices_as_values' => true," in MetaType

### DIFF
--- a/src/Backend/Form/Type/MetaType.php
+++ b/src/Backend/Form/Type/MetaType.php
@@ -104,7 +104,6 @@ class MetaType extends AbstractType
                 },
                 SEOIndex::POSSIBLE_VALUES
             ),
-            'choices_as_values' => true,
             'choice_value' => function (SEOIndex $SEOIndex = null) {
                 return (string) $SEOIndex;
             },
@@ -133,7 +132,6 @@ class MetaType extends AbstractType
                 },
                 SEOFollow::POSSIBLE_VALUES
             ),
-            'choices_as_values' => true,
             'choice_value' => function (SEOFollow $SEOFollow = null) {
                 return (string) $SEOFollow;
             },


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

`choices_as_values` is deprecated since symfony 3.1, remove it before symfony 4.

