### PR TITLE
Bugfix // Fix search settings error

### DIFF
--- a/src/Backend/Modules/Search/Actions/Settings.php
+++ b/src/Backend/Modules/Search/Actions/Settings.php
@@ -162,7 +162,7 @@ class Settings extends BackendBaseActionEdit
 
                 // module search
                 foreach ((array) $this->modules as $module) {
-                    $searchable = $this->form->getField('search_' . $module['module'])->getChecked();
+                    $searchable = (int) $this->form->getField('search_' . $module['module'])->getChecked();
                     $weight = $this->form->getField('search_' . $module['module'] . '_weight')->getValue();
 
                     BackendSearchModel::insertModuleSettings($module['module'], $searchable, $weight);


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues
- Saving the search settings with not all modules enabled generates an error on the searchable column (expects int and saved as 'null')

## Pull request description
- casting to int to save a 0 instead of 'null'

