### PR TITLE
Add a comment to clarify where custom Symfony routes should be placed

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,5 @@
+# Add your custom routes for Symfony bundles above this line
+
 _liip_imagine:
     resource: "@LiipImagineBundle/Resources/config/routing.xml"
 backend:


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

Some people have issues with Symfony bundles because they place their routes below the Fork CMS routes. This PR shows the correct position for their custom routes.

