### PR TITLE
Only copy the location widgets to an other locale if the Location module is installed

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -105,13 +105,15 @@ class Model
         // define old block ids
         $contentBlockOldIds = array_keys($contentBlockIds);
 
-        // copy location widgets and get copied widget ids
-        $copyLocationWidgets = new CopyLocationWidgetsToOtherLocale($toLocale, $fromLocale);
-        $commandBus->handle($copyLocationWidgets);
-        $locationWidgetIds = $copyLocationWidgets->extraIdMap;
+        if (BackendModel::isModuleInstalled('Location')) {
+            // copy location widgets and get copied widget ids
+            $copyLocationWidgets = new CopyLocationWidgetsToOtherLocale($toLocale, $fromLocale);
+            $commandBus->handle($copyLocationWidgets);
+            $locationWidgetIds = $copyLocationWidgets->extraIdMap;
 
-        // define old block ids
-        $locationWidgetOldIds = array_keys($locationWidgetIds);
+            // define old block ids
+            $locationWidgetOldIds = array_keys($locationWidgetIds);
+        }
 
         // get all old pages
         $ids = $database->getColumn(
@@ -238,9 +240,11 @@ class Model
                     $block['extra_id'] = $contentBlockIds[$block['extra_id']];
                 }
 
-                // Overwrite the extra_id of the old location widget with the id of the new one
-                if (in_array($block['extra_id'], $locationWidgetOldIds)) {
-                    $block['extra_id'] = $locationWidgetIds[$block['extra_id']];
+                if (BackendModel::isModuleInstalled('Location')) {
+                    // Overwrite the extra_id of the old location widget with the id of the new one
+                    if (in_array($block['extra_id'], $locationWidgetOldIds)) {
+                        $block['extra_id'] = $locationWidgetIds[$block['extra_id']];
+                    }
                 }
 
                 // add block


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
If it's not installed it would've thrown an error when copying pages to an other locale

