### PR TITLE
Fix active breadcrumb state

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Breadcrumb.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Breadcrumb.html.twig
@@ -1,6 +1,6 @@
 <ul class="breadcrumb" itemprop="breadcrumb" role="navigation">
   {% for breadcrumb in breadcrumb %}
-    <li{% if breadcrumb.last %} class="active"{% endif %}>
+    <li{% if loop.last %} class="active"{% endif %}>
       {% if breadcrumb.url %}
         <a href="{{ breadcrumb.url }}" title="{{ breadcrumb.title }}">
           {{ breadcrumb.title }}


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Breadcrumb doesnt have an active state on the last element: https://demo.fork-cms.com/en

## Pull request description
Needs to be using the loop variable to work: https://twig.symfony.com/doc/2.x/tags/for.html#the-loop-variable
