### PR TITLE
Use type="button" on buttons that trigger modals

### DIFF
--- a/src/Backend/Modules/Locale/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Locale/Layout/Templates/Edit.html.twig
@@ -58,7 +58,7 @@
       <div class="btn-toolbar">
         {% if showLocaleDelete %}
           <div class="btn-group pull-left" role="group">
-            {{ macro.buttonIcon('', 'trash-o', 'lbl.Delete'|trans|ucfirst, 'btn-danger', {"type":"submit", "data-toggle":"modal", "data-target":"#confirmDelete"}) }}
+            {{ macro.buttonIcon('', 'trash-o', 'lbl.Delete'|trans|ucfirst, 'btn-danger', {"type":"button", "data-toggle":"modal", "data-target":"#confirmDelete"}) }}
           </div>
         {% endif %}
         <div class="btn-group pull-right" role="group">


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
Use type="button" on buttons that trigger modals
using type="submit" triggers a submit, obviously.

