### PR TITLE
Fix docker image not building because libpng12-dev was not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN a2enmod rewrite
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libpng12-dev && \
+    libpng-dev && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Replaced it with libpng-dev instead

## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix


## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Creating a new docker image didn't work anymore, this fixes it
