### PR TITLE
Fix case of DateTime class name usage

### DIFF
--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGallery.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGallery.php
@@ -204,7 +204,7 @@ class MediaGallery
      */
     public function onPrePersist()
     {
-        $this->createdOn = $this->editedOn = new \Datetime();
+        $this->createdOn = $this->editedOn = new \DateTime();
 
         $this->moduleExtraId = Model::insertExtra(
             ModuleExtraType::widget(),
@@ -221,7 +221,7 @@ class MediaGallery
      */
     public function onPreUpdate()
     {
-        $this->editedOn = new \Datetime();
+        $this->editedOn = new \DateTime();
     }
 
     /**

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php
@@ -285,7 +285,7 @@ class MediaFolder implements JsonSerializable
      */
     public function onPrePersist()
     {
-        $this->createdOn = $this->editedOn = new \Datetime();
+        $this->createdOn = $this->editedOn = new \DateTime();
     }
 
     /**
@@ -293,6 +293,6 @@ class MediaFolder implements JsonSerializable
      */
     public function onPreUpdate()
     {
-        $this->editedOn = new \Datetime();
+        $this->editedOn = new \DateTime();
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
@@ -227,7 +227,7 @@ class MediaGroup implements JsonSerializable, Countable
      */
     public function onPrePersist()
     {
-        $this->editedOn = new \Datetime();
+        $this->editedOn = new \DateTime();
         $this->setNumberOfConnectedItems();
     }
 
@@ -236,7 +236,7 @@ class MediaGroup implements JsonSerializable, Countable
      */
     public function onPreUpdate()
     {
-        $this->editedOn = new \Datetime();
+        $this->editedOn = new \DateTime();
         $this->setNumberOfConnectedItems();
     }
 

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
@@ -477,7 +477,7 @@ class MediaItem implements JsonSerializable
      */
     public function onPrePersist()
     {
-        $this->createdOn = $this->editedOn = new \Datetime();
+        $this->createdOn = $this->editedOn = new \DateTime();
 
         $this->refreshAspectRatio();
     }
@@ -487,7 +487,7 @@ class MediaItem implements JsonSerializable
      */
     public function onPreUpdate()
     {
-        $this->editedOn = new \Datetime();
+        $this->editedOn = new \DateTime();
 
         $this->refreshAspectRatio();
     }


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
In some places the `DateTime` class constructor is being used with incorrect casing (`Datetime` instead of `DateTime`).

