### PR TITLE
Bugfix / Bad url on livesuggest paging numbers

### DIFF
--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -293,7 +293,7 @@ class Livesuggest extends FrontendBaseAJAXAction
             if ($useQuestionMark) {
                 $url = $this->pagination['url'] . '?page=' . ($this->pagination['requested_page'] - 1);
             } else {
-                $url = $this->pagination['url'] . '&amp;page=' . ($this->pagination['requested_page'] - 1);
+                $url = $this->pagination['url'] . '&page=' . ($this->pagination['requested_page'] - 1);
             }
 
             // set
@@ -313,7 +313,7 @@ class Livesuggest extends FrontendBaseAJAXAction
                 if ($useQuestionMark) {
                     $url = $this->pagination['url'] . '?page=' . $i;
                 } else {
-                    $url = $this->pagination['url'] . '&amp;page=' . $i;
+                    $url = $this->pagination['url'] . '&page=' . $i;
                 }
 
                 // add
@@ -330,7 +330,7 @@ class Livesuggest extends FrontendBaseAJAXAction
             if ($useQuestionMark) {
                 $url = $this->pagination['url'] . '?page=' . $i;
             } else {
-                $url = $this->pagination['url'] . '&amp;page=' . $i;
+                $url = $this->pagination['url'] . '&page=' . $i;
             }
 
             // add
@@ -349,7 +349,7 @@ class Livesuggest extends FrontendBaseAJAXAction
                 if ($useQuestionMark) {
                     $url = $this->pagination['url'] . '?page=' . $i;
                 } else {
-                    $url = $this->pagination['url'] . '&amp;page=' . $i;
+                    $url = $this->pagination['url'] . '&page=' . $i;
                 }
 
                 // add
@@ -363,7 +363,7 @@ class Livesuggest extends FrontendBaseAJAXAction
             if ($useQuestionMark) {
                 $url = $this->pagination['url'] . '?page=' . ($this->pagination['requested_page'] + 1);
             } else {
-                $url = $this->pagination['url'] . '&amp;page=' . ($this->pagination['requested_page'] + 1);
+                $url = $this->pagination['url'] . '&page=' . ($this->pagination['requested_page'] + 1);
             }
 
             // set


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

In the livesuggest results, the generated paging url's by Ajax are not correct.
Reproduce: Set the limit of the results on 2, search on "lor", and click on the paging number generated by ajax.
