### PR TITLE
fix showing "data" in the marker

### DIFF
--- a/src/Frontend/Modules/Location/Layout/Templates/Index.html.twig
+++ b/src/Frontend/Modules/Location/Layout/Templates/Index.html.twig
@@ -17,7 +17,7 @@
     {% block block_marker_texts %}
       <div class="block-marker-texts">
         {% for locationItem in locationItems %}
-          <div data-role="fork-marker-text-container" data-map-id="{{ locationItem.id }}" class="hidden" itemscope itemtype="http://schema.org/Place">
+          <div data-role="fork-marker-data-container" data-map-id="{{ locationItem.id }}" class="hidden" itemscope itemtype="http://schema.org/Place">
             <div itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">
               <meta itemprop="latitude" content="{{ locationItem.lat }}" />
               <meta itemprop="longitude" content="{{ locationItem.lng }}" />


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Data wasn't being shown in the marker popup in the "Location Index Block"
