### PR TITLE
Mailmotor SubscribeType/UnsubscribeType: ucfirst was missing in label

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
@@ -76,7 +76,7 @@ class SubscribeType extends AbstractType
             'subscribe',
             SubmitType::class,
             [
-                'label' => 'lbl.Subscribe',
+                'label' => ucfirst(Language::lbl('Subscribe')),
             ]
         );
     }

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
@@ -55,7 +55,7 @@ class SubscribeType extends AbstractType
                 'required' => true,
                 'label' => 'lbl.Email',
                 'attr' => [
-                    'placeholder' => ucfirst(Language::lbl('YourEmail')),
+                    'placeholder' => \SpoonFilter::ucfirst(Language::lbl('YourEmail')),
                 ],
             ]
         );
@@ -76,7 +76,7 @@ class SubscribeType extends AbstractType
             'subscribe',
             SubmitType::class,
             [
-                'label' => ucfirst(Language::lbl('Subscribe')),
+                'label' => \SpoonFilter::ucfirst(Language::lbl('Subscribe')),
             ]
         );
     }

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
@@ -21,14 +21,14 @@ class UnsubscribeType extends AbstractType
                 'required' => true,
                 'label' => 'lbl.Email',
                 'attr' => [
-                    'placeholder' => ucfirst(Language::lbl('YourEmail')),
+                    'placeholder' => \SpoonFilter::ucfirst(Language::lbl('YourEmail')),
                 ],
             ]
         )->add(
             'unsubscribe',
             SubmitType::class,
             [
-                'label' => ucfirst(Language::lbl('Unsubscribe')),
+                'label' => \SpoonFilter::ucfirst(Language::lbl('Unsubscribe')),
             ]
         );
     }

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
@@ -28,7 +28,7 @@ class UnsubscribeType extends AbstractType
             'unsubscribe',
             SubmitType::class,
             [
-                'label' => 'lbl.Unsubscribe',
+                'label' => ucfirst(Language::lbl('Unsubscribe')),
             ]
         );
     }


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

In the Frontend Mailmotor templates, the button label did not had a capital letter.
This PR fixes that.

