### PR TITLE
Make sure the id data attribute of tags in the datagrid contains valid JSON

### DIFF
--- a/src/Backend/Modules/Tags/Actions/Index.php
+++ b/src/Backend/Modules/Tags/Actions/Index.php
@@ -58,7 +58,7 @@ class Index extends BackendBaseActionIndex
         $this->dataGrid->setMassAction($ddmMassAction);
 
         // add attributes, so the inline editing has all the needed data
-        $this->dataGrid->setColumnAttributes('tag', ['data-id' => '{id:[id]}']);
+        $this->dataGrid->setColumnAttributes('tag', ['data-id' => '{\'id\':[id]}']);
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('Edit')) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
The inline editing of tags in the datagrid no longer worked because JS threw an error. This was caused by invalid JSON in the `data-id` attribute. I've corrected the JSON and it works as expected.

