### PR TITLE
Updated the Google maps api key link

### DIFF
--- a/src/Backend/Modules/Settings/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Settings/Layout/Templates/Index.html.twig
@@ -163,7 +163,7 @@
                   </th>
                   <td>{% form_field google_maps_key %} {% form_field_error google_maps_key %}</td>
                   <td>
-                    <a href="http://code.google.com/apis/maps/signup.html">http://code.google.com/apis/maps/signup.html</a>
+                    <a href="https://developers.google.com/maps/documentation/javascript/get-api-key">http://code.google.com/apis/maps/signup.html</a>
                   </td>
                 </tr>
               {% endif %}


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

The link that was provided did not help you anywhere.

## Pull request description

The new link is the one that allows you to immediately generate the proper API KEY for Google Maps.

