### PR TITLE
[WIP] Fixed Analytics in Backend: return type was wrong

### DIFF
--- a/src/Backend/Modules/Analytics/GoogleClient/Connector.php
+++ b/src/Backend/Modules/Analytics/GoogleClient/Connector.php
@@ -4,6 +4,7 @@ namespace Backend\Modules\Analytics\GoogleClient;
 
 use Common\ModulesSettings;
 use Google_Service_Analytics;
+use Google_Service_Analytics_GaData;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -336,14 +337,14 @@ final class Connector
      * @param string $metrics A comma-separated list of Analytics metrics.
      * @param array $optParams Optional parameters.
      *
-     * @return array
+     * @return Google_Service_Analytics_GaData
      */
     private function getAnalyticsData(
         int $startDate,
         int $endDate,
         string $metrics,
         array $optParams = []
-    ): array {
+    ): Google_Service_Analytics_GaData {
         return $this->analytics->data_ga->get(
             'ga:' . $this->settings->get('Analytics', 'profile'),
             date('Y-m-d', $startDate),

--- a/src/Backend/Modules/Analytics/Js/Analytics.js
+++ b/src/Backend/Modules/Analytics/Js/Analytics.js
@@ -3,11 +3,17 @@
  */
 jsBackend.analytics =
 {
+	$chartPieChart: null,
+	$chartDoubleMetricPerDay: null,
     init: function()
     {
         // variables
-        $chartPieChart = $('#chartPieChart');
-        $chartDoubleMetricPerDay = $('#chartDoubleMetricPerDay');
+        jsBackend.analytics.$chartPieChart = $('#chartPieChart');
+        jsBackend.analytics.$chartDoubleMetricPerDay = $('#chartDoubleMetricPerDay');
+
+        jsBackend.analytics.charts.init();
+        jsBackend.analytics.chartPieChart.init();
+        jsBackend.analytics.chartDoubleMetricPerDay.init();
     }
 };
 
@@ -15,7 +21,7 @@ jsBackend.analytics.charts =
 {
     init: function()
     {
-        if ($chartPieChart.length > 0 || $chartDoubleMetricPerDay.length > 0)
+        if (jsBackend.analytics.$chartPieChart.length > 0 || jsBackend.analytics.$chartDoubleMetricPerDay.length > 0)
         {
             Highcharts.setOptions(
             {
@@ -42,7 +48,7 @@ jsBackend.analytics.chartPieChart =
 
     init: function()
     {
-        if ($chartPieChart.length > 0) { jsBackend.analytics.chartPieChart.create(); }
+        if (jsBackend.analytics.$chartPieChart.length > 0) { jsBackend.analytics.chartPieChart.create(); }
     },
 
     // add new chart
@@ -65,7 +71,7 @@ jsBackend.analytics.chartPieChart =
             });
         });
 
-        var containerWidth = $chartPieChart.width();
+        var containerWidth = jsBackend.analytics.$chartPieChart.width();
 
         jsBackend.analytics.chartPieChart.chart = new Highcharts.Chart(
         {
@@ -111,7 +117,7 @@ jsBackend.analytics.chartDoubleMetricPerDay =
 
     init: function()
     {
-        if ($chartDoubleMetricPerDay.length > 0) { jsBackend.analytics.chartDoubleMetricPerDay.create(); }
+        if (jsBackend.analytics.$chartDoubleMetricPerDay.length > 0) { jsBackend.analytics.chartDoubleMetricPerDay.create(); }
     },
 
     // add new chart


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

The return type is not `array`, but `Google_Service_Analytics_GaData`.

## Pull request description

GoogleClient Connector return type for getAnalyticsData was falsely set to `array`,
this must be `Google_Service_Analytics_GaData` instead.

