### PR TITLE
Dont redirect on empty pages

### DIFF
--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -246,7 +246,7 @@ class Page extends KernelLoader
             $firstChildId = Navigation::getFirstChildId($record['id']);
 
             // check if we actually have a first child
-            if (Navigation::getFirstChildId($record['id']) !== false) {
+            if ($firstChildId !== 0) {
                 $this->redirect(Navigation::getUrl($firstChildId));
             }
         }

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -247,7 +247,7 @@ class Page extends KernelLoader
 
             // check if we actually have a first child
             if (Navigation::getFirstChildId($record['id']) !== false) {
-                $this->redirect(Navigation::getUrl($firstChildId), RedirectResponse::HTTP_MOVED_PERMANENTLY);
+                $this->redirect(Navigation::getUrl($firstChildId));
             }
         }
 


### PR DESCRIPTION
## Type

- Non critical bugfix
- Enhancement

## Resolves the following issues

fixes #2268 

## Pull request description

When a page has no content (e.g.: no editors, widgets, module, ...) and has children the page should redirect to the first child with a temporary redirect.

When a page has no content (e.g.: no editors, widgets, module, ...) and has no children the page should be renderen. So no redirect to home/404 or whatsoever.

