### PR TITLE
Fix media library uploads

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -1149,15 +1149,21 @@ jsBackend.data = {
   },
 
   exists: function (key) {
-    return (typeof jsBackend.data.data[key] !== 'undefined')
+    return (typeof jsBackend.data.get(key) !== 'undefined')
   },
 
   get: function (key) {
     // init if needed
     if (!jsBackend.data.initialized) jsBackend.data.init()
 
+    var keys = key.split('.')
+    var data = jsBackend.data.data
+    for (var i = 0; i < keys.length; i++) {
+      data = data[keys[i]]
+    }
+
     // return
-    return jsBackend.data.data[key]
+    return data
   }
 }
 


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

The upload function of the media library was broken due to the way the allowed file extensions were being loaded. The function used to load this value was previously using `eval` to retrieve data from `jsBackend.data` data structure using a key. So if you use a key like `MediaLibrary.mediaAllowedExtensions`, the `eval` function would evaluate the full expression `jsBackend.data.data.MediaLibrary.mediaAllowedExtensions` but the current `eval`less implementation cannot handle these cases. This PR splits the key to retrieve its components and transverses the data structure to retrieve the correct value.
This bug possibly affects other parts of the CMS.