### PR TITLE
Fix "track" cookie

### DIFF
--- a/src/Frontend/Core/Engine/Model.php
+++ b/src/Frontend/Core/Engine/Model.php
@@ -238,7 +238,7 @@ class Model extends \Common\Core\Model
         $cookie = self::getContainer()->get('fork.cookie');
 
         // get/init tracking identifier
-        (self::$visitorId = $cookie->has('track') && $cookie->get('track', '') !== '')
+        self::$visitorId = ($cookie->has('track') && $cookie->get('track', '') !== '')
             ? $cookie->get('track')
             : md5(uniqid('', true) . self::getSession()->getId());
 


### PR DESCRIPTION
The "track" cookie was never set. It needed only a very small fix to enabled it ;-)

## Type
- Non critical bugfix

## Pull request description
The "track" cookie did not work. It did not work from version 5.0.0 and up.
The visitorId never got set because of bad php code.

You can test this bug on the demo website. You don't see that a cookie "track" is ever created.
https://demo.fork-cms.com
