### PR TITLE
Check only for the existence of the Facebook API ID

### DIFF
--- a/src/Frontend/Core/Engine/Footer.php
+++ b/src/Frontend/Core/Engine/Footer.php
@@ -44,12 +44,10 @@ class Footer extends KernelLoader
         $this->template->assignGlobal('footerLinks', $footerLinks);
 
         $siteHTMLFooter = (string) $this->get('fork.settings')->get('Core', 'site_html_footer', null);
-
-        $facebookAdminIds = $this->get('fork.settings')->get('Core', 'facebook_admin_ids', null);
         $facebookAppId = $this->get('fork.settings')->get('Core', 'facebook_app_id', null);
 
         // facebook admins given?
-        if ($facebookAdminIds !== null || $facebookAppId !== null) {
+        if ($facebookAppId !== null) {
             // add Facebook container
             $siteHTMLFooter .= $this->getFacebookHtml($facebookAppId);
         }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

When loading the facebook snippet Fork is checking if one of the fields Facebook Admin IDs or Application ID is filled in. If we only fill in Admin IDs and no Application ID, this leads to an application error (500) on the frontend. This PR changes the verification to only take in consideration the Application ID, since the Admin IDs don't seem to be necessary to load the FB script.
