### PR TITLE
Order by sequence ASC when enabling sequence by drag and drop

### DIFF
--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -276,6 +276,8 @@ class DataGrid extends \SpoonDataGrid
 
         // hide the sequence column if present
         if ($this->hasColumn('sequence')) {
+            $this->setSortingColumns(['sequence']);
+            $this->setSortParameter('asc');
             $this->setColumnHidden('sequence');
         }
 


### PR DESCRIPTION
## Type
- Enhancement
- Feature

## Pull request description
Just a small ease of life improvement. No need to order in your query when enabling sequence by drag and drop.

