### PR TITLE
Only build the navigation cache if vital information has changed

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -765,7 +765,17 @@ class Edit extends BackendBaseActionEdit
 
         $this->saveTags($page['id']);
 
-        BackendPagesModel::buildCache(BL::getWorkingLanguage());
+        $cacheShouldBeUpdated = !(
+            $this->record['title'] === $page['title']
+            && $this->record['navigation_title'] === $page['navigation_title']
+            && $this->record['navigation_title_overwrite'] === $page['navigation_title_overwrite']
+            && $this->record['hidden'] === $page['hidden']
+        );
+
+        // build cache
+        if ($cacheShouldBeUpdated) {
+            BackendPagesModel::buildCache(BL::getWorkingLanguage());
+        }
 
         if ($page['status'] === 'draft') {
             $this->redirect(


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Only build the navigation cache if vital information has changed. When editing a page we don't need to rebuild the navigation cache if we only changed a typo or a block. It should only be rebuilt if the title, navigation_title or published properties changed.

This is a rather small enhancement but might be useful for sites with a lot of pages.

