### PR TITLE
Delete space between asterisk and label

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -5,7 +5,7 @@
   {{ block('help') }}
 {% endblock %}
 
-{% block form_label %}
+{%- block form_label -%}
   {% if 'checkbox' not in block_prefixes or widget_checkbox_label in ['label', 'both'] %}
     {% if label is not same as(false) %}
       {% if label is empty %}
@@ -22,12 +22,12 @@
       {% endif %}
       {% set label_attr = label_attr|merge({'class': label_attr.class|default('') ~ " " ~ label_attr_class ~ (required ? ' required' : ' optional') }) %}
       <label{% for attrname,attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-      {{ label }}{% if required %}{{- block('label_asterisk') }}{% endif %}
+      {{ label }}{% if required %}{{- block('label_asterisk') -}}{% endif %}
       </label>
 
     {% endif %}
   {% endif %}
-{% endblock form_label %}
+{%- endblock form_label -%}
 
 {% block checkbox_radio_label %}
   {% if widget is defined %}
@@ -54,8 +54,11 @@
 {% endblock checkbox_radio_label %}
 
 {%- block label_asterisk -%}
-  {% import 'Layout/Templates/macros.html.twig' as macro %}
-  {{ macro.required }}
+  {% spaceless %}
+    {% import 'Layout/Templates/macros.html.twig' as macro %}
+    {{ macro.required }}
+  {% endspaceless %}
+
 {%- endblock label_asterisk -%}
 
 {% block form_errors -%}

--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -58,7 +58,6 @@
     {% import 'Layout/Templates/macros.html.twig' as macro %}
     {{ macro.required }}
   {% endspaceless %}
-
 {%- endblock label_asterisk -%}
 
 {% block form_errors -%}

--- a/src/Backend/Core/Layout/Templates/macros.html.twig
+++ b/src/Backend/Core/Layout/Templates/macros.html.twig
@@ -19,9 +19,9 @@
   {% endif %}
 {% endmacro %}
 
-{% macro required() %}
+{%- macro required() -%}
   <abbr data-toggle="tooltip" aria-label="{{ 'lbl.RequiredField'|trans|ucfirst }}" title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr>
-{% endmacro %}
+{%- macro required() -%}
 
 {% macro icon(icon) %}
   <span class="fa fa-{{ icon }}" aria-hidden="true"></span>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues

## Pull request description
Delete the space between asterisk and label for form fields

