### PR TITLE
Page data no longer used

### DIFF
--- a/src/Backend/Modules/Pages/Engine/CacheBuilder.php
+++ b/src/Backend/Modules/Pages/Engine/CacheBuilder.php
@@ -148,6 +148,7 @@ class CacheBuilder
             'hidden' => (bool) $page['hidden'],
             'extra_blocks' => null,
             'has_children' => (bool) $page['has_children'],
+            'data' => $page['data']
         ];
 
         $pageData['extra_blocks'] = $this->getPageExtraBlocks($page);


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description
This was no longer fetched from the database, this is required for the navigation to hide the page in the nav if auth required.