### PR TITLE
Use a valid date format

### DIFF
--- a/src/Frontend/Modules/Blog/Layout/Templates/Archive.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Archive.html.twig
@@ -41,7 +41,7 @@
             {% for item in items %}
               <tr>
                 <td class="date">
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
                     {{ item.publish_on|spoondate(dateFormatShort,LANGUAGE ) }}
                   </time>
                 </td>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Category.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Category.html.twig
@@ -32,7 +32,7 @@
                 <div class="col-xs-12">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
                     {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Detail.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Detail.html.twig
@@ -23,7 +23,7 @@
           <div class="col-xs-12">
             {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
             {{ 'lbl.On'|trans }}
-            <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+            <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
               {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
             </time>
           </div>
@@ -145,7 +145,7 @@
                   </a>
                   {% endif %}
                   {{ 'lbl.Wrote'|trans }}
-                  <time itemprop="commentTime" datetime="{{ comment.created_on|date('Y-m-d\TH,i,s' ) }}">
+                  <time itemprop="commentTime" datetime="{{ comment.created_on|date('Y-m-d\\TH:i:s.vP' ) }}">
                     {{ comment.created_on|timeago|raw }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Index.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Index.html.twig
@@ -31,7 +31,7 @@
                 <div class="col-xs-12 col-md-8">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
                     {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
@@ -29,7 +29,7 @@
                 <div class="col-xs-12 col-md-8">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(post.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\TH,i,s') }}">
+                  <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\\TH:i:s.vP') }}">
                     {{ post.publish_on|spoondate(dateFormatLong, LANGUAGE ) }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Widgets/RecentComments.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Widgets/RecentComments.html.twig
@@ -19,7 +19,7 @@
                 {{ comment.author }}
               {% if comment.website %}</a>{% endif %}
               {{ 'lbl.CommentedOn'|trans }} <a href="{{ comment.full_url }}">{{ comment.post_title }}</a>
-              <time class="muted" itemprop="commentTime" datetime="{{ comment.created_on|date('Y-m-d\TH,i,s') }}">
+              <time class="muted" itemprop="commentTime" datetime="{{ comment.created_on|date('Y-m-d\\TH:i:s.vP') }}">
                 {{ comment.created_on|timeago|raw }}
               </time>
             </li>


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Improve readability of the time datetime property format. In certain cases the w3c validator throws an error.

