### PR TITLE
Fix tagcloud widget not showing the most used tags

### DIFF
--- a/src/Frontend/Modules/Tags/Engine/Model.php
+++ b/src/Frontend/Modules/Tags/Engine/Model.php
@@ -74,6 +74,18 @@ class Model
         );
     }
 
+    public static function getMostUsed(int $limit): array
+    {
+        return (array) FrontendModel::getContainer()->get('database')->getRecords(
+            'SELECT t.tag AS name, t.url, t.number
+             FROM tags AS t
+             WHERE t.language = ? AND t.number > 0
+             ORDER BY t.number DESC
+             LIMIT ?',
+            [FrontendLocale::frontendLanguage(), $limit]
+        );
+    }
+
     /**
      * @param string $module The module wherein the otherId occurs.
      * @param int $otherId The id of the item.

--- a/src/Frontend/Modules/Tags/Widgets/TagCloud.php
+++ b/src/Frontend/Modules/Tags/Widgets/TagCloud.php
@@ -13,9 +13,6 @@ use Frontend\Core\Engine\Base\Widget as FrontendBaseWidget;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Modules\Tags\Engine\Model as FrontendTagsModel;
 
-/**
- * This is a widget with the tags
- */
 class TagCloud extends FrontendBaseWidget
 {
     public function execute(): void
@@ -27,24 +24,26 @@ class TagCloud extends FrontendBaseWidget
 
     private function parse(): void
     {
-        // get categories
-        $tags = FrontendTagsModel::getAll();
+        $tags = FrontendTagsModel::getMostUsed(10);
 
-        // we just need the 10 first items
-        $tags = array_slice($tags, 0, 10);
+        if (empty($tags)) {
+            $this->template->assign('widgetTagsTagCloud', []);
 
-        // build link
-        $link = FrontendNavigation::getUrlForBlock('Tags', 'Detail');
-
-        // any tags?
-        if (!empty($tags)) {
-            // loop and reset url
-            foreach ($tags as &$row) {
-                $row['url'] = $link . '/' . $row['url'];
-            }
+            return;
         }
 
-        // assign comments
-        $this->template->assign('widgetTagsTagCloud', $tags);
+        $link = FrontendNavigation::getUrlForBlock($this->getModule(), 'Detail');
+
+        $this->template->assign(
+            'widgetTagsTagCloud',
+            array_map(
+                function (array $tag) use ($link) {
+                    $tag['url'] = $link . '/' . $tag['url'];
+
+                    return $tag;
+                },
+                $tags
+            )
+        );
     }
 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The tag cloud returned the first 10 tags sorted alphabetically (very inefficiently)

This PR will make sure that the 10 most used tags are used in the tag cloud

