### PR TITLE
Breadcrumb: remove last element in breadcrumb

### DIFF
--- a/src/Frontend/Core/Engine/Breadcrumb.php
+++ b/src/Frontend/Core/Engine/Breadcrumb.php
@@ -171,4 +171,9 @@ class Breadcrumb extends KernelLoader
         // assign
         $this->template->assignGlobal('breadcrumb', $this->items);
     }
+
+    public function removeLastElement(): void
+    {
+        array_pop($this->items);
+    }
 }


### PR DESCRIPTION
## Type

- Feature

## What has changed?

Added a `$this->breadcrumb->removeLastElement` method.

## Pull request description

Sometimes you want to finetune your breadcrumb like you want it to be.
That's why I added `$this->breadcrumb->removeLastElement()`, so unnecessary pages can be deleted.

An example situation:
`Home / News / Article / Title of the article`
Where "Article" is a page with a module block "Article".
But we actually don't want "Article" to be shown in the breadcrumb, because visiting that page gives a 404.

With the new `removeLastElement`, the following is possible.
```php
$this->breadcrumb->removeLastElement();
$this->breadcrumb->addElement($article->getTitle);
```

Will result in
`Home / News / Title of the article`