### PR TITLE
Fix array instead of file name passed on to the function

### DIFF
--- a/src/Backend/Modules/Extensions/Actions/UploadModule.php
+++ b/src/Backend/Modules/Extensions/Actions/UploadModule.php
@@ -87,7 +87,7 @@ class UploadModule extends BackendBaseActionAdd
             $fileName = $file['name'];
 
             if ($i === 0) {
-                $prefix = $this->extractPrefix($file);
+                $prefix = $this->extractPrefix($file['name']);
             }
 
             // check if the file is in one of the valid directories
@@ -184,7 +184,7 @@ class UploadModule extends BackendBaseActionAdd
      */
     private function extractPrefix(string $file): string
     {
-        $name = explode(PATH_SEPARATOR, $file['name']);
+        $name = explode(PATH_SEPARATOR, $file);
         $prefix = [];
 
         foreach ($name as $element) {
@@ -197,7 +197,7 @@ class UploadModule extends BackendBaseActionAdd
 
         // If the zip has a top-level single directory, eg
         // /myModuleName/, then we should just assume that is the prefix.
-        return $file['name'];
+        return $file;
     }
 
     /**


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
The upload module action was broken because of typehints and faulty data being passed on to that method
