### PR TITLE
Fix collapse navigation button for pages and media library

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}

--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}

--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}

--- a/src/Backend/Modules/Pages/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Index.html.twig
@@ -11,8 +11,11 @@
         {{ tree|raw }}
       </div>
     </div>
-    <div id="fullwidthSwitch">
-      <a href="#close">&nbsp;</a>
+    <div class="toggle-nav-collapse hidden-xs">
+      <button href="#" class="js-toggle-nav" role="button">
+        {{ macro.icon('chevron-left') }}
+        <span class="sr-only js-nav-screen-text"></span>
+      </button>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
The collapse arrow was gone on the pages and media library navigation because it uses a different template
