### PR TITLE
Import macros because they are used

### DIFF
--- a/src/Backend/Modules/Mailmotor/Layout/Templates/Settings.html.twig
+++ b/src/Backend/Modules/Mailmotor/Layout/Templates/Settings.html.twig
@@ -1,4 +1,5 @@
 {% extends 'Layout/Templates/base.html.twig' %}
+{% import 'Layout/Templates/macros.html.twig' as macro %}
 
 {% block content %}
   {{ form_start(form) }}


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
The settings page of mailmotor does not work because the macros where not imported.

