### PR TITLE
Use find method instead of magic method

### DIFF
--- a/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGalleryRepository.php
+++ b/src/Backend/Modules/MediaGalleries/Domain/MediaGallery/MediaGalleryRepository.php
@@ -32,7 +32,7 @@ final class MediaGalleryRepository extends EntityRepository
         }
 
         /** @var MediaGallery|null $mediaGallery */
-        $mediaGallery = parent::findOneById($id);
+        $mediaGallery = $this->find($id);
 
         if ($mediaGallery === null) {
             throw MediaGalleryNotFound::forId($id);

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolderRepository.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolderRepository.php
@@ -58,7 +58,7 @@ final class MediaFolderRepository extends EntityRepository
             throw MediaFolderNotFound::forEmptyId();
         }
 
-        $mediaFolder = parent::findOneById($id);
+        $mediaFolder = $this->find($id);
 
         if ($mediaFolder === null) {
             throw MediaFolderNotFound::forId($id);

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroupRepository.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroupRepository.php
@@ -20,7 +20,7 @@ final class MediaGroupRepository extends EntityRepository
         }
 
         /** @var MediaGroup $mediaGroup */
-        $mediaGroup = parent::findOneById($id);
+        $mediaGroup = $this->find($id);
 
         if ($mediaGroup === null) {
             throw MediaGroupNotFound::forId($id);


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description
This PR replaces the usage of the magic method `findOneById` with the method `find` in the MediaLibrary and MediaGallery modules.
