### PR TITLE
Fix related tags type error

### DIFF
--- a/src/Frontend/Modules/Tags/Widgets/Related.php
+++ b/src/Frontend/Modules/Tags/Widgets/Related.php
@@ -112,40 +112,28 @@ class Related extends FrontendBaseWidget
      */
     private function getTags(): void
     {
-        // get page id
         $pageId = $this->getContainer()->get('page')->getId();
-
-        // array of excluded records
         $this->exclude[] = ['module' => 'Pages', 'other_id' => $pageId];
 
-        // get tags for page
         $tags = (array) FrontendTagsModel::getForItem('pages', $pageId);
         foreach ($tags as $tag) {
             $this->tags = array_merge((array) $this->tags, (array) $tag['name']);
         }
 
-        // get page record
         $record = (array) FrontendNavigation::getPageInfo($pageId);
-
-        // loop blocks
         foreach ((array) $record['extra_blocks'] as $block) {
-            // set module class
             $class = 'Frontend\\Modules\\' . $block['module'] . '\\Engine\\Model';
 
             if (is_callable([$class, 'getIdForTags'])) {
-                // get record for module
-                $record = FrontendTagsModel::callFromInterface($block['module'], $class, 'getIdForTags', $this->url);
+                $itemId = FrontendTagsModel::callFromInterface($block['module'], $class, 'getIdForTags', $this->url);
 
-                // check if record exists
-                if (!$record) {
+                if (!$itemId) {
                     continue;
                 }
 
-                // add to excluded records
-                $this->exclude[] = ['module' => $block['module'], 'other_id' => $record['id']];
+                $this->exclude[] = ['module' => $block['module'], 'other_id' => $itemId];
 
-                // get record's tags
-                $tags = (array) FrontendTagsModel::getForItem($block['module'], $record['id']);
+                $tags = (array) FrontendTagsModel::getForItem($block['module'], $itemId);
                 foreach ($tags as $tag) {
                     $this->tags = array_merge((array) $this->tags, (array) $tag['name']);
                 }


### PR DESCRIPTION

## Type
- Critical bugfix

## Pull request description
The related tags widget did not work, because of an error.
Type error: Argument 2 passed to Frontend\Modules\Tags\Engine\Model::getForItem() must be of the type integer, null given, called in src/Frontend/Modules/Tags/Widgets/Related.php on line 152

The getIdForTags function returns an id and not a record as assumed in the related widget code.
Also removed useless comments in this function.
