### PR TITLE
Fix gulp serve backend

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,8 +92,7 @@ gulp.task("build:backend", function() {
 gulp.task("serve:backend", function() {
   livereload.listen();
   gulp.watch([
-        "src/Backend/Core/Layout/Sass/screen.scss",
-        "src/Backend/Core/Layout/Sass/debug.scss",
+        "src/Backend/Core/Layout/Sass/**/*.scss"
       ],
       ["build:backend:sass:generate-css"]
   );


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Changes in sass files in subfolders or other files than debug.scss and screen.scss were not detected by gulp

