### PR TITLE
Remove annoying whitespace in the datagrid

### DIFF
--- a/src/Backend/Core/Layout/Templates/Datagrid.tpl
+++ b/src/Backend/Core/Layout/Templates/Datagrid.tpl
@@ -43,9 +43,7 @@
   <tr
     {$rows.attributes}>
     {iteration:rows.columns}
-    <td
-      {$rows.columns.attributes}>{$rows.columns.value}
-    </td>
+    <td {$rows.columns.attributes}>{$rows.columns.value}</td>
     {/iteration:rows.columns}
   </tr>
   {/iteration:rows}


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Ever had to change a bunch of translations in one go? You probably used the inline editor in the datagrid, right? Ever notice those annoying whitespaces you'd have to clear every time you fixed a typo? And every time you forgot to delete them your navigation alignment would be botched or something, right? Yeah, I know..

Well I say: NO MORE!

tl;dr: I removed the whitespaces so you can do inline edits without those pesky spaces ruining your day.