### PR TITLE
Fix that the whole panel is not focussed when clicking on an item within

### DIFF
--- a/src/Backend/Core/Layout/Sass/components/_tabs.scss
+++ b/src/Backend/Core/Layout/Sass/components/_tabs.scss
@@ -17,6 +17,10 @@
   }
 }
 
+div.active.tab-pane:focus {
+  outline: none;
+}
+
 .nav-tabs {
   .has-error,
   .active.has-error {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues

## Pull request description
When you clicked an checkbox / radio button within a tab content (p.ex. blog module > edit item > click hidden / published), the whole active tab would get a dotted outline onclick. This fixes that. 

