### PR TITLE
allowed cookies fix

### DIFF
--- a/src/Common/Core/Cookie.php
+++ b/src/Common/Core/Cookie.php
@@ -146,7 +146,7 @@ final class Cookie
      */
     public function hasAllowedCookies(): bool
     {
-        return $this->get('cookie_bar_agree', 'N') === 'N';
+        return $this->get('cookie_bar_agree', 'N') === 'Y';
     }
 
     /**


### PR DESCRIPTION

## Type
- Non critical bugfix

## Pull request description
The hasAllowedCookies() function returns misleading values.
- It was testing for 'N', while that should be 'Y'.
- Because the default value is 'N' and it is testing for the value 'N', when no "cookie_bar_agree" was set, the function returns true.

This has been fixed.


