### PR TITLE
Fix check if the email or displayname exists without excluding a profile

### DIFF
--- a/src/Frontend/Modules/Profiles/Engine/Model.php
+++ b/src/Frontend/Modules/Profiles/Engine/Model.php
@@ -40,23 +40,37 @@ class Model
 
     public static function existsByEmail(string $email, int $excludedId = null): bool
     {
+        $where = 'p.email = :email';
+        $parameters = ['email' => $email];
+
+        if ($excludedId !== null) {
+            $where .= ' AND p.id != :excludedId';
+            $parameters['excludedId'] = $excludedId;
+        }
+
         return (bool) FrontendModel::getContainer()->get('database')->getVar(
             'SELECT 1
              FROM profiles AS p
-             WHERE p.email = ? AND p.id != ?
-             LIMIT 1',
-            [$email, $excludedId]
+             WHERE ' . $where . ' LIMIT 1',
+            $parameters
         );
     }
 
-    public static function existsDisplayName($displayName, int $excludedId = null): bool
+    public static function existsDisplayName(string $displayName, int $excludedId = null): bool
     {
+        $where = 'p.display_name = :displayName';
+        $parameters = ['displayName' => $displayName];
+
+        if ($excludedId !== null) {
+            $where .= ' AND p.id != :excludedId';
+            $parameters['excludedId'] = $excludedId;
+        }
+
         return (bool) FrontendModel::getContainer()->get('database')->getVar(
             'SELECT 1
              FROM profiles AS p
-             WHERE p.id != ? AND p.display_name = ?
-             LIMIT 1',
-            [$excludedId, $displayName]
+             WHERE ' . $where . ' LIMIT 1',
+            $parameters
         );
     }
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

not all mysql servers support  this caused the check to see if the email address or display name was valid to fail sometimes

