### PR TITLE
Fix raw tag for url in faq spam message

### DIFF
--- a/src/Backend/Modules/Faq/Layout/Templates/Settings.html.twig
+++ b/src/Backend/Modules/Faq/Layout/Templates/Settings.html.twig
@@ -87,7 +87,7 @@
                   {{ 'msg.HelpSpamFilter'|trans }}
                   {% if noAkismetKey %}
                     <br>
-                    {{ 'msg.NoAkismetKey'|trans|format(geturl('index','settings')|raw) }}
+                    {{ 'msg.NoAkismetKey'|trans|format(geturl('index','settings'))|raw }}
                   {% endif %}
                 </p>
               </li>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Will fix the html url on https://demo.fork-cms.com/private/en/faq/settings
![Bug](https://cldup.com/GdLMjQ8MoS-3000x3000.png)
