### PR TITLE
Close all submenu's when opening and closing the menu tree

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -1555,13 +1555,17 @@ jsBackend.pages.tree = {
 
       if (collapsed) {
         $buttonText.html(jsBackend.locale.lbl('OpenTreeNavigation'))
-        $.tree.reference('#tree div').close_all()
+        $.each($('#tree div'), function (index, element) {
+          $.tree.reference($(element).attr('id')).close_all()
+        })
 
         return
       }
 
       $buttonText.html(jsBackend.locale.lbl('CloseTreeNavigation'))
-      $.tree.reference('#tree div').open_all()
+      $.each($('#tree div'), function (index, element) {
+        $.tree.reference($(element).attr('id')).open_all()
+      })
     })
   }
 }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
fixes #2685 

## Pull request description
Instead of targeting one menu div element, I am now looping through all the sub menu's to open or close them all.

