### PR TITLE
Make it possible to access all items in navigation tree with keyboard

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -7245,6 +7245,14 @@
         <translation language="zh"><![CDATA[關閉導航]]></translation>
         <translation language="de"><![CDATA[schließe die Navigation]]></translation>
       </item>
+      <item type="label" name="OpenTreeNavigation">
+        <translation language="nl"><![CDATA[klap boomnavigatie open]]></translation>
+        <translation language="en"><![CDATA[open tree navigation]]></translation>
+      </item>
+      <item type="label" name="CloseTreeNavigation">
+        <translation language="nl"><![CDATA[boomnavigatie dichtklappen]]></translation>
+        <translation language="en"><![CDATA[close tree navigation]]></translation>
+      </item>
       <item type="label" name="NavigationTitle">
         <translation language="nl"><![CDATA[navigatietitel]]></translation>
         <translation language="en"><![CDATA[navigation title]]></translation>

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibrary.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibrary.js
@@ -198,6 +198,8 @@ jsBackend.mediaLibrary.tree = {
         $(this).removeClass('open').addClass('leaf')
       }
     })
+
+    jsBackend.mediaLibrary.tree.toggleJsTreeCollapse()
   },
 
   // before an item will be moved we have to do some checks
@@ -300,6 +302,25 @@ jsBackend.mediaLibrary.tree = {
     }
 
     return $(refNode).prop('id').replace('folder-', '')
+  },
+
+  toggleJsTreeCollapse: function () {
+    $('[data-role="toggle-js-tree-collapse"]').on('click', function () {
+      var $this = $(this)
+      $this.toggleClass('tree-collapsed')
+      var collapsed = $this.hasClass('tree-collapsed')
+      var $buttonText = $('[data-role="toggle-js-tree-collapse-text"]')
+
+      if (collapsed) {
+        $buttonText.html(jsBackend.locale.lbl('OpenTreeNavigation'))
+        $.tree.reference('#tree div').close_all()
+
+        return
+      }
+
+      $buttonText.html(jsBackend.locale.lbl('CloseTreeNavigation'))
+      $.tree.reference('#tree div').open_all()
+    })
   }
 }
 

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaBrowser.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaBrowser.html.twig
@@ -32,6 +32,9 @@
                     <div class="row">
                       <div class="col-sm-3">
                         <div id="mediaTree">
+                          <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+                            <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+                          </button>
                           <div id="tree">
                             {{ tree|raw }}
                           </div>

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemEdit.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-xs visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-xs visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemUpload.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-xs visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MoveMediaFoldersNotPossible'|trans|ucfirst }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -1401,6 +1401,8 @@ jsBackend.pages.tree = {
 
     // set the item selected
     if (typeof selectedId !== 'undefined') $('#' + selectedId).addClass('selected')
+
+    jsBackend.pages.tree.toggleJsTreeCollapse()
   },
 
   // before an item will be moved we have to do some checks
@@ -1497,6 +1499,25 @@ jsBackend.pages.tree = {
           jsBackend.messages.add('success', jsBackend.locale.msg('PageIsMoved').replace('%1$s', json.data.title))
         }
       }
+    })
+  },
+
+  toggleJsTreeCollapse: function () {
+    $('[data-role="toggle-js-tree-collapse"]').on('click', function () {
+      var $this = $(this)
+      $this.toggleClass('tree-collapsed')
+      var collapsed = $this.hasClass('tree-collapsed')
+      var $buttonText = $('[data-role="toggle-js-tree-collapse-text"]')
+
+      if (collapsed) {
+        $buttonText.html(jsBackend.locale.lbl('OpenTreeNavigation'))
+        $.tree.reference('#tree div').close_all()
+
+        return
+      }
+
+      $buttonText.html(jsBackend.locale.lbl('CloseTreeNavigation'))
+      $.tree.reference('#tree div').open_all()
     })
   }
 }

--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MovePagesNotPossible'|trans }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>

--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MovePagesNotPossible'|trans|ucfirst }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>

--- a/src/Backend/Modules/Pages/Layout/Templates/Index.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Index.html.twig
@@ -7,6 +7,9 @@
       <div class="alert alert-warning visible-xs visible-sm">
         <p>{{ macro.icon('exclamation-triangle') }}{{ 'msg.MovePagesNotPossible'|trans|ucfirst }}</p>
       </div>
+      <button class="btn btn-default btn-sm tree-collapsed" data-role="toggle-js-tree-collapse">
+        <span data-role="toggle-js-tree-collapse-text">{{ 'lbl.OpenTreeNavigation'|trans }}</span>
+      </button>
       <div id="tree">
         {{ tree|raw }}
       </div>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

It isn't possible to open the navigation trees used in the media library and the pages module at the moment. This adds a button that will make it possible to open or close it

<img width="234" alt="screen shot 2018-02-01 at 15 21 37" src="https://user-images.githubusercontent.com/3634654/35683249-a2411210-0763-11e8-942d-d72871a2fe4b.png">
<img width="225" alt="screen shot 2018-02-01 at 15 21 34" src="https://user-images.githubusercontent.com/3634654/35683250-a25db186-0763-11e8-9591-292ccf8e989f.png">

