### PR TITLE
Preserve sorted order of images

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemGetAllById.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemGetAllById.php
@@ -34,6 +34,12 @@ class MediaItemGetAllById extends BackendBaseAJAXAction
             return [];
         }
 
-        return $this->get('media_library.repository.item')->findById($ids);
+        $mediaItems = [];
+
+        foreach ($ids as $id) {
+            $mediaItems[] = $this->get('media_library.repository.item')->findOneById($id);
+        }
+
+        return $mediaItems;
     }
 }


### PR DESCRIPTION
## Type
Non critical bugfix

## Pull request description
When a user sorted the images it would save perfectly. But when the
user reloads the edit page the order would be gone. By this the order
is preserved and can be used as expected.