### PR TITLE
Don't show description in autocomplete suggestion

### DIFF
--- a/src/Frontend/Modules/Search/Js/Search.js
+++ b/src/Frontend/Modules/Search/Js/Search.js
@@ -70,7 +70,7 @@ jsFrontend.search =
       source: searchEngine,
       templates: {
         suggestion: function (data) {
-          return '<a><strong>' + data.value + '</strong><p>' + data.description + '</p></a>'
+          return '<a><strong>' + data.value + '</strong><p>'
         }
       }
     }).bind('typeahead:select', function (ev, suggestion) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
fixes #2647 

## Pull request description
Removes the full HTML description rendering in the autosuggest dropdown or the search widget.

