### PR TITLE
2565 media library folder name longer than one word

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php
@@ -3,7 +3,6 @@
 namespace Backend\Modules\MediaLibrary\Domain\MediaFolder;
 
 use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItem;
-use Common\Uri;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -104,7 +103,7 @@ class MediaFolder implements JsonSerializable
         ?MediaFolder $parent,
         int $userId
     ) {
-        $this->setName($name);
+        $this->name = $name;
         $this->parent = $parent;
         $this->userId = $userId;
         $this->items = new ArrayCollection();
@@ -125,7 +124,7 @@ class MediaFolder implements JsonSerializable
 
     public function update(string $name, MediaFolder $parent = null)
     {
-        $this->setName($name);
+        $this->name = $name;
 
         if ($parent instanceof self) {
             $this->setParent($parent);
@@ -207,13 +206,6 @@ class MediaFolder implements JsonSerializable
     public function getName(): string
     {
         return $this->name;
-    }
-
-    private function setName(string $name): self
-    {
-        $this->name = Uri::getUrl($name);
-
-        return $this;
     }
 
     public function getCreatedOn(): \DateTime


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
Fixes #2565 

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

The white spaces from a folder with a name longer then one word won't be urlised anymore