### PR TITLE
Remove duplicate id="fine-uploader-gallery" element

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaLibraryUpload.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaLibraryUpload.html.twig
@@ -141,7 +141,6 @@
           </div>
         </div>
       </div>
-      <div id="fine-uploader-gallery"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

`<div id="fine-uploader-gallery"></div>` was twice in this template, so I removed one.
