### PR TITLE
Fix button macro with icons

### DIFF
--- a/src/Backend/Core/Layout/Templates/macros.html.twig
+++ b/src/Backend/Core/Layout/Templates/macros.html.twig
@@ -15,7 +15,8 @@
 {% endmacro %}
 
 {% macro infoTooltip(title) %}
-  <abbr tabindex="0" data-toggle="tooltip" aria-label="{{ title }}" title="{{ title }}">{{ _self.icon('info-circle') }}</abbr>
+  {% import _self as macro %}
+  <abbr tabindex="0" data-toggle="tooltip" aria-label="{{ title }}" title="{{ title }}">{{ macro.icon('info-circle') }}</abbr>
 {% endmacro %}
 
 {% macro dataGrid(dataGrid, noItemsMessage) %}

--- a/src/Backend/Core/Layout/Templates/macros.html.twig
+++ b/src/Backend/Core/Layout/Templates/macros.html.twig
@@ -1,6 +1,7 @@
 {% macro buttonIcon(url, icon, label, buttonType, extra) %}
   <a href="{{ url }}" class="btn {{ buttonType|default('btn-default') }}" title="{{ label }}" {{ extra }}>
-    {{ _self.icon(icon) }}
+    {% import _self as macro %}
+    {{ macro.icon(icon) }}
     <span class="btn-text">{{ label }}</span>
   </a>
 {% endmacro %}


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
A lot of icons where not showing in buttons, the same for icons in info tooltips.
The imports of the macro icon in other macro wasn't working

