### PR TITLE
Show subscribe/unsubscribe form errors

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
+++ b/src/Frontend/Modules/Mailmotor/Layout/Templates/Subscribe.html.twig
@@ -41,6 +41,7 @@
               {% do form.subscribe.setRendered %}
             </div>
           </div>
+          {{ form_errors(form.email) }}
         </div>
         {{ form_rest(form) }}
         {{ form_end(form) }}

--- a/src/Frontend/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
+++ b/src/Frontend/Modules/Mailmotor/Layout/Templates/Unsubscribe.html.twig
@@ -37,6 +37,7 @@
               {% do form.unsubscribe.setRendered %}
             </div>
           </div>
+          {{ form_errors(form.email) }}
         </div>
         {{ form_rest(form) }}
         {{ form_end(form) }}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Error messages were not displayed in the subscribe/unsubscribe actions of mailmotor

