### PR TITLE
Updated Twigtemplate so language gets set

### DIFF
--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -2,6 +2,7 @@
 
 namespace Frontend\Core\Engine;
 
+use Frontend\Core\Language\Locale;
 use Common\Core\Twig\BaseTwigTemplate;
 use Common\Core\Twig\Extensions\TwigFilters;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
@@ -31,6 +32,7 @@ class TwigTemplate extends BaseTwigTemplate
     ) {
         $container = Model::getContainer();
         $this->forkSettings = $container->get('fork.settings');
+        $this->language = Locale::frontendLanguage();
 
         parent::__construct($environment, $parser, $locator);
 

--- a/src/Frontend/Core/Language/Locale.php
+++ b/src/Frontend/Core/Language/Locale.php
@@ -6,9 +6,13 @@ use Common\Locale as CommonLocale;
 
 final class Locale extends CommonLocale
 {
-    public static function frontendLanguage(): self
+    public static function frontendLanguage(): ?self
     {
-        return new self(FRONTEND_LANGUAGE);
+        if (\defined('FRONTEND_LANGUAGE')) {
+            return new self(FRONTEND_LANGUAGE);
+        }
+
+        return null;
     }
 
     protected function getPossibleLanguages(): array


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Set the language so it is available to be assigned in Common/Core/Twig/BaseTwigTemplate.php to the frontend variables. For the Backend this was already set. Because this was not set the isEN or other language checks would not work anymore in the frontend templates.

