### PR TITLE
Add additional blocks for MediaLibrary module

### DIFF
--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig
@@ -94,5 +94,7 @@
       </div>
     </div>
   {% endblock %}
+
+  {% block widget_footer %}{% endblock %}
 </section>
 {% endif %}

--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig
@@ -40,7 +40,9 @@
         </figure>
       {% endfor %}
     </div>
+  {% endblock %}
 
+  {% block lightbox_template %}
     <!-- Root element of PhotoSwipe. Must have class pswp. -->
     <div class="pswp" role="dialog">
 

--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Listing.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Listing.html.twig
@@ -24,5 +24,7 @@
       </ul>
     </div>
   {% endblock %}
+
+  {% block widget_footer %}{% endblock %}
 </section>
 {% endif %}

--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneImage.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneImage.html.twig
@@ -22,5 +22,7 @@
         </figure>
       </div>
     {% endblock %}
+
+    {% block widget_footer %}{% endblock %}
   </section>
 {% endif %}

--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneRandomImage.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneRandomImage.html.twig
@@ -22,5 +22,7 @@
         </figure>
       </div>
     {% endblock %}
+
+    {% block widget_footer %}{% endblock %}
   </section>
 {% endif %}

--- a/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Slider.html.twig
+++ b/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Slider.html.twig
@@ -24,5 +24,7 @@
       {% endfor %}
     </div>
   {% endblock %}
+
+  {% block widget_footer %}{% endblock %}
 </section>
 {% endif %}


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

* Added missing "heading/footer" blocks in the "MediaLibrary module" templates.
* In `Lightbox.html.twig`, divided into `block_body` and `lightbox_template`.
