### PR TITLE
Capitalize action buttons in the datagrid

### DIFF
--- a/src/Backend/Core/Engine/DataGrid.php
+++ b/src/Backend/Core/Engine/DataGrid.php
@@ -118,7 +118,7 @@ class DataGrid extends \SpoonDataGrid
             $value =
                 '<a href="' . $url . '" class="btn btn-default btn-xs pull-right">' .
                 ($icon ? '<span class="fa ' . $icon . '" aria-hidden="true"></span>&nbsp;' : '') .
-                $value .
+                ucfirst($value) .
                 '</a>';
 
             // reset URL
@@ -130,7 +130,7 @@ class DataGrid extends \SpoonDataGrid
             $value =
                 '<a href="' . $url . '" class="btn btn-default btn-xs">' .
                 ($icon ? '<span class="fa ' . $icon . '"></span>&nbsp;' : '') .
-                $value .
+                ucfirst($value) .
                 '</a>';
 
             // reset URL


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
Datagrid action buttons are lowercased

## Pull request description
Capitalize datagrid action buttons

