### PR TITLE
OpenGraph error when you add a OneImage MediaLibrary widget without images

### DIFF
--- a/src/Frontend/Modules/MediaLibrary/Widgets/OneImage.php
+++ b/src/Frontend/Modules/MediaLibrary/Widgets/OneImage.php
@@ -26,6 +26,10 @@ class OneImage extends FrontendMediaWidget
         /** @var MediaGroupMediaItem $firstConnectedItem */
         $firstConnectedItem = $this->mediaGroup->getConnectedItems()->first();
 
+        if ($firstConnectedItem === false) {
+            return;
+        }
+
         // Add OpenGraph image
         $this->header->addOpenGraphImage($firstConnectedItem->getItem()->getAbsoluteWebPath());
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When you add a "OneImage" MediaLibrary widget to a page. But you haven't uploaded images to it yet, an error is thrown because there is no image to addToOpenGraph.

## Solution

Check added to verify that it is empty.

