### PR TITLE
Set a minimum font size on the body for the backend editors

### DIFF
--- a/src/Frontend/Core/Layout/Sass/editor_content.scss
+++ b/src/Frontend/Core/Layout/Sass/editor_content.scss
@@ -6,6 +6,7 @@ body {
   height: 100%;
   height: expression((window) && ((document.documentElement.clientHeight - 6) + "px"));
   height: auto;
+  font-size: 16px; // min height so we can work with rems and not have super tiny text in the editors
   margin: 0;
   padding: 6px;
   width: auto;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

This fixes the tiny text when using rems with for example bootstrap 4

