### PR TITLE
Don't set the row parameter in the Categories action's datagrid

### DIFF
--- a/src/Backend/Modules/Faq/Actions/Categories.php
+++ b/src/Backend/Modules/Faq/Actions/Categories.php
@@ -47,7 +47,6 @@ class Categories extends BackendBaseActionIndex
         } else {
             $this->dataGrid->setColumnsHidden(['sequence']);
         }
-        $this->dataGrid->setRowAttributes(['id' => '[id]']);
         $this->dataGrid->setPaging(false);
 
         // check if this action is allowed


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Sequencing FAQ categories didn't work again, so I fixed it.. again.
We need to update DataGrid to twig ASAP.

