### PR TITLE
Make sure we can empty the datepicker field

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -282,6 +282,13 @@ jsFrontend.forms = {
           // Rename the original field, used to contain the display value
           $(this).attr('id', $(this).attr('id') + '-display')
           $(this).attr('name', $(this).attr('name') + '-display')
+
+          // make sure we can make the value empty
+          $(this).on('change', function (event) {
+            if ($(this).val() === '') {
+              clone.val('')
+            }
+          })
         })
 
         $inputDatefields.datepicker({


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Now when you have a datepicker, you can't make it empty again. When you remove the value and submit, it just remembers the old value. This fixes it.

