### PR TITLE
Use the correct alt texts for the fork cms logo

### DIFF
--- a/src/Backend/Core/Layout/Templates/header.html.twig
+++ b/src/Backend/Core/Layout/Templates/header.html.twig
@@ -1,7 +1,7 @@
 <div class="header clearfix">
   <div class="site-info">
     <div class="site-icon-block">
-      <img class="site-icon" src="/apple-touch-icon.png" alt="apple touch icon">
+      <img class="site-icon" src="/apple-touch-icon.png" alt="Fork CMS logo">
       {% if debug %}
         <div class="debug-mode">{{ 'lbl.DebugMode'|trans|uppercase }}</div>
       {% endif %}

--- a/src/Backend/Modules/Authentication/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Authentication/Layout/Templates/Index.html.twig
@@ -35,7 +35,7 @@
       <div class="col-md-6 col-md-offset-3">
         <div class="page-header page-header-login">
           <div class="site-info">
-            <img class="site-icon" src="/apple-touch-icon.png" alt="apple touch icon">
+            <img class="site-icon" src="/apple-touch-icon.png" alt="Fork CMS logo">
             <div class="site-text">
               <p class="site-title">{{ SITE_TITLE }}</p>
               <a class="site-url" data-url="{{ SITE_URL }}{{ prefixURL }}/{{ item.url }}{% if appendRevision %}?page_revision={{ item.revision_id }}{% endif %}" href="{{ SITE_URL }}{{ prefixURL }}/{{ item.url }}{% if appendRevision %}?page_revision={{ item.revision_id }}{% endif %}">


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Fixing the logo alt-texts for the people with screenreaders

