### PR TITLE
Specify form ID to avoid deleting all entries.

### DIFF
--- a/src/Backend/Modules/Blog/Js/Blog.js
+++ b/src/Backend/Modules/Blog/Js/Blog.js
@@ -30,7 +30,7 @@ jsBackend.Blog.controls =
         $categoryId = $('#categoryId');
 
         $saveAsDraft.on('click', function (e) {
-            $('form').append('<input type="hidden" name="status" value="draft" />').submit();
+            $('form#edit').append('<input type="hidden" name="status" value="draft" />').submit();
         });
 
         if ($addCategorySubmit.length > 0 && $addCategoryDialog.length > 0) {


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

As a backend user I want to to save a blog post as a draft without every item for this `id` being deleted.