### PR TITLE
Fix in mailmotor email validation

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Subscription.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Subscription.php
@@ -13,7 +13,7 @@ final class Subscription
      *
      * @Assert\NotBlank(message="err.FieldIsRequired")
      * @Assert\Email
-     * @MailingListAssert\EmailSubscription
+     * @MailingListAssert\EmailSubscription(groups={"is_email"})
      */
     public $email;
 

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
@@ -13,7 +13,7 @@ final class Unsubscription
      *
      * @Assert\NotBlank(message="err.FieldIsRequired")
      * @Assert\Email
-     * @MailingListAssert\EmailUnsubscription
+     * @MailingListAssert\EmailUnsubscription(groups={"is_email"})
      */
     public $email;
 

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/SubscribeType.php
@@ -138,13 +138,19 @@ class SubscribeType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Subscription::class,
             'validation_groups' => function (FormInterface $form) {
+                $groups = ['Default'];
+
+                if (\SpoonFilter::isEmail($form->getData()->email)) {
+                    $groups[] = 'is_email';
+                }
+
                 // Define overwrite interests
                 $overwriteInterests = $this->modulesSettings->get('Mailmotor', 'overwrite_interests', true);
                 if (!empty($this->interests) && $overwriteInterests) {
-                    return ['Default', 'has_interests'];
+                    $groups[] = 'has_interests';
                 }
 
-                return ['Default'];
+                return $groups;
             },
         ]);
     }

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/UnsubscribeType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UnsubscribeType extends AbstractType
@@ -37,6 +38,15 @@ class UnsubscribeType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Unsubscription::class,
+            'validation_groups' => function (FormInterface $form) {
+                $groups = ['Default'];
+
+                if (\SpoonFilter::isEmail($form->getData()->email)) {
+                    $groups[] = 'is_email';
+                }
+
+                return $groups;
+            },
         ]);
     }
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

When you want to "subscribe/unsubscribe" in the mailmotor. First the Email validation needs to be OK before we send feedback to any gateway API (will reduce page loading time also).
But it seems that all validations are checked first.
This is not necessary and potentially give an error. Like when you use MailChimp, you get an error returned that the "mail address" is wrong.

```
     * @Assert\NotBlank(message="err.FieldIsRequired")
     * @Assert\Email
     * @MailingListAssert\EmailSubscription(groups={"is_email"})
```
