### PR TITLE
Ensure getRandomString() returns a string with the requested length

### DIFF
--- a/src/Frontend/Modules/Profiles/Engine/Model.php
+++ b/src/Frontend/Modules/Profiles/Engine/Model.php
@@ -226,7 +226,7 @@ class Model
         // get random characters
         for ($i = 0; $i < $length; ++$i) {
             // random index
-            $index = mt_rand(0, mb_strlen($characters));
+            $index = mt_rand(0, mb_strlen($characters) - 1);
 
             // add character to salt
             $string .= mb_substr($characters, $index, 1, $charset);


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Here's something I found when writing tests for the Profiles module:

In `FrontendProfilesModel::getRandomString()`:
If `$characters = 'ABC'` then `mb_strlen($characters) === 3`
`mt_rand(0, 3)` could be `3`
Which then would cause `mb_substr('ABC', 3, 1)` to be `''`, thus not lengthening the returned string by 1

So in theory, though very unlikely, it's possible to do `getRandomString(999)` and receive an empty string.
