### PR TITLE
Fix adding a new profile in the backend

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/Add.php
+++ b/src/Backend/Modules/Profiles/Actions/Add.php
@@ -169,6 +169,7 @@ class Add extends BackendBaseActionAdd
                     'url' => BackendProfilesModel::getUrl($txtDisplayName->getValue()),
                     'last_login' => BackendModel::getUTCDate(null, 0),
                     'password' => BackendProfilesModel::encryptPassword($password),
+                    'status' => 'active',
                 ];
 
                 $this->id = BackendProfilesModel::insert($values);


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Adding profiles in the backend didn't work because the status wasn't set.
It did give the error when using the docker image but not on the demo, but it is better to fix it than the hope the server will handle it properly

