### PR TITLE
Fix check if user belongs to a certain group

### DIFF
--- a/src/Backend/Modules/Groups/Engine/Model.php
+++ b/src/Backend/Modules/Groups/Engine/Model.php
@@ -166,7 +166,7 @@ class Model
         $groupsByUser = static::getGroupsByUser($userId);
 
         foreach ($groupsByUser as $group) {
-            if ($group['id'] === $groupId) {
+            if ((int) $group['id'] === $groupId) {
                 return true;
             }
         }


### PR DESCRIPTION
The group id coming from the database is a string and it must cast as an integer for the comparison.

## Type

- Non critical bugfix

## Pull request description

The comparison between the group id coming from the database and the one provided in the method `Model::isUserInGroup` of the Groups module should be done using integers.
The value coming from the database is now a string and the value passed into the method is an integer.
