### PR TITLE
increase log level for the dockerstdout since it also impacts the console commands

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -16,7 +16,7 @@ monolog:
         dockerstdout:
             type: stream
             path: php://stdout
-            level: debug
+            level: error
             formatter: monolog.full_trace_formatter
             channels: ["!event"]
 


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

We got a lot of stuff that we didn't need mixed in with the console commands because of the log level for docker

