### PR TITLE
Use the cookie service to check if the cookie bar should be shown

### DIFF
--- a/src/Frontend/Core/Header/GoogleAnalytics.php
+++ b/src/Frontend/Core/Header/GoogleAnalytics.php
@@ -36,7 +36,7 @@ final class GoogleAnalytics
 
     private function shouldAnonymize(): bool
     {
-        return $this->modulesSettings->get('Core', 'show_cookie_bar', false) && !Cookie::hasAllowedCookies();
+        return $this->modulesSettings->get('Core', 'show_cookie_bar', false) && !$this->cookie->hasAllowedCookies();
     }
 
     private function getGoogleAnalyticsEvent(): string


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
the cookie service can't be used staticly

