### PR TITLE
[WIP] Sitemap generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "spoon/library": "^3.0",
         "league/flysystem-aws-s3-v3": "^1.0.13",
         "league/flysystem-cached-adapter": "^1.0.6",
-        "pimple/pimple": "^3.2"
+        "pimple/pimple": "^3.2",
+        "thepixeldeveloper/sitemap": "^4.5"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e61d3f75fbcb5b0412b6e5c72721db89",
+    "content-hash": "fbfc136ff2b514d58b2d26e8f5342599",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -3888,6 +3888,50 @@
                 "framework"
             ],
             "time": "2017-08-01T10:26:30+00:00"
+        },
+        {
+            "name": "thepixeldeveloper/sitemap",
+            "version": "4.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThePixelDeveloper/Sitemap.git",
+                "reference": "65063910023c62cb4e3293c64a75acfe06189866"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThePixelDeveloper/Sitemap/zipball/65063910023c62cb4e3293c64a75acfe06189866",
+                "reference": "65063910023c62cb4e3293c64a75acfe06189866",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Thepixeldeveloper\\Sitemap\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathew Davies",
+                    "homepage": "http://mathew-davies.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "XML sitemap generation",
+            "keywords": [
+                "Sitemap",
+                "xml"
+            ],
+            "time": "2017-10-02T20:06:17+00:00"
         },
         {
             "name": "tijsverkoyen/akismet",

--- a/src/Backend/Modules/Blog/Actions/Index.php
+++ b/src/Backend/Modules/Blog/Actions/Index.php
@@ -10,6 +10,8 @@ use Backend\Core\Engine\Model as BackendModel;
 use Backend\Core\Engine\DataGridDatabase as BackendDataGridDatabase;
 use Backend\Core\Engine\DataGridFunctions as BackendDataGridFunctions;
 use Backend\Modules\Blog\Engine\Model as BackendBlogModel;
+use Backend\Modules\SitemapGenerator\Domain\SitemapItemChanged;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * This is the index-action (default), it will display the overview of blog posts

--- a/src/Backend/Modules/Settings/Js/Settings.js
+++ b/src/Backend/Modules/Settings/Js/Settings.js
@@ -98,7 +98,7 @@ jsBackend.settings =
         $statusAlert.toggleClass('hidden');
 
         // start the dot animation
-        var dotAnimation = jsBackend.settings.startDotAnimation();
+        var dotAnimation = jsBackend.settings.startDotAnimation($statusAlert);
 
         // start the action clearing
         $.ajax(
@@ -129,7 +129,7 @@ jsBackend.settings =
                 complete: function()
                 {
                     // stop the dot animation
-                    jsBackend.settings.stopDotAnimation(dotAnimation);
+                    jsBackend.settings.stopDotAnimation(dotAnimation, $statusAlert);
                     // hide the status
                     $statusAlert.toggleClass('hidden');
                     // reset the button
@@ -140,7 +140,7 @@ jsBackend.settings =
         );
     },
 
-    startDotAnimation: function (speed, dotAmount)
+    startDotAnimation: function ($element, speed, dotAmount)
     {
         // set the default speed
         if (!speed) {
@@ -152,7 +152,7 @@ jsBackend.settings =
             dotAmount = 3;
         }
 
-        var $dotsAnimation = $('[data-role="fork-dots-animation"]');
+        var $dotsAnimation = $element.find('[data-role="fork-dots-animation"]');
 
         // clear the initial content
         $dotsAnimation.text('');
@@ -170,10 +170,10 @@ jsBackend.settings =
         )
     },
 
-    stopDotAnimation: function (animation)
+    stopDotAnimation: function (animation, $element)
     {
         // clear the text
-        $('[data-role="fork-dots-animation"]').text('');
+        $element.find('[data-role="fork-dots-animation"]').text('');
 
         // clear the interval
         clearInterval(animation);

--- a/src/Backend/Modules/Settings/Js/Settings.js
+++ b/src/Backend/Modules/Settings/Js/Settings.js
@@ -15,6 +15,7 @@ jsBackend.settings =
 
         $('#testEmailConnection').on('click', jsBackend.settings.testEmailConnection);
         $('[data-role="fork-clear-cache"]').on('click', jsBackend.settings.clearCache);
+        $('[data-role="fork-generate-sitemap"]').on('click', jsBackend.settings.generateSitemap);
 
         $('#activeLanguages input:checkbox').on('change', jsBackend.settings.changeActiveLanguage).change();
     },
@@ -135,6 +136,57 @@ jsBackend.settings =
                     // reset the button
                     $clearCacheButton.on('click', jsBackend.settings.clearCache);
                     $clearCacheButton.attr('disabled', false);
+                }
+            }
+        );
+    },
+
+    generateSitemap: function (e)
+    {
+        // prevent default
+        e.preventDefault();
+
+        // save the button for later use
+        var $generateSitemapButton = $('[data-role="fork-generate-sitemap"]');
+
+        // disable the handler to prevent sending too many requests
+        $generateSitemapButton.off('click', jsBackend.settings.generateSitemap);
+        $generateSitemapButton.attr('disabled', 'disabled');
+
+        // display the status alert
+        var $statusAlert = $('[data-role="fork-generate-sitemap-status"]');
+        $statusAlert.toggleClass('hidden');
+
+        // start the dot animation
+        var dotAnimation = jsBackend.settings.startDotAnimation($statusAlert);
+
+        $.ajax(
+            {
+                timeout: 60000, // generating the sitemap might take a while
+                data: {
+                    fork: {
+                        module: 'SitemapGenerator',
+                        action: 'GenerateSitemap'
+                    }
+                },
+                success: function(data)
+                {
+                    jsBackend.messages.add('success', jsBackend.locale.msg('SitemapGenerated'));
+                },
+                error: function()
+                {
+                    // show error in case something goes wrong with the call itself
+                    jsBackend.messages.add('danger', jsBackend.locale.err('SomethingWentWrong'));
+                },
+                complete: function()
+                {
+                    // stop the dot animation
+                    jsBackend.settings.stopDotAnimation(dotAnimation, $statusAlert);
+                    // hide the status
+                    $statusAlert.toggleClass('hidden');
+                    // reset the button
+                    $generateSitemapButton.on('click', jsBackend.settings.generateSitemap);
+                    $generateSitemapButton.attr('disabled', false);
                 }
             }
         );

--- a/src/Backend/Modules/Settings/Layout/Templates/Tools.html.twig
+++ b/src/Backend/Modules/Settings/Layout/Templates/Tools.html.twig
@@ -20,4 +20,24 @@
       </div>
     </div>
   </div>
+
+  <div class="row fork-module-content">
+    <div class="col-md-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">
+            {{ 'lbl.GenerateSitemap'|trans|ucfirst }}
+          </h3>
+        </div>
+        <div class="panel-body">
+          <p class="help-block">{{ 'msg.GenerateSitemap'|trans }}</p>
+          <a href="#" data-role="fork-generate-sitemap" class="btn btn-primary">{{ 'lbl.GenerateSitemap'|trans|ucfirst }}</a>
+          <div class="alert alert-warning hidden" role="alert" data-role="fork-generate-sitemap-status">
+            {{ 'msg.GeneratingSitemap'|trans }}
+            <span data-role="fork-dots-animation"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/src/Backend/Modules/SitemapGenerator/Ajax/GenerateSitemap.php
+++ b/src/Backend/Modules/SitemapGenerator/Ajax/GenerateSitemap.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Ajax;
+
+use Backend\Core\Engine\Base\AjaxAction;
+use Backend\Modules\SitemapGenerator\Domain\Command\GenerateSitemap as GenerateSitemapCommand;
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+
+class GenerateSitemap extends AjaxAction
+{
+    public function execute(): void
+    {
+        parent::execute();
+
+        try {
+            $this->get('command_bus')->handle(new GenerateSitemapCommand());
+        } catch (Exception $exception) {
+            $this->output(
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                [],
+                $exception->getMessage()
+            );
+        }
+
+        $this->output(Response::HTTP_OK);
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Config.php
+++ b/src/Backend/Modules/SitemapGenerator/Config.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator;
+
+use Backend\Core\Engine\Base\Config as BaseConfig;
+
+class Config extends BaseConfig
+{
+}

--- a/src/Backend/Modules/SitemapGenerator/DependencyInjection/SitemapGeneratorExtension.php
+++ b/src/Backend/Modules/SitemapGenerator/DependencyInjection/SitemapGeneratorExtension.php
@@ -4,14 +4,21 @@ namespace Backend\Modules\SitemapGenerator\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
-class SitemapGeneratorExtension extends Extension
+class SitemapGeneratorExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('doctrine.yml');
     }
 }

--- a/src/Backend/Modules/SitemapGenerator/DependencyInjection/SitemapGeneratorExtension.php
+++ b/src/Backend/Modules/SitemapGenerator/DependencyInjection/SitemapGeneratorExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+class SitemapGeneratorExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/Command/GenerateSitemap.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/Command/GenerateSitemap.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Domain\Command;
+
+final class GenerateSitemap
+{
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/Command/GenerateSitemapHandler.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/Command/GenerateSitemapHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Domain\Command;
+
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntry;
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntryRepository;
+use Symfony\Component\Filesystem\Filesystem;
+use Thepixeldeveloper\Sitemap\Output;
+use Thepixeldeveloper\Sitemap\Url;
+use Thepixeldeveloper\Sitemap\Urlset;
+
+final class GenerateSitemapHandler
+{
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var SitemapEntryRepository */
+    private $sitemapEntryRepository;
+
+    /** @var string */
+    private $rootPath;
+
+    public function __construct(
+        Filesystem $filesystem,
+        SitemapEntryRepository $sitemapEntryRepository,
+        string $rootPath
+    ) {
+        $this->filesystem = $filesystem;
+        $this->sitemapEntryRepository = $sitemapEntryRepository;
+        $this->rootPath = $rootPath;
+    }
+
+    public function handle(GenerateSitemap $command): void
+    {
+        /** @var SitemapEntry[] $entries */
+        $entries = $this->sitemapEntryRepository->findAll();
+
+        $urlSet = new Urlset();
+
+        foreach ($entries as $entry) {
+            $urlSet->addUrl(new Url($entry->getUrl()));
+        }
+
+        $output = new Output();
+
+        $this->filesystem->dumpFile($this->rootPath . '/sitemap.xml', $output->getOutput($urlSet));
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
@@ -6,7 +6,7 @@ use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="Backend\Modules\SitemapGenerator\Domain\SitemapEntryRepository")
  * @ORM\HasLifecycleCallbacks
  */
 class SitemapEntry

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Domain;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\HasLifecycleCallbacks
+ */
+class SitemapEntry
+{
+    /**
+     * @var string
+     *
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    private $module;
+
+    /**
+     * @var string
+     *
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    private $entity;
+
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
+    private $otherId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    private $slug;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string")
+     */
+    private $url;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
+    private $createdOn;
+
+    /**
+     * @var DateTime
+     *
+     * @ORM\Column(type="datetime")
+     */
+    private $editedOn;
+
+    public function __construct(string $module, string $entity, int $otherId, string $slug, string $url)
+    {
+        $this->module = $module;
+        $this->entity = $entity;
+        $this->otherId = $otherId;
+        $this->slug = $slug;
+        $this->url = $url;
+    }
+
+    public function getModule(): string
+    {
+        return $this->module;
+    }
+
+    public function getEntity(): string
+    {
+        return $this->entity;
+    }
+
+    public function getOtherId(): int
+    {
+        return $this->otherId;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getCreatedOn(): DateTime
+    {
+        return $this->createdOn;
+    }
+
+    public function getEditedOn(): DateTime
+    {
+        return $this->editedOn;
+    }
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function prePersist()
+    {
+        $this->createdOn = $this->editedOn = new DateTime();
+    }
+
+    /**
+     * @ORM\PreUpdate()
+     */
+    public function preUpdate()
+    {
+        $this->editedOn = new DateTime();
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
@@ -83,6 +83,12 @@ class SitemapEntry
         );
     }
 
+    public function update(string $slug, string $url): void
+    {
+        $this->slug = $slug;
+        $this->url = $url;
+    }
+
     public function getModule(): string
     {
         return $this->module;

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
@@ -72,6 +72,17 @@ class SitemapEntry
         $this->url = $url;
     }
 
+    public static function fromEvent(SitemapItemChanged $event): self
+    {
+        return new self(
+            $event->getModule(),
+            $event->getEntity(),
+            $event->getId(),
+            $event->getSlug(),
+            $event->getUrl()
+        );
+    }
+
     public function getModule(): string
     {
         return $this->module;

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntry.php
@@ -38,6 +38,14 @@ class SitemapEntry
     /**
      * @var string
      *
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    private $language;
+
+    /**
+     * @var string
+     *
      * @ORM\Column(type="string")
      */
     private $slug;
@@ -63,11 +71,18 @@ class SitemapEntry
      */
     private $editedOn;
 
-    public function __construct(string $module, string $entity, int $otherId, string $slug, string $url)
-    {
+    public function __construct(
+        string $module,
+        string $entity,
+        int $otherId,
+        string $language,
+        string $slug,
+        string $url
+    ) {
         $this->module = $module;
         $this->entity = $entity;
         $this->otherId = $otherId;
+        $this->language = $language;
         $this->slug = $slug;
         $this->url = $url;
     }
@@ -78,6 +93,7 @@ class SitemapEntry
             $event->getModule(),
             $event->getEntity(),
             $event->getId(),
+            $event->getLanguage(),
             $event->getSlug(),
             $event->getUrl()
         );
@@ -102,6 +118,11 @@ class SitemapEntry
     public function getOtherId(): int
     {
         return $this->otherId;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
     }
 
     public function getSlug(): string

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntryRepository.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntryRepository.php
@@ -9,11 +9,12 @@ class SitemapEntryRepository extends EntityRepository
     public function add(SitemapEntry $sitemapEntry): void
     {
         $this->getEntityManager()->persist($sitemapEntry);
+        $this->getEntityManager()->flush($sitemapEntry);
     }
 
-    public function update(SitemapEntry $sitemapEntry): void
+    public function update(): void
     {
-        $this->getEntityManager()->flush($sitemapEntry);
+        $this->getEntityManager()->flush();
     }
 
     public function getChildren(SitemapEntry $parent): array

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntryRepository.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapEntryRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Domain;
+
+use Doctrine\ORM\EntityRepository;
+
+class SitemapEntryRepository extends EntityRepository
+{
+    public function add(SitemapEntry $sitemapEntry): void
+    {
+        $this->getEntityManager()->persist($sitemapEntry);
+    }
+
+    public function update(SitemapEntry $sitemapEntry): void
+    {
+        $this->getEntityManager()->flush($sitemapEntry);
+    }
+
+    public function getChildren(SitemapEntry $parent): array
+    {
+        return $this->createQueryBuilder('se')
+            ->select('se')
+            ->where('se.url LIKE :parentUrl')
+            ->setParameter('parentUrl', $parent->getUrl() . '%')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
@@ -6,6 +6,8 @@ use Symfony\Component\EventDispatcher\Event;
 
 class SitemapItemChanged extends Event
 {
+    const EVENT_NAME = 'sitemap.item_changed';
+
     /** @var string */
     private $module;
 

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Domain;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class SitemapItemChanged extends Event
+{
+    /** @var string */
+    private $module;
+
+    /** @var string */
+    private $entity;
+
+    /** @var int */
+    private $id;
+
+    /** @var string */
+    private $slug;
+
+    /** @var string */
+    private $url;
+
+    public function __construct(string $module, string $entity, int $id, string $slug, string$url)
+    {
+        $this->module = $module;
+        $this->entity = $entity;
+        $this->id = $id;
+        $this->slug = $slug;
+        $this->url = $url;
+    }
+
+    public function getModule(): string
+    {
+        return $this->module;
+    }
+
+    public function getEntity(): string
+    {
+        return $this->entity;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
+++ b/src/Backend/Modules/SitemapGenerator/Domain/SitemapItemChanged.php
@@ -18,16 +18,20 @@ class SitemapItemChanged extends Event
     private $id;
 
     /** @var string */
+    private $language;
+
+    /** @var string */
     private $slug;
 
     /** @var string */
     private $url;
 
-    public function __construct(string $module, string $entity, int $id, string $slug, string$url)
+    public function __construct(string $module, string $entity, int $id, string $language, string $slug, string$url)
     {
         $this->module = $module;
         $this->entity = $entity;
         $this->id = $id;
+        $this->language = $language;
         $this->slug = $slug;
         $this->url = $url;
     }
@@ -45,6 +49,11 @@ class SitemapItemChanged extends Event
     public function getId(): int
     {
         return $this->id;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
     }
 
     public function getSlug(): string

--- a/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
+++ b/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\EventListener;
+
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntry;
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntryRepository;
+use Backend\Modules\SitemapGenerator\Domain\SitemapItemChanged;
+
+final class SitemapItemChangedListener
+{
+    /** @var SitemapEntryRepository */
+    private $sitemapEntryRepository;
+
+    public function __construct(SitemapEntryRepository $sitemapEntryRepository)
+    {
+        $this->sitemapEntryRepository = $sitemapEntryRepository;
+    }
+
+    public function onSitemapItemChanged(SitemapItemChanged $event)
+    {
+        $currentItem = $this->getCurrentItem($event);
+
+        if (!$currentItem instanceof SitemapEntry) {
+            $this->sitemapEntryRepository->add(SitemapEntry::fromEvent($event));
+
+            return;
+        }
+
+        $this->update($currentItem, $event);
+    }
+
+    private function update(SitemapEntry $currentItem, SitemapItemChanged $event): void
+    {
+        /** @var SitemapEntry[] $children */
+        $children = $this->sitemapEntryRepository->getChildren($currentItem);
+
+        foreach ($children as $child) {
+            $newUrl = str_replace($currentItem->getUrl(), $event->getUrl(), $child->getUrl());
+            $child->update(
+                $child->getSlug(),
+                $newUrl
+            );
+
+            $this->sitemapEntryRepository->update($child);
+        }
+
+        $currentItem->update(
+            $event->getSlug(),
+            $event->getUrl()
+        );
+
+        $this->sitemapEntryRepository->update($currentItem);
+    }
+
+    private function getCurrentItem(SitemapItemChanged $event): ?SitemapEntry
+    {
+        return $this->sitemapEntryRepository->findOneBy(
+            [
+                'module' => $event->getModule(),
+                'entity' => $event->getEntity(),
+                'otherId' => $event->getId(),
+            ]
+        );
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
+++ b/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
@@ -40,8 +40,6 @@ final class SitemapItemChangedListener
                 $child->getSlug(),
                 $newUrl
             );
-
-            $this->sitemapEntryRepository->update($child);
         }
 
         $currentItem->update(
@@ -49,7 +47,7 @@ final class SitemapItemChangedListener
             $event->getUrl()
         );
 
-        $this->sitemapEntryRepository->update($currentItem);
+        $this->sitemapEntryRepository->update();
     }
 
     private function getCurrentItem(SitemapItemChanged $event): ?SitemapEntry

--- a/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
+++ b/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
@@ -2,18 +2,24 @@
 
 namespace Backend\Modules\SitemapGenerator\EventListener;
 
+use Backend\Modules\SitemapGenerator\Domain\Command\GenerateSitemap;
 use Backend\Modules\SitemapGenerator\Domain\SitemapEntry;
 use Backend\Modules\SitemapGenerator\Domain\SitemapEntryRepository;
 use Backend\Modules\SitemapGenerator\Domain\SitemapItemChanged;
+use SimpleBus\Message\Bus\MessageBus;
 
 final class SitemapItemChangedListener
 {
     /** @var SitemapEntryRepository */
     private $sitemapEntryRepository;
 
-    public function __construct(SitemapEntryRepository $sitemapEntryRepository)
+    /** @var MessageBus */
+    private $commandBus;
+
+    public function __construct(SitemapEntryRepository $sitemapEntryRepository, MessageBus $commandBus)
     {
         $this->sitemapEntryRepository = $sitemapEntryRepository;
+        $this->commandBus = $commandBus;
     }
 
     public function onSitemapItemChanged(SitemapItemChanged $event)
@@ -48,6 +54,8 @@ final class SitemapItemChangedListener
         );
 
         $this->sitemapEntryRepository->update();
+
+        $this->commandBus->handle(new GenerateSitemap());
     }
 
     private function getCurrentItem(SitemapItemChanged $event): ?SitemapEntry

--- a/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
+++ b/src/Backend/Modules/SitemapGenerator/EventListener/SitemapItemChangedListener.php
@@ -57,6 +57,7 @@ final class SitemapItemChangedListener
                 'module' => $event->getModule(),
                 'entity' => $event->getEntity(),
                 'otherId' => $event->getId(),
+                'language' => $event->getLanguage(),
             ]
         );
     }

--- a/src/Backend/Modules/SitemapGenerator/Installer/Data/locale.xml
+++ b/src/Backend/Modules/SitemapGenerator/Installer/Data/locale.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale>
+  <Backend>
+    <Core>
+      <item type="label" name="SitemapGenerator">
+        <translation language="nl"><![CDATA[automatische sitemap generator]]></translation>
+        <translation language="en"><![CDATA[automatic sitemap generator]]></translation>
+        <translation language="hu"><![CDATA[automatikus webhelytérkép-generátor]]></translation>
+        <translation language="it"><![CDATA[generatore di sitemap automatico]]></translation>
+        <translation language="ru"><![CDATA[автоматический генератор карты сайта]]></translation>
+        <translation language="zh"><![CDATA[自动站点地图生成器]]></translation>
+        <translation language="de"><![CDATA[automatischer Sitemap-Generator]]></translation>
+        <translation language="fr"><![CDATA[générateur de sitemap automatique]]></translation>
+        <translation language="es"><![CDATA[generador de sitemap automático]]></translation>
+        <translation language="uk"><![CDATA[автоматичний генератор Sitemap]]></translation>
+        <translation language="lt"><![CDATA[automatinis svetainės schemos generatorius]]></translation>
+        <translation language="sv"><![CDATA[automatisk sitemapgenerator]]></translation>
+        <translation language="el"><![CDATA[αυτόματη γεννήτρια χάρτη]]></translation>
+      </item>
+    </Core>
+  </Backend>
+</locale>

--- a/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
+++ b/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
@@ -2,12 +2,15 @@
 
 namespace Backend\Modules\SitemapGenerator\Installer;
 
+use Backend\Core\Engine\Model;
 use Backend\Core\Installer\ModuleInstaller;
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntry;
 
 class Installer extends ModuleInstaller
 {
     public function install(): void
     {
         $this->addModule('SitemapGenerator');
+        Model::get('fork.entity.create_schema')->forEntityClass(SitemapEntry::class);
     }
 }

--- a/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
+++ b/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
@@ -11,6 +11,7 @@ class Installer extends ModuleInstaller
     public function install(): void
     {
         $this->addModule('SitemapGenerator');
+        $this->importLocale(__DIR__ . '/Data/locale.xml');
         Model::get('fork.entity.create_schema')->forEntityClass(SitemapEntry::class);
     }
 }

--- a/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
+++ b/src/Backend/Modules/SitemapGenerator/Installer/Installer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Installer;
+
+use Backend\Core\Installer\ModuleInstaller;
+
+class Installer extends ModuleInstaller
+{
+    public function install(): void
+    {
+        $this->addModule('SitemapGenerator');
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/commands.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/commands.yml
@@ -1,0 +1,9 @@
+services:
+    sitemap_generator.handler.generate_sitemap:
+        class: Backend\Modules\SitemapGenerator\Domain\Command\GenerateSitemapHandler
+        arguments:
+            - "@filesystem"
+            - "@sitemap_generator.sitemap_entry_repository"
+            - "%site.path_www%"
+        tags:
+            - { name: command_handler, handles: Backend\Modules\SitemapGenerator\Domain\Command\GenerateSitemap }

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/doctrine.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/doctrine.yml
@@ -1,0 +1,9 @@
+doctrine:
+  orm:
+    mappings:
+      sitemap_entry:
+        type: annotation
+        is_bundle: false
+        dir: "%kernel.project_dir%/src/Backend/Modules/SitemapGenerator/Domain"
+        alias: SitemapGeneratorSitemapEntry
+        prefix: Backend\Modules\SitemapGenerator\Domain

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/eventListeners.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/eventListeners.yml
@@ -1,0 +1,7 @@
+services:
+  sitemap_generator.listener.item_changed:
+    class: Backend\Modules\SitemapGenerator\EventListener\SitemapItemChangedListener
+    arguments:
+      - "@sitemap_generator.sitemap_entry_repository"
+    tags:
+      - { name: kernel.event_listener, event: sitemap.item_changed, method: onSitemapItemChanged }

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/eventListeners.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/eventListeners.yml
@@ -3,5 +3,6 @@ services:
     class: Backend\Modules\SitemapGenerator\EventListener\SitemapItemChangedListener
     arguments:
       - "@sitemap_generator.sitemap_entry_repository"
+      - "@command_bus"
     tags:
       - { name: kernel.event_listener, event: sitemap.item_changed, method: onSitemapItemChanged }

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/repositories.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/repositories.yml
@@ -1,0 +1,6 @@
+services:
+    sitemap_generator.sitemap_entry_repository:
+        class: Backend\Modules\SitemapGenerator\Domain\SitemapEntryRepository
+        factory: ["@doctrine.orm.entity_manager", getRepository]
+        arguments:
+            - Backend\Modules\SitemapGenerator\Domain\SitemapEntry

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
@@ -1,0 +1,1 @@
+services:

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
@@ -1,1 +1,2 @@
-services:
+imports:
+    - { resource: repositories.yml }

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
@@ -1,2 +1,3 @@
 imports:
+    - { resource: eventListeners.yml }
     - { resource: repositories.yml }

--- a/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
+++ b/src/Backend/Modules/SitemapGenerator/Resources/config/services.yml
@@ -1,3 +1,4 @@
 imports:
+    - { resource: commands.yml }
     - { resource: eventListeners.yml }
     - { resource: repositories.yml }

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
@@ -11,9 +11,20 @@ class SitemapEntryTest extends TestCase
     /** @var SitemapItemChanged */
     protected $sitemapItemChangedEvent;
 
+    /** @var SitemapEntry */
+    protected $baseSitemapEntry;
+
     public function setUp(): void
     {
         $this->sitemapItemChangedEvent = new SitemapItemChanged(
+            'Blog',
+            'BlogPost',
+            23,
+            'foo-bar',
+            '/en/news/detail/foo-bar'
+        );
+
+        $this->baseSitemapEntry = new SitemapEntry(
             'Blog',
             'BlogPost',
             23,
@@ -24,33 +35,25 @@ class SitemapEntryTest extends TestCase
 
     public function testConstructor(): void
     {
-        $sitemapEntry = new SitemapEntry(
-            'Blog',
-            'BlogPost',
-            23,
-            'foo-bar',
-            '/en/news/detail/foo-bar'
-        );
-
         $this->assertSame(
             'Blog',
-            $sitemapEntry->getModule()
+            $this->baseSitemapEntry->getModule()
         );
         $this->assertSame(
             'BlogPost',
-            $sitemapEntry->getEntity()
+            $this->baseSitemapEntry->getEntity()
         );
         $this->assertSame(
             23,
-            $sitemapEntry->getOtherId()
+            $this->baseSitemapEntry->getOtherId()
         );
         $this->assertSame(
             'foo-bar',
-            $sitemapEntry->getSlug()
+            $this->baseSitemapEntry->getSlug()
         );
         $this->assertSame(
             '/en/news/detail/foo-bar',
-            $sitemapEntry->getUrl()
+            $this->baseSitemapEntry->getUrl()
         );
     }
 

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
@@ -82,4 +82,33 @@ class SitemapEntryTest extends TestCase
             $sitemapEntry->getUrl()
         );
     }
+
+    public function testUpdate():void
+    {
+        $this->baseSitemapEntry->update(
+            'bar-foo',
+            '/en/news/detail/bar-foo'
+        );
+
+        $this->assertSame(
+            'Blog',
+            $this->baseSitemapEntry->getModule()
+        );
+        $this->assertSame(
+            'BlogPost',
+            $this->baseSitemapEntry->getEntity()
+        );
+        $this->assertSame(
+            23,
+            $this->baseSitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            'bar-foo',
+            $this->baseSitemapEntry->getSlug()
+        );
+        $this->assertSame(
+            '/en/news/detail/bar-foo',
+            $this->baseSitemapEntry->getUrl()
+        );
+    }
 }

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Tests\Domain;
+
+use Backend\Modules\SitemapGenerator\Domain\SitemapEntry;
+use Backend\Modules\SitemapGenerator\Domain\SitemapItemChanged;
+use PHPUnit\Framework\TestCase;
+
+class SitemapEntryTest extends TestCase
+{
+    /** @var SitemapItemChanged */
+    protected $sitemapItemChangedEvent;
+
+    public function setUp(): void
+    {
+        $this->sitemapItemChangedEvent = new SitemapItemChanged(
+            'Blog',
+            'BlogPost',
+            23,
+            'foo-bar',
+            '/en/news/detail/foo-bar'
+        );
+    }
+
+    public function testConstructor(): void
+    {
+        $sitemapEntry = new SitemapEntry(
+            'Blog',
+            'BlogPost',
+            23,
+            'foo-bar',
+            '/en/news/detail/foo-bar'
+        );
+
+        $this->assertSame(
+            'Blog',
+            $sitemapEntry->getModule()
+        );
+        $this->assertSame(
+            'BlogPost',
+            $sitemapEntry->getEntity()
+        );
+        $this->assertSame(
+            23,
+            $sitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            'foo-bar',
+            $sitemapEntry->getSlug()
+        );
+        $this->assertSame(
+            '/en/news/detail/foo-bar',
+            $sitemapEntry->getUrl()
+        );
+    }
+
+    public function testStaticCreator(): void
+    {
+        $sitemapEntry = SitemapEntry::fromEvent($this->sitemapItemChangedEvent);
+
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getModule(),
+            $sitemapEntry->getModule()
+        );
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getEntity(),
+            $sitemapEntry->getEntity()
+        );
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getId(),
+            $sitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getSlug(),
+            $sitemapEntry->getSlug()
+        );
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getUrl(),
+            $sitemapEntry->getUrl()
+        );
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapEntryTest.php
@@ -20,6 +20,7 @@ class SitemapEntryTest extends TestCase
             'Blog',
             'BlogPost',
             23,
+            'en',
             'foo-bar',
             '/en/news/detail/foo-bar'
         );
@@ -28,6 +29,7 @@ class SitemapEntryTest extends TestCase
             'Blog',
             'BlogPost',
             23,
+            'en',
             'foo-bar',
             '/en/news/detail/foo-bar'
         );
@@ -46,6 +48,10 @@ class SitemapEntryTest extends TestCase
         $this->assertSame(
             23,
             $this->baseSitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            'en',
+            $this->baseSitemapEntry->getLanguage()
         );
         $this->assertSame(
             'foo-bar',
@@ -72,6 +78,10 @@ class SitemapEntryTest extends TestCase
         $this->assertSame(
             $this->sitemapItemChangedEvent->getId(),
             $sitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            $this->sitemapItemChangedEvent->getLanguage(),
+            $sitemapEntry->getLanguage()
         );
         $this->assertSame(
             $this->sitemapItemChangedEvent->getSlug(),
@@ -101,6 +111,10 @@ class SitemapEntryTest extends TestCase
         $this->assertSame(
             23,
             $this->baseSitemapEntry->getOtherId()
+        );
+        $this->assertSame(
+            'en',
+            $this->baseSitemapEntry->getLanguage()
         );
         $this->assertSame(
             'bar-foo',

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapItemChangedTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapItemChangedTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Backend\Modules\SitemapGenerator\Tests\Domain;
+
+use Backend\Modules\SitemapGenerator\Domain\SitemapItemChanged;
+use PHPUnit\Framework\TestCase;
+
+class SitemapItemChangedTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $event = new SitemapItemChanged(
+            'Blog',
+            'BlogPost',
+            23,
+            'foo-bar',
+            '/en/news/detail/foo-bar'
+        );
+
+        $this->assertSame(
+            'Blog',
+            $event->getModule()
+        );
+        $this->assertSame(
+            'BlogPost',
+            $event->getEntity()
+        );
+        $this->assertSame(
+            23,
+            $event->getId()
+        );
+        $this->assertSame(
+            'foo-bar',
+            $event->getSlug()
+        );
+        $this->assertSame(
+            '/en/news/detail/foo-bar',
+            $event->getUrl()
+        );
+    }
+}

--- a/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapItemChangedTest.php
+++ b/src/Backend/Modules/SitemapGenerator/Tests/Domain/SitemapItemChangedTest.php
@@ -13,6 +13,7 @@ class SitemapItemChangedTest extends TestCase
             'Blog',
             'BlogPost',
             23,
+            'en',
             'foo-bar',
             '/en/news/detail/foo-bar'
         );
@@ -28,6 +29,10 @@ class SitemapItemChangedTest extends TestCase
         $this->assertSame(
             23,
             $event->getId()
+        );
+        $this->assertSame(
+            'en',
+            $event->getLanguage()
         );
         $this->assertSame(
             'foo-bar',

--- a/src/Backend/Modules/SitemapGenerator/info.xml
+++ b/src/Backend/Modules/SitemapGenerator/info.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+  <name>SitemapGenerator</name>
+  <version>1.0.0</version>
+  <requirements>
+    <minimum_version>5.0.5</minimum_version>
+  </requirements>
+  <description>
+    <![CDATA[
+      This module houses an event to throw every time something about your website changes.
+      It also houses a listener which will re-generate the sitemap.xml file every time the event is thrown.
+    ]]>
+  </description>
+  <authors>
+    <author>
+      <name><![CDATA[Stijn Vrolijk]]></name>
+      <url><![CDATA[https://www.sumocoders.be]]></url>
+    </author>
+  </authors>
+</module>


### PR DESCRIPTION
## Type

- Feature

## Pull request description

This feature will create a `sitemap.xml` file for your Fork CMS website. It works by dispatching events when certain items (items that have their own URL, specifically) change, thus altering the  sitemap. 

**This is currently a work in progress.**

The basics are there but I want might to investigate some further options such as automatic dispatching of events based on the Meta entity.

## How it works

Easy, in your controllers/command handlers just do something like this:
```
        /** @var EventDispatcher $dispatcher */
        $dispatcher = $this->get('event_dispatcher');
        $dispatcher->dispatch(SitemapItemChanged::EVENT_NAME, new SitemapItemChanged(
            'Pages', //Module
            'Page', //Entity
            1, //Id
            'en', //Language
            'news', //Slug
            '/en/news' //Url
        ));
```

The generator will handle the rest.

## TODO

- [ ] Add the sitemap to the robots.txt file
- [ ] Make sure the sitemap doesn't end up in git
- [ ] Take a look at Hreflang connections between pages
- [ ] Try to implement lastmod
- [ ] Make sure the sitemap doesn't get overwritten when deploying
- [ ] How are we going to handle the sitemap on a fresh install? 
- [ ] Add event dispatches to the core modules' CRUD
- [ ] ... ?
