### PR TITLE
When using the modulesettings in your services the installation won't work anymore.

### DIFF
--- a/app/config/config_install.yml
+++ b/app/config/config_install.yml
@@ -50,15 +50,8 @@ services:
     mailer_configurator:
         class: stdClass
 
-    # dummy service during the installation
-    fork.settings:
-        class: stdClass
-        public: true
-
-    # dummy service during the installation
     cache.pool:
-        class: stdClass
-        public: true
+        class: Symfony\Component\Cache\Adapter\ArrayAdapter
 
     database:
         class: SpoonDatabase


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

This pr fixes that issue by using actual implementations instead of stdClass
