### PR TITLE
Fix google reCAPTCHA javascript link in production

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -331,7 +331,7 @@ class Form extends FrontendBaseWidget
         $this->template->assign('successMessage', false);
 
         if ($this->hasRecaptchaField) {
-            $this->header->addJS('https://www.google.com/recaptcha/api.js?hl=' . Locale::frontendLanguage());
+            $this->header->addJS('https://www.google.com/recaptcha/api.js?hl=' . Locale::frontendLanguage(), false);
             $this->template->assign('hasRecaptchaField', true);
             $this->template->assign('siteKey', FrontendModel::get('fork.settings')->get('Core', 'google_recaptcha_site_key'));
         }


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

Using `$this->header->addJS(`, we add a link.
The second parameter is by default true and that means it will get minified in production.
That is wrong (because it is a link) and causes an error and stopping google reCAPTCHA from working.

## Pull request description

The JavaScript file is a link, so it has no content and therefore does not need to be minified.