### PR TITLE
Fix tests when site.multilanguage is false

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: config_dev.yml }
 
+parameters:
+    site.multilanguage: true
+
 framework:
     test: ~
     session:


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

Headaches for looking way to long why the tests keep failing locally


## Pull request description

If the parameter site.multilanguage is false in the parameters the tests fail since they need multi-language, this fixes that by forcing it to be true in the tests

