### PR TITLE
Bugfix in MediaLibrary frontend Twig method media_library_widget

### DIFF
--- a/src/Frontend/Modules/MediaLibrary/Twig/Extensions/FrontendHelperExtensions.php
+++ b/src/Frontend/Modules/MediaLibrary/Twig/Extensions/FrontendHelperExtensions.php
@@ -36,14 +36,14 @@ class FrontendHelperExtensions extends \Twig_Extension
      * @param string $title - You can give your optional custom title.
      * @param string $module - You can parse a widget from a custom module. Default is the "MediaLibrary" module.
      *
-     * @return Twig_Markup
+     * @return string
      */
     public function parseWidget(
         string $mediaWidgetAction,
         string $mediaGroupId,
         string $title = null,
         string $module = null
-    ): Twig_Markup {
+    ): string {
         return $this->frontendHelper->parseWidget(
             $mediaWidgetAction,
             $mediaGroupId,


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When using `{{ media_library_widget('Lightbox', realization.mediaGroup.id) }}` in the frontend. An error was thrown because the method return string and not the required Twig_Markup.

## Pull request description

Changed return type `Twig_Markup` to `string`.