### PR TITLE
Add CurlPost to Google Recaptcha

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -12,6 +12,7 @@ use Frontend\Modules\FormBuilder\Engine\Model as FrontendFormBuilderModel;
 use Frontend\Modules\FormBuilder\FormBuilderEvents;
 use Frontend\Modules\FormBuilder\Event\FormBuilderSubmittedEvent;
 use ReCaptcha\ReCaptcha;
+use ReCaptcha\RequestMethod\CurlPost;
 use SpoonFormAttributes;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -411,7 +412,7 @@ class Form extends FrontendBaseWidget
                     $this->form->addError(FL::err('RecaptchaInvalid'));
                 }
 
-                $recaptcha = new ReCaptcha($secret);
+                $recaptcha = new ReCaptcha($secret, new CurlPost());
 
                 $response = $recaptcha->verify($response);
 


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

Add CurlPost to Google Recaptcha

We add this because otherwise "allow_url_fopen" must be enabled, otherwise a "invalid-json" error will be thrown by Google.
Using CurlPost, it does not listen to "allow_url_fopen" and it always works.