### PR TITLE
CKEDITOR / Update Link dialog with internal pages

### DIFF
--- a/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
+++ b/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
@@ -61,19 +61,19 @@ CKEDITOR.dialog.add(
                                         }.bind(this.getDialog());
                                     },
                                     style: 'margin-top: 20px;'
-                                },
-                                {
-                                    type: 'select',
-                                    label: jsBackend.locale.msg('EditorSelectInternalPage'),
-                                    id: 'localPage',
-                                    title: jsBackend.locale.msg('EditorSelectInternalPage'),
-                                    items: linkList,
-                                    onChange: function (event) {
-                                        this.getDialog().getContentElement('tab', 'url').setValue(event.data.value);
-                                    }
-                                },
+                                }
                             ]
-                        }
+                        },
+                        {
+                            type: 'select',
+                            label: jsBackend.locale.msg('EditorSelectInternalPage'),
+                            id: 'localPage',
+                            title: jsBackend.locale.msg('EditorSelectInternalPage'),
+                            items: linkList,
+                            onChange: function (event) {
+                                this.getDialog().getContentElement('tab', 'url').setValue(event.data.value);
+                            }
+                        },
                     ]
                 }
             ],

--- a/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
+++ b/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
@@ -61,7 +61,17 @@ CKEDITOR.dialog.add(
                                         }.bind(this.getDialog());
                                     },
                                     style: 'margin-top: 20px;'
-                                }
+                                },
+                                {
+                                    type: 'select',
+                                    label: jsBackend.locale.msg('EditorSelectInternalPage'),
+                                    id: 'localPage',
+                                    title: jsBackend.locale.msg('EditorSelectInternalPage'),
+                                    items: linkList,
+                                    onChange: function (event) {
+                                        this.getDialog().getContentElement('tab', 'url').setValue(event.data.value);
+                                    }
+                                },
                             ]
                         }
                     ]


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues
Restore the dropdown with internal pages in the Ckeditor link dialog.

![schermafbeelding 2018-03-02 om 17 31 36](https://user-images.githubusercontent.com/4540274/36909901-9a2c2572-1e3f-11e8-8f4b-0a0ecc4c7579.png)

