### PR TITLE
The tags should be case insensitive unique

### DIFF
--- a/src/Backend/Modules/Tags/Engine/Model.php
+++ b/src/Backend/Modules/Tags/Engine/Model.php
@@ -235,8 +235,8 @@ class Model
             $tags = (array) explode(',', (string) $tags);
         }
 
-        // make sure the list of tags contains only unique and non-empty elements
-        $tags = array_filter(array_unique($tags));
+        // make sure the list of tags contains only unique and non-empty elements in a case insensitive way
+        $tags = array_filter(array_intersect_key($tags, array_unique(array_map('strtolower', $tags))));
 
         // get database
         $database = BackendModel::getContainer()->get('database');


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
array_unique takes the case into account, adding a tag Ichtus and ichtus would result in a 500 error since the database would see it as a double entry but the php as separate entries

