### PR TITLE
Default console env should be prod, it is also documentent that way

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -18,8 +18,8 @@ use Symfony\Component\Debug\Debug;
 use Backend\Init as BackendInit;
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
+$env = $input->getParameterOption(array('--env', '-e'), getenv('FORK_ENV') ?: 'prod');
+$debug = getenv('FORK_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 // Fork has not yet been installed
 $parametersFile = __DIR__ . '/../app/config/parameters.yml';


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
Fixes #2236 


## Pull request description
<!-- Describe what your pull request will fix / add / … -->
`  -e, --env=ENV         The Environment name. [default: "prod"]`
Is in the documentation, but we had it on dev


