### PR TITLE
Use correct check for blog detail revision

### DIFF
--- a/src/Frontend/Modules/Blog/Actions/Detail.php
+++ b/src/Frontend/Modules/Blog/Actions/Detail.php
@@ -57,7 +57,7 @@ class Detail extends FrontendBaseBlock
         parent::setMeta($meta);
 
         // Add no-index, so the draft won't get accidentally indexed
-        if ($this->url->getParameter('revision', 'int') !== 0) {
+        if ($this->url->getParameter('revision', 'int') !== null) {
             $this->header->addMetaData(['name' => 'robots', 'content' => 'noindex, nofollow'], true);
         }
     }


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
getParameter returns `null` if the value isn't found. Therefor we need to check if it's `null`, not `0`.

This caused all blog posts since **Fork CMS 5.1.0** to not get cached by search engines. If this is something that is important to you, please fix this retroactively.

Thanks to @bramds for reporting the issue.
