### PR TITLE
Set a label and for attr for each form field in blog add/edit

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
@@ -42,8 +42,12 @@
               <div class="col-md-8">
                 <div class="panel panel-default panel-editor">
                   <div class="panel-heading">
-                    <h2>{{ 'lbl.MainContent'|trans|ucfirst }}
-                      {{ macro.required }}</h2>
+                    <h2>
+                      <label for="text">
+                        {{ 'lbl.MainContent'|trans|ucfirst }}
+                        {{ macro.required }}
+                      </label>
+                    </h2>
                   </div>
                   <div class="panel-body">
                     {% form_field text %}
@@ -57,7 +61,7 @@
                 {% if imageIsAllowed %}
                   <div class="panel panel-default">
                     <div class="panel-heading">
-                      <h2>{{ 'lbl.Image'|trans|ucfirst }}</h2>
+                      <h2><label for="image">{{ 'lbl.Image'|trans|ucfirst }}</label></h2>
                     </div>
                     <div class="panel-body">
                       {% form_field image %} {% form_field_error image %}
@@ -67,8 +71,10 @@
                 <div class="panel panel-default panel-editor last">
                   <div class="panel-heading">
                     <h2>
-                      {{ 'lbl.Summary'|trans|ucfirst }}
-                      {{ macro.infoTooltip('msg.HelpSummary'|trans|ucfirst) }}
+                      <label for="introduction">
+                        {{ 'lbl.Summary'|trans|ucfirst }}
+                        {{ macro.infoTooltip('msg.HelpSummary'|trans|ucfirst) }}
+                      </label>
                     </h2>
                   </div>
                   <div class="panel-body">

--- a/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
@@ -56,8 +56,12 @@
               <div class="col-md-8">
                 <div class="panel panel-default panel-editor">
                   <div class="panel-heading">
-                    <h2>{{ 'lbl.MainContent'|trans|ucfirst }}
-                      {{ macro.required }}</h2>
+                    <h2>
+                      <label for="text">
+                        {{ 'lbl.MainContent'|trans|ucfirst }}
+                        {{ macro.required }}
+                      </label>
+                    </h2>
                   </div>
                   <div class="panel-body">
                     {% form_field text %}
@@ -71,7 +75,7 @@
                 {% if imageIsAllowed %}
                   <div class="panel panel-default">
                     <div class="panel-heading">
-                      <h2>{{ 'lbl.Image'|trans|ucfirst }}</h2>
+                      <h2><label for="image">{{ 'lbl.Image'|trans|ucfirst }}</label></h2>
                     </div>
                     <div class="panel-body">
                       {% if item.image %}
@@ -92,8 +96,10 @@
                 <div class="panel panel-default panel-editor last">
                   <div class="panel-heading">
                     <h2>
-                      {{ 'lbl.Summary'|trans|ucfirst }}
-                      {{ macro.infoTooltip('msg.HelpSummary'|trans|ucfirst) }}
+                      <label for="introduction">
+                        {{ 'lbl.Summary'|trans|ucfirst }}
+                        {{ macro.infoTooltip('msg.HelpSummary'|trans|ucfirst) }}
+                      </label>
                     </h2>
                   </div>
                   <div class="panel-body">


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Add labels for each field in blog add/edit so the focus will be set on the linked input.
Does not work for bootstrap tagsinput and ckeditor

