### PR TITLE
Remove obsolete where parameters in the FAQ extra widget data

### DIFF
--- a/src/Backend/Modules/Faq/Installer/Installer.php
+++ b/src/Backend/Modules/Faq/Installer/Installer.php
@@ -225,8 +225,8 @@ class Installer extends ModuleInstaller
         $database->update(
             'modules_extras',
             $extra,
-            'id = ? AND module = ? AND type = ? AND action = ?',
-            [$item['extra_id'], $this->getModule(), ModuleExtraType::widget(), 'category_list']
+            'id = ?',
+            [$item['extra_id']]
         );
 
         return $item['id'];


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

When installing the FAQ module a widget gets created to display the default category. However, in the update of said widget there was an incorrect parameter (`category_list` vs `CategoryList`) which caused the update to never happen. This caused 500 errors when adding the widget to a page.

To counter this I've simply removed the obsolete where parameters since our `extra_id` is unique to our widget.

