### PR TITLE
Fix external url check

### DIFF
--- a/src/ForkCMS/Bundle/CoreBundle/Validator/UrlValidator.php
+++ b/src/ForkCMS/Bundle/CoreBundle/Validator/UrlValidator.php
@@ -12,11 +12,7 @@ final class UrlValidator
         $violations = Validation::createValidator()->validate(
             $url,
             [
-                new Assert\Url(
-                    [
-                        'checkDNS' => true, // Just a crappy name to say that it will check the url has a valid hostname
-                    ]
-                ),
+                new Assert\Url(),
             ]
         );
 


### PR DESCRIPTION
## Type
- Critical bugfix

## Issues
fixes #2388 

## Pull request description
The dns check did an external call, this would slow down the site if used a lot and also resulted in false positives in docker

