### PR TITLE
Create folders on the Media Library overview

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryFolders.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryFolders.js
@@ -18,7 +18,7 @@ jsBackend.mediaLibraryFolders = {
     var selectedFolderId = (utils.url.getGetValue('folder')) ? utils.url.getGetValue('folder') : ''
 
     // add folders on startup
-    if ($('#uploadMediaFolderId').length > 0) {
+    if ($('#uploadMediaFolderId').length > 0 || $('#addFolderParentId').length > 0) {
       jsBackend.mediaLibraryFolders.updateFolders(selectedFolderId)
     }
 
@@ -118,7 +118,7 @@ jsBackend.mediaLibraryFolders = {
         // update folders in media module
         if (!dialog) {
           // add folders to dropdowns
-          $('#mediaFolders, #uploadMediaFolderId').html(html)
+          $('#mediaFolders, #uploadMediaFolderId, #addFolderParentId').html(html)
 
           // select the new folder
           if (selectFolderId) {

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryFolders.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryFolders.js
@@ -128,7 +128,9 @@ jsBackend.mediaLibraryFolders = {
           }
 
           // update boxes
-          jsBackend.mediaLibraryHelper.upload.toggleUploadBoxes()
+          if (typeof jsBackend.mediaLibraryHelper !== 'undefined') {
+            jsBackend.mediaLibraryHelper.upload.toggleUploadBoxes()
+          }
         }
 
         // add folders to dropdown

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
@@ -29,6 +29,9 @@
         {% endif %}
         {% if not mediaFolder %}
           {{ macro.buttonIcon( geturl('MediaItemUpload'), 'upload', 'lbl.AddMediaItems'|trans|capitalize) }}
+          <a href="#" id="addFolder" class="btn btn-default" title="{{ 'lbl.MediaAddFolder'|trans|capitalize }}">
+            <span>{{ macro.icon('folder') }}{{ 'lbl.MediaAddFolder'|trans|capitalize }}</span>
+          </a>
         {% endif %}
       {% endif %}
     </div>


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
fixes #2563

## Pull request description
Make it possible to add folders on the Media Library overview page.
I have added a button in the menu that calls the add folder modal and loads the folder list in a dropdown menu.

