### PR TITLE
Formbuilder: 'send mail' fix

### DIFF
--- a/src/Frontend/Modules/FormBuilder/Event/FormBuilderSubmittedEvent.php
+++ b/src/Frontend/Modules/FormBuilder/Event/FormBuilderSubmittedEvent.php
@@ -25,7 +25,7 @@ class FormBuilderSubmittedEvent extends Event
      */
     protected $dataId;
 
-    public function __construct(array $form, array $data, int $dataId)
+    public function __construct(array $form, array $data, ?int $dataId)
     {
         $this->form = $form;
         $this->data = $data;


### PR DESCRIPTION
Making sure the form in frontend Formbuilder dont break on send using the 'Send mail' method.

## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

fixes https://github.com/forkcms/forkcms/issues/2533

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Making it possible to submit a form in frontend with the 'Send mail' function.

