### PR TITLE
Wcag update tags input help text

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -12160,8 +12160,8 @@
         <translation language="en"><![CDATA[move down one position]]></translation>
       </item>
       <item type="message" name="HelpTextTags">
-        <translation language="nl"><![CDATA[Typ tekst gevolgd door komma of ⏎ om een nieuwe tag toe te voegen. Typ enkele letters en gebruik pijl omlaag om een bestaande tag te selecteren]]></translation>
-        <translation language="en"><![CDATA[Type text followed by comma or ⏎ to add a new tag. Type a few letters and use the down arrow to select an existing tag]]></translation>
+        <translation language="nl"><![CDATA[Typ tekst gevolgd door komma of ENTER om een nieuwe tag toe te voegen. Typ enkele letters en gebruik pijl omlaag om een bestaande tag te selecteren]]></translation>
+        <translation language="en"><![CDATA[Type text followed by comma or ENTER to add a new tag. Type a few letters and use the down arrow to select an existing tag]]></translation>
       </item>
     </Core>
   </Backend>

--- a/src/Backend/Modules/Blog/Actions/Add.php
+++ b/src/Backend/Modules/Blog/Actions/Add.php
@@ -62,7 +62,13 @@ class Add extends BackendBaseActionAdd
             $this->form->getField('category_id')->setDefaultElement('');
         }
         $this->form->addDropdown('user_id', BackendUsersModel::getUsers(), BackendAuthentication::getUser()->getUserId());
-        $this->form->addText('tags', null, null, 'form-control js-tags-input', 'form-control danger js-tags-input');
+        $this->form->addText(
+            'tags',
+             null,
+             null,
+             'form-control js-tags-input',
+             'form-control danger js-tags-input'
+         )->setAttribute('aria-describedby', 'tags-info');
         $this->form->addDate('publish_on_date');
         $this->form->addTime('publish_on_time');
         if ($this->imageIsAllowed) {

--- a/src/Backend/Modules/Blog/Actions/Add.php
+++ b/src/Backend/Modules/Blog/Actions/Add.php
@@ -64,11 +64,11 @@ class Add extends BackendBaseActionAdd
         $this->form->addDropdown('user_id', BackendUsersModel::getUsers(), BackendAuthentication::getUser()->getUserId());
         $this->form->addText(
             'tags',
-             null,
-             null,
-             'form-control js-tags-input',
-             'form-control danger js-tags-input'
-         )->setAttribute('aria-describedby', 'tags-info');
+            null,
+            null,
+            'form-control js-tags-input',
+            'form-control danger js-tags-input'
+        )->setAttribute('aria-describedby', 'tags-info');
         $this->form->addDate('publish_on_date');
         $this->form->addTime('publish_on_time');
         if ($this->imageIsAllowed) {

--- a/src/Backend/Modules/Blog/Actions/Edit.php
+++ b/src/Backend/Modules/Blog/Actions/Edit.php
@@ -201,7 +201,7 @@ class Edit extends BackendBaseActionEdit
             null,
             'form-control js-tags-input',
             'form-control danger js-tags-input'
-        );
+        )->setAttribute('aria-describedby', 'tags-info');
         $this->form->addDate('publish_on_date', $this->record['publish_on']);
         $this->form->addTime('publish_on_time', date('H:i', $this->record['publish_on']));
         if ($this->imageIsAllowed) {

--- a/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Add.html.twig
@@ -121,7 +121,7 @@
                       <div class="form-group last">
                         <label for="tags" class="control-label">{{ 'lbl.Tags'|trans|ucfirst }}</label>
                         {% form_field tags %} {% form_field_error tags %}
-                        <div class="help-block">{{ 'msg.HelpTextTags'|trans }}</div>
+                        <div class="help-block" id="tags-info">{{ 'msg.HelpTextTags'|trans }}</div>
                       </div>
                     {% endif %}
                   </div>

--- a/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
@@ -146,7 +146,7 @@
                       <div class="form-group last">
                         <label for="tags" class="control-label">{{ 'lbl.Tags'|trans|ucfirst }}</label>
                         {% form_field tags %} {% form_field_error tags %}
-                        <div class="help-block">{{ 'msg.HelpTextTags'|trans }}</div>
+                        <div class="help-block" id="tags-info">{{ 'msg.HelpTextTags'|trans }}</div>
                       </div>
                     {% endif %}
                   </div>

--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -304,7 +304,13 @@ class Add extends BackendBaseActionAdd
 
         if ($this->showTags()) {
             // tags
-            $this->form->addText('tags', null, null, 'form-control js-tags-input', 'form-control danger js-tags-input');
+            $this->form->addText(
+                'tags',
+                null,
+                null,
+                'form-control js-tags-input',
+                'form-control danger js-tags-input'
+            )->setAttribute('aria-describedby', 'tags-info');
         }
 
         // a specific action

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -539,7 +539,7 @@ class Edit extends BackendBaseActionEdit
                 null,
                 'form-control js-tags-input',
                 'error js-tags-input'
-            );
+            )->setAttribute('aria-describedby', 'tags-info');;
         }
 
         // a specific action

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -539,7 +539,7 @@ class Edit extends BackendBaseActionEdit
                 null,
                 'form-control js-tags-input',
                 'error js-tags-input'
-            )->setAttribute('aria-describedby', 'tags-info');;
+            )->setAttribute('aria-describedby', 'tags-info');
         }
 
         // a specific action

--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -188,7 +188,7 @@
                 <div class="col-md-12">
                   <p class="tab-pane-title">{{ 'msg.AddTagsHere'|trans }}</p>
                   {% form_field tags %} {% form_field_error tags %}
-                  <div class="help-block">{{ 'msg.HelpTextTags'|trans }}</div>
+                  <div class="help-block" id="tags-info">{{ 'msg.HelpTextTags'|trans }}</div>
                 </div>
               </div>
             </div>

--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -329,7 +329,7 @@
                 <div class="col-md-12">
                   <label for="tags">{{ 'msg.AddTagsHere'|trans }}</label>
                   {% form_field tags %} {% form_field_error tags %}
-                  <div class="help-block">{{ 'msg.HelpTextTags'|trans }}</div>
+                  <div class="help-block" id="tags-info">{{ 'msg.HelpTextTags'|trans }}</div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Screenreaders can't handle the enter symbol.
Added aria describedby so the help block is linked to the input field

