### PR TITLE
Properly fix the form template in the installer

### DIFF
--- a/app/Resources/views/Core/Layout/Templates/FormLayout.html.twig
+++ b/app/Resources/views/Core/Layout/Templates/FormLayout.html.twig
@@ -1,2 +1,0 @@
-{# we need this for the installer #}
-{% extends 'bootstrap_3_layout.html.twig' %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,6 +6,7 @@ imports:
 
 parameters:
     fork.is_installed: true
+    fork.form.theme: 'Core/Layout/Templates/FormLayout.html.twig'
 
 framework:
     secret: "%kernel.secret%"
@@ -33,7 +34,7 @@ twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
     form_themes:
-        - 'Core/Layout/Templates/FormLayout.html.twig'
+        - "%fork.form.theme%"
     paths:
       '%site.path_www%/src/Frontend/Modules/': ForkFrontendModules
 

--- a/app/config/config_install.yml
+++ b/app/config/config_install.yml
@@ -35,6 +35,7 @@ monolog:
 parameters:
     doctrine.dbal.connection_factory.class: ForkCMS\Bundle\InstallerBundle\Service\InstallerConnectionFactory
     fork.is_installed: false
+    fork.form.theme: "ForkCMSInstallerBundle:Installer:form_theme.html.twig"
 
 services:
     # dummy service during the installation


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description
The fix for the form templates in the installer prevented us from adding custom form themes in our themes.

This pr should fix this issue. I did remove that file that was placed to fix it since it had a comment that only reason it was there was to fix the installer and since it breaks stuff I removed it

