### PR TITLE
<meta viewport added to make the mobile version work

### DIFF
--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
@@ -3,6 +3,7 @@
 <head>
   {# Meta #}
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="generator" content="Fork CMS" />
   {{ meta|raw }}
   {{ metaCustom|raw }}


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

On mobile phones the desktop version was shown. Adding `<meta viewport ...` fixed this.

Screenshot of how it looked before:

![image-1](https://user-images.githubusercontent.com/588616/32315835-1fa45c56-bfae-11e7-8746-8a135b3b0135.jpg)

