### PR TITLE
Track mailto links as external links

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -532,7 +532,7 @@ jsFrontend.statistics = {
     if (typeof _gaq === 'object' || typeof ga === 'function') {
       // create a new selector
       $.expr[':'].external = function (obj) {
-        return (typeof obj.href !== 'undefined') && !obj.href.match(/^mailto:/) && (obj.hostname !== window.location.hostname)
+        return (typeof obj.href !== 'undefined') && (obj.hostname !== window.location.hostname)
       }
 
       // bind on all links that don't have the class noTracking


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
fixes #2359

## Pull request description
fix mailto links were excluded from the external tracking but we did have a method on how to track them, so now we will actually track them

