### PR TITLE
Replace some leftover cancelButton macros with a buttonIcon implementation

### DIFF
--- a/src/Backend/Modules/Profiles/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Profiles/Layout/Templates/Add.html.twig
@@ -91,7 +91,7 @@
     <div class="col-md-12">
       <div class="btn-toolbar">
         <div class="btn-group" role="group">
-          {{ macro.cancelButton(geturl('Index')) }}
+          {{ macro.buttonIcon(geturl('Index'), 'times', 'lbl.Cancel'|trans|ucfirst) }}
         </div>
         <div class="btn-group pull-right" role="group">
           {{ macro.buttonIcon('', 'plus-square', 'lbl.Add'|trans|ucfirst, 'btn-primary', { "type":"submit", "id":"addButton", "name":"add" }) }}

--- a/src/Backend/Modules/Profiles/Layout/Templates/AddGroup.html.twig
+++ b/src/Backend/Modules/Profiles/Layout/Templates/AddGroup.html.twig
@@ -22,7 +22,7 @@
     <div class="col-md-12">
       <div class="btn-toolbar">
         <div class="btn-group" role="group">
-          {{ macro.cancelButton(geturl('Groups')) }}
+          {{ macro.buttonIcon(geturl('Groups'), 'times', 'lbl.Cancel'|trans|ucfirst) }}
         </div>
         <div class="btn-group pull-right" role="group">
           {{ macro.buttonIcon('', 'plus-square', 'lbl.AddGroup'|trans|ucfirst, 'btn-primary', { "type":"submit", "id":"addButton", "name":"add" }) }}

--- a/src/Backend/Modules/Profiles/Layout/Templates/AddProfileGroup.html.twig
+++ b/src/Backend/Modules/Profiles/Layout/Templates/AddProfileGroup.html.twig
@@ -43,7 +43,7 @@
     <div class="col-md-12">
       <div class="btn-toolbar">
         <div class="btn-group" role="group">
-          {{ macro.cancelButton(geturl('Edit') ~ '&id=' ~ id ~ "#tabGroups") }}
+          {{ macro.buttonIcon(geturl('Edit') ~ '&id=' ~ id ~ "#tabGroups", 'times', 'lbl.Cancel'|trans|ucfirst) }}
         </div>
         <div class="btn-group pull-right" role="group">
           {{ macro.buttonIcon('', 'plus-square', 'lbl.Add'|trans|ucfirst, 'btn-primary', { "type":"submit", "id":"addButton", "name":"add" }) }}

--- a/src/Backend/Modules/Profiles/Layout/Templates/EditGroup.html.twig
+++ b/src/Backend/Modules/Profiles/Layout/Templates/EditGroup.html.twig
@@ -25,7 +25,7 @@
           {% if showProfilesDeleteGroup %}
             {{ macro.buttonIcon('', 'trash-o', 'lbl.Delete'|trans|ucfirst, 'btn-danger', { "type":"button", "data-toggle":"modal", "data-target":"#confirmDelete" }) }}
           {% endif %}
-          {{ macro.cancelButton(geturl('Groups')) }}
+          {{ macro.buttonIcon(geturl('Groups'), 'times', 'lbl.Cancel'|trans|ucfirst) }}
         </div>
         <div class="btn-group pull-right" role="group">
           {{ macro.buttonIcon('', 'floppy-o', 'lbl.Save'|trans|ucfirst, 'btn-primary', { "type":"submit", "name":"edit", "id":"saveButton" }) }}


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description
Recently I added cancel buttons to most actions using a `cancelButton` macro. This was replaced with an implementation of the `buttonIcon` macro by @Katrienvh but it seems like she missed a few.

Because of this several actions in the backend are unusable.

