### PR TITLE
Add a button to go to the new password page since it was missing

### DIFF
--- a/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
+++ b/src/Frontend/Modules/Profiles/Layout/Templates/Settings.html.twig
@@ -120,6 +120,9 @@
         <div class="col-sm-offset-2 col-sm-6">
           <input class="btn btn-primary" type="submit" value="{{ 'lbl.Save'|trans|ucfirst }}" />
         </div>
+        <div class="col-sm-4">
+          <a href="{{ geturlforblock('Profiles', 'ChangePassword') }}" class="btn btn-default pull-right">{{ 'lbl.NewPassword'|trans|ucfirst }}</a>
+        </div>
       </div>
       {% endform %}
     </div>


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

There was no link anymore to the change password action in the profiles module. Because of this the only way for profiles to change their password was using the password reset action.

This pr adds the button to that page to the profile settings action

<img width="958" alt="screen shot 2017-10-05 at 10 22 16" src="https://user-images.githubusercontent.com/3634654/31217446-472f527e-a9b7-11e7-9033-db9bd12c984c.png">


