### PR TITLE
Fix bootstrap tabs html5 form validation

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -1211,6 +1211,19 @@ jsBackend.forms =
         jsBackend.forms.tagsInput();
         jsBackend.forms.meta();
         jsBackend.forms.datePicker();
+        jsBackend.forms.bootstrapTabFormValidation();
+    },
+
+    bootstrapTabFormValidation: function () {
+        $('.tab-pane input, .tab-pane textarea, .tab-pane select').on('invalid', function () {
+            var $invalidField = $(this)
+            // Find the tab-pane that this element is inside, and get the id
+            var invalidTabId = $invalidField.closest('.tab-pane').attr('id')
+
+            // Find the link that corresponds to the pane and have it show
+            $('a[href=#' + invalidTabId + '], [data-target=#' + invalidTabId + ']').tab('show')
+            $invalidField.focus()
+        })
     },
 
     meta: function() {


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

If the first invalid field is in an inactive tab the user doesn't see the error
This pr fixes that

