### PR TITLE
.val() is not needed

### DIFF
--- a/src/Backend/Modules/Profiles/Js/Profiles.js
+++ b/src/Backend/Modules/Profiles/Js/Profiles.js
@@ -16,7 +16,7 @@ jsBackend.Profiles =
         init: function()
         {
             // update the hidden input for the new group's ID with the remembered value
-            var $txtNewGroup = $('input[name="newGroup"]').val();
+            var $txtNewGroup = $('input[name="newGroup"]');
 
             // clone the groups SELECT into the "add to group" mass action dialog
             $('.jsMassActionAddToGroupSelectGroup').replaceWith(


### PR DESCRIPTION
.val() is not needed, we want the element, not the value

## Type


- Non critical bugfix

## Resolves the following issues

Reference to element is now correct.



