### PR TITLE
Fixed thumbnail resize

### DIFF
--- a/src/ForkCMS/Utility/Thumbnails.php
+++ b/src/ForkCMS/Utility/Thumbnails.php
@@ -84,21 +84,28 @@ class Thumbnails
         if ($folder['width'] !== null && $folder['height'] !== null) {
             // we scale on the smaller dimension
             if ($box->getWidth() > $box->getHeight()) {
-                $width  = $box->getWidth() * ($folder['height']/$box->getHeight());
-                $height =  $folder['height'];
+                $width  = $folder['width'];
+                $height = $folder['height'];
+
+                if ($box->getWidth() < $width) {
+                    $height = ($box->getHeight() / $box->getWidth()) * $width;
+                    $image = $image->resize(new Box($width, $height));
+                } else {
+                    $image = $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
+                }
 
                 // we center the crop in relation to the width
-                $cropPoint = new Point(max($width - $folder['width'], 0)/2, 0);
+                $cropPoint = new Point(0, 0);
             } else {
                 $width  = $folder['width'];
                 $height =  $box->getHeight() * ($folder['width']/$box->getWidth());
 
+                // we scale the image to make the smaller dimension fit our resize box
+                $image = $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
+
                 // we center the crop in relation to the height
                 $cropPoint = new Point(0, max($height - $folder['height'], 0)/2);
             }
-
-            // we scale the image to make the smaller dimension fit our resize box
-            $image = $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
 
             // and crop exactly to the box
             $image->crop($cropPoint, new Box($folder['width'], $folder['height']));


### PR DESCRIPTION
## Type
Critical bugfix

## Resolves the following issues
#2640 

## Pull request description
Fix thumbnail resize

The original image:
![original](https://user-images.githubusercontent.com/310526/45363355-99ef6800-b5d7-11e8-9b13-88e7c52d1671.jpeg)

Cropped image:
![cropped](https://user-images.githubusercontent.com/310526/45363361-9eb41c00-b5d7-11e8-98b7-9f0097b17d58.jpeg)