### PR TITLE
Change return type of getAction to accept NULL

### DIFF
--- a/src/Frontend/Core/Engine/Block/ExtraInterface.php
+++ b/src/Frontend/Core/Engine/Block/ExtraInterface.php
@@ -145,7 +145,7 @@ class ExtraInterface extends KernelLoader implements ModuleExtraInterface
      *
      * @return string
      */
-    public function getAction(): string
+    public function getAction(): ?string
     {
         if ($this->action !== null) {
             return $this->action;


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
Functionality of creating urls like: /projects/{category_url}/{item_url} was impossible.

## Pull request description
NULL was no longer accepted as a return type for getAction. That broke some of the functionality of creating urls like: /projects/{category_url}/{item_url} since that requires the action field within ModuleExtra to be NULL.
