### PR TITLE
Delete entries linked to a deleted group

### DIFF
--- a/src/Backend/Modules/Groups/Engine/Model.php
+++ b/src/Backend/Modules/Groups/Engine/Model.php
@@ -53,6 +53,9 @@ class Model
     public static function delete(int $groupId): void
     {
         BackendModel::getContainer()->get('database')->delete('groups', 'id = ?', [$groupId]);
+        BackendModel::getContainer()->get('database')->delete('groups_settings', 'group_id = ?', [$groupId]);
+        BackendModel::getContainer()->get('database')->delete('groups_rights_actions', 'group_id = ?', [$groupId]);
+        BackendModel::getContainer()->get('database')->delete('groups_rights_modules', 'group_id = ?', [$groupId]);
     }
 
     public static function deleteActionPermissions(array $actionPermissions): void

--- a/src/Backend/Modules/Groups/Engine/Model.php
+++ b/src/Backend/Modules/Groups/Engine/Model.php
@@ -52,10 +52,13 @@ class Model
 
     public static function delete(int $groupId): void
     {
-        BackendModel::getContainer()->get('database')->delete('groups', 'id = ?', [$groupId]);
-        BackendModel::getContainer()->get('database')->delete('groups_settings', 'group_id = ?', [$groupId]);
-        BackendModel::getContainer()->get('database')->delete('groups_rights_actions', 'group_id = ?', [$groupId]);
-        BackendModel::getContainer()->get('database')->delete('groups_rights_modules', 'group_id = ?', [$groupId]);
+        /** @var SpoonDatabase $database */
+        $database = BackendModel::getContainer()->get('database');
+
+        $database->delete('groups', 'id = ?', [$groupId]);
+        $database->delete('groups_settings', 'group_id = ?', [$groupId]);
+        $database->delete('groups_rights_actions', 'group_id = ?', [$groupId]);
+        $database->delete('groups_rights_modules', 'group_id = ?', [$groupId]);
     }
 
     public static function deleteActionPermissions(array $actionPermissions): void


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description

When a group is deleted, the linked settings and rights are not being deleted. This leaves some garbage in the database, which is not a good thing.

