### PR TITLE
Skip rewriting and https enabling on localhost

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -80,13 +80,13 @@ deny from env=stayout
     # </IfModule>
     # RewriteCond %{HTTPS} !=on
     # RewriteCond %{HTTP_HOST} !.*\.dev [NC]
-    # RewriteCond %{HTTP_HOST} !localhost$ [NC]
+    # RewriteCond %{HTTP_HOST} !.*localhost(:\d+)?$ [NC]
     # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # one url to rule them all
     # RewriteCond %{HTTP_HOST} !^www\.<domain>\.be [NC]
     # RewriteCond %{HTTP_HOST} !.*\.dev [NC]
-    # RewriteCond %{HTTP_HOST} !localhost$ [NC]
+    # RewriteCond %{HTTP_HOST} !.*localhost(:\d+)?$ [NC]
     # RewriteRule ^(.*)$ http://www.<domain>.be/$1 [R=301,L]
 
     # src dir should pass via the front controller

--- a/.htaccess
+++ b/.htaccess
@@ -80,11 +80,13 @@ deny from env=stayout
     # </IfModule>
     # RewriteCond %{HTTPS} !=on
     # RewriteCond %{HTTP_HOST} !.*\.dev [NC]
+    # RewriteCond %{HTTP_HOST} !localhost$ [NC]
     # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # one url to rule them all
     # RewriteCond %{HTTP_HOST} !^www\.<domain>\.be [NC]
     # RewriteCond %{HTTP_HOST} !.*\.dev [NC]
+    # RewriteCond %{HTTP_HOST} !localhost$ [NC]
     # RewriteRule ^(.*)$ http://www.<domain>.be/$1 [R=301,L]
 
     # src dir should pass via the front controller


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
/

## Pull request description
There was already an option in .htaccess to skip https and url rewriting for .dev domains. Adding localhost should fix it for when you're using docker for example. 

Also, [Chrome 63 forces .dev domains to use https](https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/) so using .dev for local development isn't so useful anymore FYI


It should skip on these hostnames:
```
localhost
localhost:3000
subdomain.localhost:3000
```