### PR TITLE
Fix in mailmotor email validation

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Subscription.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Subscription.php
@@ -12,7 +12,7 @@ final class Subscription
      * @var string
      *
      * @Assert\NotBlank(message="err.FieldIsRequired")
-     * @Assert\Email
+     * @Assert\Email(message="err.EmailIsInvalid")
      * @MailingListAssert\EmailSubscription
      */
     public $email;

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
@@ -12,7 +12,7 @@ final class Unsubscription
      * @var string
      *
      * @Assert\NotBlank(message="err.FieldIsRequired")
-     * @Assert\Email
+     * @Assert\Email(message="err.FieldIsRequired")
      * @MailingListAssert\EmailUnsubscription
      */
     public $email;

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Command/Unsubscription.php
@@ -12,7 +12,7 @@ final class Unsubscription
      * @var string
      *
      * @Assert\NotBlank(message="err.FieldIsRequired")
-     * @Assert\Email(message="err.FieldIsRequired")
+     * @Assert\Email(message="err.EmailIsInvalid")
      * @MailingListAssert\EmailUnsubscription
      */
     public $email;

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
@@ -23,9 +23,8 @@ class EmailSubscriptionValidator extends ConstraintValidator
      *
      * @param Subscriber $subscriber
      */
-    public function setSubscriber(
-        Subscriber $subscriber
-    ): void {
+    public function setSubscriber(Subscriber $subscriber): void
+    {
         $this->subscriber = $subscriber;
     }
 

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
@@ -2,10 +2,10 @@
 
 namespace Frontend\Modules\Mailmotor\Domain\Subscription\Validator\Constraints;
 
+use MailMotor\Bundle\MailMotorBundle\Exception\NotImplementedException;
 use MailMotor\Bundle\MailMotorBundle\Helper\Subscriber;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use MailMotor\Bundle\MailMotorBundle\Exception\NotImplementedException;
 
 /**
  * @Annotation

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
@@ -34,6 +34,11 @@ class EmailSubscriptionValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
+        // There are already violations thrown, so we return immediately
+        if (count($this->context->getViolations()) > 0) {
+            return;
+        }
+
         try {
             // The email is already in our mailing list
             if ($this->subscriber->isSubscribed($value)) {

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailSubscriptionValidator.php
@@ -18,7 +18,8 @@ class EmailSubscriptionValidator extends ConstraintValidator
     protected $subscriber;
 
     /**
-     * Set subscriber - using a constructor didn't work.
+     * Set subscriber
+     * Note: it's not possible by using a constructor
      *
      * @param Subscriber $subscriber
      */

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
@@ -18,7 +18,8 @@ class EmailUnsubscriptionValidator extends ConstraintValidator
     protected $subscriber;
 
     /**
-     * Set subscriber - using a constructor didn't work.
+     * Set subscriber
+     * Note: it's not possible by using a constructor
      *
      * @param Subscriber $subscriber
      */

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
@@ -2,10 +2,10 @@
 
 namespace Frontend\Modules\Mailmotor\Domain\Subscription\Validator\Constraints;
 
+use MailMotor\Bundle\MailMotorBundle\Exception\NotImplementedException;
 use MailMotor\Bundle\MailMotorBundle\Helper\Subscriber;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use MailMotor\Bundle\MailMotorBundle\Exception\NotImplementedException;
 
 /**
  * @Annotation

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
@@ -34,6 +34,11 @@ class EmailUnsubscriptionValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
+        // There are already violations thrown, so we return immediately
+        if (count($this->context->getViolations()) > 0) {
+            return;
+        }
+
         try {
             // The email doesn't exists in the mailing list
             if (!$this->subscriber->exists($value)) {

--- a/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
+++ b/src/Frontend/Modules/Mailmotor/Domain/Subscription/Validator/Constraints/EmailUnsubscriptionValidator.php
@@ -23,9 +23,8 @@ class EmailUnsubscriptionValidator extends ConstraintValidator
      *
      * @param Subscriber $subscriber
      */
-    public function setSubscriber(
-        Subscriber $subscriber
-    ): void {
+    public function setSubscriber(Subscriber $subscriber): void
+    {
         $this->subscriber = $subscriber;
     }
 


### PR DESCRIPTION
## Type

- Non critical bugfix
- Enhancement

## Resolves the following issues

1. If an invalid email was submitted the Constraint of the MailMotor module couldn't handle it
2. Don't connect to external Gateway API every time. Only do when there is no error.

## Pull request description

* Bugfix: added missing "EmailInvalid" error message
* Enhancement: we only connect to external gateway API's when there is a valid mail address (according to \SpoonEmail)
* Enhancement: Comment updates
* Enhancement: Multi-line constructor to one line
* Enhancement: Moved imported namespaces alphabetically

