### PR TITLE
Removed the target-attribute

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Component/StorageProvider/LocalStorageProvider.php
+++ b/src/Backend/Modules/MediaLibrary/Component/StorageProvider/LocalStorageProvider.php
@@ -47,12 +47,12 @@ class LocalStorageProvider implements LocalStorageProviderInterface
             return '<img src="' . $mediaItem->getWebPath() . '" title="' . $mediaItem->getTitle() . '" />';
         }
 
-        return '<a href="' . $mediaItem->getWebPath() . '" title="' . $mediaItem->getTitle() . '" target="_blank">' . $mediaItem->getTitle() . '</a>';
+        return '<a href="' . $mediaItem->getWebPath() . '" title="' . $mediaItem->getTitle() . '">' . $mediaItem->getTitle() . '</a>';
     }
 
     public function getLinkHTML(MediaItem $mediaItem): string
     {
-        return '<a href="' . $this->getAbsoluteWebPath($mediaItem) . '" title="' . $mediaItem->getTitle() . '" target="_blank">' . $mediaItem->getTitle() . '</a>';
+        return '<a href="' . $this->getAbsoluteWebPath($mediaItem) . '" title="' . $mediaItem->getTitle() . '">' . $mediaItem->getTitle() . '</a>';
     }
 
     public function getUploadRootDir(): string

--- a/src/Backend/Modules/MediaLibrary/Component/StorageProvider/MovieStorageProvider.php
+++ b/src/Backend/Modules/MediaLibrary/Component/StorageProvider/MovieStorageProvider.php
@@ -35,7 +35,7 @@ class MovieStorageProvider implements StorageProviderInterface
 
     public function getLinkHTML(MediaItem $mediaItem): string
     {
-        return '<a href="' . $this->getAbsoluteWebPath($mediaItem) . '" title="' . $mediaItem->getTitle() . '" target="_blank">' . $mediaItem->getTitle() . '</a>';
+        return '<a href="' . $this->getAbsoluteWebPath($mediaItem) . '" title="' . $mediaItem->getTitle() . '">' . $mediaItem->getTitle() . '</a>';
     }
 
     public function getWebPath(MediaItem $mediaItem): string


### PR DESCRIPTION
## Type

- Non critical bugfix
- Enhancement

## Pull request description

It is not logical to set the target-attribute to _blank by default, as you
can't know for sure what the intention is.

Even more important is that  you are breaking user expectations, nobody is
expecting that a link opens a new tab/page.

See also:
* https://css-tricks.com/use-target_blank/
* https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
