### PR TITLE
Catch mailmotor spamming errors

### DIFF
--- a/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
@@ -69,6 +69,8 @@ class Subscribe extends FrontendBaseBlock
                 throw $exception;
             }
 
+            $this->getContainer()->get('logger')->error('Mailmotor Subcribe Mailchimp error: ' . $reason);
+
             $this->template->assign('mailmotorSubscribeHasFormError', true);
             $this->template->assign('form', $form->createView());
 

--- a/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Subscribe.php
@@ -2,6 +2,7 @@
 
 namespace Frontend\Modules\Mailmotor\Actions;
 
+use Exception;
 use Frontend\Core\Engine\Base\Block as FrontendBaseBlock;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Core\Language\Locale;
@@ -61,6 +62,20 @@ class Subscribe extends FrontendBaseBlock
             );
 
             $doubleOptIn = false;
+        } catch (Exception $exception) {
+            $reason = json_decode($exception->getMessage());
+            // check if the error is one from mailchimp
+            if ($reason === false) {
+                throw $exception;
+            }
+
+            $this->template->assign('mailmotorSubscribeHasFormError', true);
+            $this->template->assign('form', $form->createView());
+
+            $this->loadTemplate();
+            $this->parse();
+
+            return;
         }
 
         $redirectLink .= '&double-opt-in=';

--- a/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
+++ b/src/Frontend/Modules/Mailmotor/Actions/Unsubscribe.php
@@ -2,6 +2,7 @@
 
 namespace Frontend\Modules\Mailmotor\Actions;
 
+use Exception;
 use Frontend\Core\Engine\Base\Block as FrontendBaseBlock;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Core\Language\Locale;
@@ -51,6 +52,20 @@ class Unsubscribe extends FrontendBaseBlock
                 NotImplementedUnsubscribedEvent::EVENT_NAME,
                 new NotImplementedUnsubscribedEvent($unsubscription)
             );
+        } catch (Exception $exception) {
+            $reason = json_decode($exception->getMessage());
+            // check if the error is one from mailchimp
+            if ($reason === false) {
+                throw $exception;
+            }
+
+            $this->template->assign('mailmotorUnsubscribeHasFormError', true);
+            $this->template->assign('form', $form->createView());
+
+            $this->loadTemplate();
+            $this->parse();
+
+            return;
         }
 
         $this->redirect(


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

When spammers fill in the mailmotor subscribe they can trigger the following error:
```json
{"type":"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/","title":"Invalid Resource","status":400,"detail":"tcr10112@gmail.com has signed up to a lot of lists very recently; we're not allowing more signups for now","instance":"xxxxxxxxx"}
```
this will catch it and keep spammers from messing up your error log

