### PR TITLE
Media folders were still being encoded on edit

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaFolderEdit.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaFolderEdit.php
@@ -59,7 +59,7 @@ class MediaFolderEdit extends BackendBaseAJAXAction
             throw new AjaxExitException(Language::err('TitleIsRequired'));
         }
 
-        return Uri::getUrl($name);
+        return $name;
     }
 
     private function updateMediaFolder(): UpdateMediaFolder


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
In 5.4 we stopped urlising media library folder names. But we forgot to do that change in the edit as well.

