### PR TITLE
Set blue link in blog dashboard widget bolder for a higher color cont…

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Widgets/Comments.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Widgets/Comments.html.twig
@@ -20,7 +20,7 @@
         <tbody>
           {% for blogComment in blogComments %}
             <tr class="{{ cycle(['odd', 'even'], loop.index0) }}">
-              <td><a href="{{ blogComment.full_url }}">{{ blogComment.title }}</a></td>
+              <td class="title"><a href="{{ blogComment.full_url }}">{{ blogComment.title }}</a></td>
               <td class="name">{{ blogComment.author }}</td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
…rast ratio

## Type
- Enhancement

## Pull request description
This will make the color contrast ratio higher in the blog dashboard widget, the blue text was hard to read on the table rows with a gray background.

