### PR TITLE
Fix the HTTPS detection when getting the configuration during install

### DIFF
--- a/src/ForkCMS/Bundle/InstallerBundle/Service/ForkInstaller.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Service/ForkInstaller.php
@@ -307,9 +307,7 @@ class ForkInstaller
             '<database-user>' => addslashes($data->getDatabaseUsername()),
             '<database-password>' => addslashes($data->getDatabasePassword()),
             '<database-port>' => $data->getDatabasePort(),
-            '<site-protocol>' => isset($_SERVER['SERVER_PROTOCOL']) ?
-                (mb_strpos(mb_strtolower($_SERVER['SERVER_PROTOCOL']), 'https') === false ? 'http' : 'https') :
-                'http',
+            '<site-protocol>' => isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http',
             '<site-domain>' => $_SERVER['HTTP_HOST'] ?? 'fork.local',
             '<site-default-title>' => 'Fork CMS',
             '<site-multilanguage>' => $data->getLanguageType() === 'multiple' ? 'true' : 'false',

--- a/src/ForkCMS/Bundle/InstallerBundle/Service/ForkInstaller.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Service/ForkInstaller.php
@@ -307,7 +307,7 @@ class ForkInstaller
             '<database-user>' => addslashes($data->getDatabaseUsername()),
             '<database-password>' => addslashes($data->getDatabasePassword()),
             '<database-port>' => $data->getDatabasePort(),
-            '<site-protocol>' => isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) ? 'https' : 'http',
+            '<site-protocol>' => $this->isHttpRequest() ? 'https' : 'http',
             '<site-domain>' => $_SERVER['HTTP_HOST'] ?? 'fork.local',
             '<site-default-title>' => 'Fork CMS',
             '<site-multilanguage>' => $data->getLanguageType() === 'multiple' ? 'true' : 'false',
@@ -317,6 +317,19 @@ class ForkInstaller
             '<action-rights-level>' => 7,
             '<secret>' => Model::generateRandomString(32, true, true, true, false),
         ];
+    }
+
+    private function isHttpRequest(): bool
+    {
+        if (!isset($_SERVER['HTTPS'])) {
+            return false;
+        }
+
+        if (empty($_SERVER['HTTPS'])) {
+            return false;
+        }
+
+        return strtolower($_SERVER['HTTPS']) !== 'off';
     }
 
     /**


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
fixes #2614 

## Pull request description
Use the `HTTPS` server variable's existence instead of checking the `SERVER_PROTOCOL` variable.
See http://php.net/manual/en/reserved.variables.server.php

