### PR TITLE
Catch Doctrine's DBALException if the database connection fails

### DIFF
--- a/src/ForkCMS/Bundle/InstallerBundle/Service/InstallerConnectionFactory.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Service/InstallerConnectionFactory.php
@@ -6,6 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\DriverManager;
 use ForkCMS\Bundle\InstallerBundle\Controller\InstallerController;
 use ForkCMS\Bundle\InstallerBundle\Entity\InstallationData;
@@ -33,7 +34,7 @@ class InstallerConnectionFactory extends ConnectionFactory
 
             //continue with regular connection creation using new params
             return parent::createConnection($params, $config, $eventManager, $mappingTypes);
-        } catch (ConnectionException $e) {
+        } catch (ConnectionException | DBALException $e) {
             return $this->getInstallerConnection($params, $config, $eventManager);
         }
     }


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
On step 4 of the installer, the database variables are guessed from the URL of the website.
Fork then tries to connect to this database to see if it worked. If it doesn't it catches a ConnectionException but since DoctrineBundle 1.6.8 it also throws a DBALException if it can't determine the server version. We now catch that exception as well and treat it like a ConnectionException.

For more information see https://github.com/doctrine/DoctrineBundle/issues/673

