### PR TITLE
Add missing comma in buttonIcon macro call

### DIFF
--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -371,7 +371,7 @@
         </div>
         <div class="btn-group pull-right" role="group">
           {{ macro.buttonIcon('', 'file-o', 'lbl.SaveDraft'|trans|ucfirst, 'btn-default', { "id":"saveAsDraft" }) }}
-          {{ macro.buttonIcon('', 'floppy-o', 'lbl.Save'|trans|ucfirst, 'btn-primary', { "id":"editButton" "type":"submit", "name":"edit" }) }}
+          {{ macro.buttonIcon('', 'floppy-o', 'lbl.Save'|trans|ucfirst, 'btn-primary', { "id":"editButton", "type":"submit", "name":"edit" }) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
A comma was missing from the buttonIcon macro call, breaking the Pages Edit action.

