### PR TITLE
In some circumstances it could happen that first() would return a boo…

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
@@ -163,7 +163,7 @@ class MediaGroup implements JsonSerializable
     {
         $connectedMediaItems = $this->getConnectedMediaItems();
 
-        return $connectedMediaItems instanceof Collection ? $this->getConnectedMediaItems()->first() : null;
+        return $connectedMediaItems->isEmpty() ? null : $connectedMediaItems->first();
     }
 
     public function hasConnectedItems(): bool


### PR DESCRIPTION
…lean instead of an object or null. This could cause some errors in PHP.

## Type
- Non critical bugfix

## Resolves the following issues


## Pull request description
In some situations it could happen that false was returned instead of null. Since php 7.2 uses type hinting to check for null or a MediaItem it would cause a PHP error.

This fix checks if the object is a instance of Collection but also if there is a first item. If both are true return the first item otherwise return always false.

