### PR TITLE
Only attempt to get the request if the request is available

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -76,17 +76,19 @@ class Model extends \Common\Core\Model
         }
 
         $parameters['token'] = self::getToken();
-        $queryParameterBag = self::getRequest()->query;
+        if (self::requestIsAvailable()) {
+            $queryParameterBag = self::getRequest()->query;
 
-        // add offset, order & sort (only if not yet manually added)
-        if (!isset($parameters['offset']) && $queryParameterBag->has('offset')) {
-            $parameters['offset'] = $queryParameterBag->getInt('offset');
-        }
-        if (!isset($parameters['order']) && $queryParameterBag->has('order')) {
-            $parameters['order'] = $queryParameterBag->get('order');
-        }
-        if (!isset($parameters['sort']) && $queryParameterBag->has('sort')) {
-            $parameters['sort'] = $queryParameterBag->get('sort');
+            // add offset, order & sort (only if not yet manually added)
+            if (!isset($parameters['offset']) && $queryParameterBag->has('offset')) {
+                $parameters['offset'] = $queryParameterBag->getInt('offset');
+            }
+            if (!isset($parameters['order']) && $queryParameterBag->has('order')) {
+                $parameters['order'] = $queryParameterBag->get('order');
+            }
+            if (!isset($parameters['sort']) && $queryParameterBag->has('sort')) {
+                $parameters['sort'] = $queryParameterBag->get('sort');
+            }
         }
 
         $queryString = '?' . http_build_query($parameters);


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Previously, if we'd try to create a URL for an action without having a request, it would fail because of fallbacks implemented. Now we only attempt to get the fallbacks from the request if the request actually exists

