### PR TITLE
Autocomplete attributes on Formbuilder input fields

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -174,6 +174,21 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('datetime_classname');
         $this->form->addText('datetime_error_message');
 
+        // map the values to replace them with the backend translations
+        // use array combine to set the keys as the autocomplete values instead of key values
+        $this->form->addDropdown(
+            'datetime_autocomplete',
+            array_map(
+                function ($value) {
+                    return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
+                },
+                array_combine(
+                    Autocomplete::POSSIBLE_VALUES,
+                    Autocomplete::POSSIBLE_VALUES
+                )
+            )
+        );
+
         // dropdown dialog
         $this->form->addText('dropdown_label');
         $this->form->addText('dropdown_values');

--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -97,7 +97,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('textbox_validation_parameter');
         $this->form->addText('textbox_error_message');
 
-        $this->form->addDropdown('textbox_autocomplete', Autocomplete::getAutocompleteValues());
+        $this->form->addDropdown('textbox_autocomplete', Autocomplete::getValuesForDropdown());
 
         // textarea dialog
         $this->form->addText('textarea_label');
@@ -161,7 +161,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('datetime_classname');
         $this->form->addText('datetime_error_message');
 
-        $this->form->addDropdown('datetime_autocomplete', Autocomplete::getAutocompleteValues());
+        $this->form->addDropdown('datetime_autocomplete', Autocomplete::getValuesForDropdown());
 
         // dropdown dialog
         $this->form->addText('dropdown_label');

--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -102,7 +102,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addDropdown(
             'textbox_autocomplete',
             array_map(
-                function ($value) {
+                function (string $value): string {
                     return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
                 },
                 array_combine(
@@ -179,7 +179,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addDropdown(
             'datetime_autocomplete',
             array_map(
-                function ($value) {
+                function (string $value): string {
                     return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
                 },
                 array_combine(

--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -7,6 +7,7 @@ use Backend\Core\Engine\Model as BackendModel;
 use Backend\Core\Engine\Form as BackendForm;
 use Backend\Core\Language\Language as BL;
 use Backend\Form\Type\DeleteType;
+use Backend\Modules\FormBuilder\Engine\Autocomplete;
 use Frontend\Core\Language\Language as FL;
 use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
 use Backend\Modules\FormBuilder\Engine\Helper as FormBuilderHelper;
@@ -95,6 +96,21 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('textbox_confirmation_mail_subject');
         $this->form->addText('textbox_validation_parameter');
         $this->form->addText('textbox_error_message');
+
+        // map the values to replace them with the backend translations
+        // use array combine to set the keys as the autocomplete values instead of key values
+        $this->form->addDropdown(
+            'textbox_autocomplete',
+            array_map(
+                function ($value) {
+                    return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
+                },
+                array_combine(
+                    Autocomplete::POSSIBLE_VALUES,
+                    Autocomplete::POSSIBLE_VALUES
+                )
+            )
+        );
 
         // textarea dialog
         $this->form->addText('textarea_label');

--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -97,20 +97,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('textbox_validation_parameter');
         $this->form->addText('textbox_error_message');
 
-        // map the values to replace them with the backend translations
-        // use array combine to set the keys as the autocomplete values instead of key values
-        $this->form->addDropdown(
-            'textbox_autocomplete',
-            array_map(
-                function (string $value): string {
-                    return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
-                },
-                array_combine(
-                    Autocomplete::POSSIBLE_VALUES,
-                    Autocomplete::POSSIBLE_VALUES
-                )
-            )
-        );
+        $this->form->addDropdown('textbox_autocomplete', Autocomplete::getAutocompleteValues());
 
         // textarea dialog
         $this->form->addText('textarea_label');
@@ -174,20 +161,7 @@ class Edit extends BackendBaseActionEdit
         $this->form->addText('datetime_classname');
         $this->form->addText('datetime_error_message');
 
-        // map the values to replace them with the backend translations
-        // use array combine to set the keys as the autocomplete values instead of key values
-        $this->form->addDropdown(
-            'datetime_autocomplete',
-            array_map(
-                function (string $value): string {
-                    return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
-                },
-                array_combine(
-                    Autocomplete::POSSIBLE_VALUES,
-                    Autocomplete::POSSIBLE_VALUES
-                )
-            )
-        );
+        $this->form->addDropdown('datetime_autocomplete', Autocomplete::getAutocompleteValues());
 
         // dropdown dialog
         $this->form->addText('dropdown_label');

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -4,6 +4,7 @@ namespace Backend\Modules\FormBuilder\Ajax;
 
 use Backend\Core\Engine\Base\AjaxAction as BackendBaseAJAXAction;
 use Backend\Core\Language\Language as BL;
+use Backend\Modules\FormBuilder\Engine\Autocomplete;
 use Backend\Modules\FormBuilder\Engine\Helper as FormBuilderHelper;
 use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
 use Common\Uri as CommonUri;
@@ -56,6 +57,10 @@ class SaveField extends BackendBaseAJAXAction
         }
         $validationParameter = trim($this->getRequest()->request->get('validation_parameter', ''));
         $errorMessage = trim($this->getRequest()->request->get('error_message', ''));
+        $autocomplete = $this->getRequest()->request->get('autocomplete', '');
+        if (!in_array($autocomplete, Autocomplete::POSSIBLE_VALUES)) {
+            $autocomplete = '';
+        }
 
         // special field for textbox
         $replyTo = $this->getRequest()->request->getBoolean('reply_to');
@@ -245,6 +250,10 @@ class SaveField extends BackendBaseAJAXAction
         }
         if ($classname !== '') {
             $settings['classname'] = \SpoonFilter::htmlspecialchars($classname);
+        }
+
+        if ($autocomplete != '') {
+            $settings['autocomplete'] = $autocomplete;
         }
 
         // reply-to, only for textboxes

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -58,9 +58,6 @@ class SaveField extends BackendBaseAJAXAction
         $validationParameter = trim($this->getRequest()->request->get('validation_parameter', ''));
         $errorMessage = trim($this->getRequest()->request->get('error_message', ''));
         $autocomplete = $this->getRequest()->request->get('autocomplete', '');
-        if (!in_array($autocomplete, Autocomplete::POSSIBLE_VALUES)) {
-            $autocomplete = '';
-        }
 
         // special field for textbox
         $replyTo = $this->getRequest()->request->getBoolean('reply_to');
@@ -252,9 +249,7 @@ class SaveField extends BackendBaseAJAXAction
             $settings['classname'] = \SpoonFilter::htmlspecialchars($classname);
         }
 
-        if ($autocomplete != '') {
-            $settings['autocomplete'] = $autocomplete;
-        }
+        $settings['autocomplete'] = in_array($autocomplete, Autocomplete::POSSIBLE_VALUES) ? $autocomplete : '';
 
         // reply-to, only for textboxes
         if ($type === 'textbox') {

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -2,7 +2,7 @@
 
 namespace Backend\Modules\FormBuilder\Engine;
 
-use Backend\Core\Language\Language as BL;
+use Backend\Core\Language\Language;
 
 /**
  * Autocomplete attribute values for the form_builder module.
@@ -93,7 +93,7 @@ final class Autocomplete
         // use array combine to set the keys as the autocomplete values instead of key values
         return array_map(
             function (string $value): string {
-                return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
+                return $value . ' (' . Language::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
             },
             array_combine(
                 Autocomplete::POSSIBLE_VALUES,

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -2,6 +2,9 @@
 
 namespace Backend\Modules\FormBuilder\Engine;
 
+/**
+ * Autocomplete attribute values for the form_builder module.
+ */
 final class Autocomplete
 {
     const NAME = 'name';

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -87,7 +87,7 @@ final class Autocomplete
         self::PHOTO
     ];
 
-    public static function getAutocompleteValues(): array
+    public static function getValuesForDropdown(): array
     {
         // map the values to replace them with the backend translations
         // use array combine to set the keys as the autocomplete values instead of key values

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Engine;
+
+final class Autocomplete
+{
+    const NAME = 'name';
+    const HONORIFIC_PREFIX = 'honorific-prefix';
+    const GIVEN_NAME = 'given-name';
+    const ADDITIONAL_NAME = 'additional-name';
+    const FAMILY_NAME = 'family-name';
+    const NICKNAME = 'nickname';
+    const EMAIL = 'email';
+    const USERNAME = 'username';
+    const NEW_PASSWORD = 'new-password';
+    const CURRENT_PASSWORD = 'current-password';
+    const ORGANIZATION_TITLE = 'organization-title';
+    const ORGANIZATION = 'organization';
+    const STREET_ADDRESS = 'street-address';
+    const COUNTRY = 'country';
+    const COUNTRY_NAME = 'country-name';
+    const POSTAL_CODE = 'postal-code';
+    const CC_NAME = 'cc-name';
+    const CC_GIVEN_NAME = 'cc-given-name';
+    const CC_ADDITIONAL_NAME = 'cc-additional-name';
+    const CC_FAMILY_NAME = 'cc-family-name';
+    const CC_NUMBER = 'cc-number';
+    const CC_EXP = 'cc-exp';
+    const CC_EXP_MONTH = 'cc-exp-month';
+    const CC_EXP_YEAR = 'cc-exp-year';
+    const CC_CSC = 'cc-csc';
+    const CC_TYPE = 'cc-type';
+    const TRANSACTION_CURRENCY = 'transaction-currency';
+    const TRANSACTION_AMOUNT = 'transaction-amount';
+    const LANGUAGE = 'language';
+    const BDAY = 'bday';
+    const BDAY_DAY = 'bday-day';
+    const BDAY_MONTH = 'bday-month';
+    const BDAY_YEAR = 'bday-year';
+    const SEX = 'sex';
+    const TEL = 'tel';
+    const URL = 'url';
+    const PHOTO = 'photo';
+
+    const POSSIBLE_VALUES = [
+        self::NAME,
+        self::HONORIFIC_PREFIX,
+        self::GIVEN_NAME,
+        self::ADDITIONAL_NAME,
+        self::FAMILY_NAME,
+        self::NICKNAME,
+        self::EMAIL,
+        self::USERNAME,
+        self::NEW_PASSWORD,
+        self::CURRENT_PASSWORD,
+        self::ORGANIZATION_TITLE,
+        self::ORGANIZATION,
+        self::STREET_ADDRESS,
+        self::COUNTRY,
+        self::COUNTRY_NAME,
+        self::POSTAL_CODE,
+        self::CC_NAME,
+        self::CC_GIVEN_NAME,
+        self::CC_ADDITIONAL_NAME,
+        self::CC_FAMILY_NAME,
+        self::CC_NUMBER,
+        self::CC_EXP,
+        self::CC_EXP_MONTH,
+        self::CC_EXP_YEAR,
+        self::CC_CSC,
+        self::CC_TYPE,
+        self::TRANSACTION_CURRENCY,
+        self::TRANSACTION_AMOUNT,
+        self::LANGUAGE,
+        self::BDAY,
+        self::BDAY_DAY,
+        self::BDAY_MONTH,
+        self::BDAY_YEAR,
+        self::SEX,
+        self::TEL,
+        self::URL,
+        self::PHOTO
+    ];
+}

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -2,6 +2,8 @@
 
 namespace Backend\Modules\FormBuilder\Engine;
 
+use Backend\Core\Language\Language as BL;
+
 /**
  * Autocomplete attribute values for the form_builder module.
  */
@@ -84,4 +86,19 @@ final class Autocomplete
         self::URL,
         self::PHOTO
     ];
+
+    public static function getAutocompleteValues(): array
+    {
+        // map the values to replace them with the backend translations
+        // use array combine to set the keys as the autocomplete values instead of key values
+        return array_map(
+            function (string $value): string {
+                return $value . ' (' . BL::getLabel('Autocomplete_' . str_replace('-', '_', $value)) . ')';
+            },
+            array_combine(
+                Autocomplete::POSSIBLE_VALUES,
+                Autocomplete::POSSIBLE_VALUES
+            )
+        );
+    }
 }

--- a/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Autocomplete.php
@@ -5,7 +5,9 @@ namespace Backend\Modules\FormBuilder\Engine;
 use Backend\Core\Language\Language;
 
 /**
- * Autocomplete attribute values for the form_builder module.
+ * The autocomplete values can be found on
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
  */
 final class Autocomplete
 {

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -1178,6 +1178,538 @@
         <translation language="en"><![CDATA[subject confirmation mail]]></translation>
         <translation language="pl"><![CDATA[temat emaila z potwierdzeniem]]></translation>
       </item>
+      <item type="label" name="Autocomplete">
+        <translation language="nl"><![CDATA[Autocomplete waarde]]></translation>
+        <translation language="en"><![CDATA[Autocomplete value]]></translation>
+        <translation language="it"><![CDATA[Valore di completamento automatico]]></translation>
+        <translation language="ru"><![CDATA[Valoarea de completare automată]]></translation>
+        <translation language="zh"><![CDATA[自動填充值]]></translation>
+        <translation language="fr"><![CDATA[Valeur de saisie semi-automatique]]></translation>
+        <translation language="hu"><![CDATA[Automatikus kiegészítés érték]]></translation>
+        <translation language="de"><![CDATA[Autocomplete-Wert]]></translation>
+        <translation language="es"><![CDATA[Valor de autocompletar]]></translation>
+        <translation language="uk"><![CDATA[Значення автозаповнення]]></translation>
+        <translation language="sv"><![CDATA[Autofullständigt värde]]></translation>
+        <translation language="el"><![CDATA[Τιμή αυτόματης συμπλήρωσης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteName">
+        <translation language="nl"><![CDATA[Volledige naam]]></translation>
+        <translation language="en"><![CDATA[Full name]]></translation>
+        <translation language="it"><![CDATA[Nome e cognome]]></translation>
+        <translation language="ru"><![CDATA[Numele complet]]></translation>
+        <translation language="zh"><![CDATA[全名]]></translation>
+        <translation language="fr"><![CDATA[Nom complet]]></translation>
+        <translation language="hu"><![CDATA[Teljes név]]></translation>
+        <translation language="de"><![CDATA[Vollständiger Name]]></translation>
+        <translation language="es"><![CDATA[Nombre completo]]></translation>
+        <translation language="uk"><![CDATA[Повне ім'я]]></translation>
+        <translation language="sv"><![CDATA[Fullständiga namn]]></translation>
+        <translation language="el"><![CDATA[Πλήρες όνομα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteHonorificPrefix">
+        <translation language="nl"><![CDATA[Het voorvoegsel of de titel, zoals "Mrs.", "Mr."]]></translation>
+        <translation language="en"><![CDATA[The prefix or title, such as "Mrs.", "Mr."]]></translation>
+        <translation language="it"><![CDATA[Il prefisso o il titolo, come "Mrs.", "Mr."]]></translation>
+        <translation language="ru"><![CDATA[Prefixul sau titlul, cum ar fi "doamna", "domnul"]]></translation>
+        <translation language="zh"><![CDATA[前缀或标题]]></translation>
+        <translation language="fr"><![CDATA[Le préfixe ou le titre, tel que "Mme", "M."]]></translation>
+        <translation language="hu"><![CDATA[Az előtag vagy cím, például "Mrs.", "Mr."]]></translation>
+        <translation language="de"><![CDATA[Das Präfix oder der Titel]]></translation>
+        <translation language="es"><![CDATA[El prefijo o título]]></translation>
+        <translation language="uk"><![CDATA[Префікс або заголовок]]></translation>
+        <translation language="sv"><![CDATA[Prefixet eller titeln]]></translation>
+        <translation language="el"><![CDATA[Το πρόθεμα ή ο τίτλος]]></translation>
+      </item>
+      <item type="label" name="AutocompleteGivenName">
+        <translation language="nl"><![CDATA[Voornaam]]></translation>
+        <translation language="en"><![CDATA[First name]]></translation>
+        <translation language="it"><![CDATA[nome]]></translation>
+        <translation language="ru"><![CDATA[Имя]]></translation>
+        <translation language="zh"><![CDATA[名]]></translation>
+        <translation language="de"><![CDATA[Vorname]]></translation>
+        <translation language="fr"><![CDATA[prénom]]></translation>
+        <translation language="hu"><![CDATA[keresztnév]]></translation>
+        <translation language="es"><![CDATA[primer nombre]]></translation>
+        <translation language="uk"><![CDATA[І'мя]]></translation>
+        <translation language="lt"><![CDATA[Vardas]]></translation>
+        <translation language="el"><![CDATA[Όνομα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteAdditionalName">
+        <translation language="nl"><![CDATA[Midden naam]]></translation>
+        <translation language="en"><![CDATA[Middle name]]></translation>
+        <translation language="it"><![CDATA[Secondo nome]]></translation>
+        <translation language="ru"><![CDATA[Al doilea nume]]></translation>
+        <translation language="zh"><![CDATA[中间名字]]></translation>
+        <translation language="fr"><![CDATA[Deuxième nom]]></translation>
+        <translation language="hu"><![CDATA[Középső név]]></translation>
+        <translation language="de"><![CDATA[Zweiter Vorname]]></translation>
+        <translation language="es"><![CDATA[Segundo nombre]]></translation>
+        <translation language="uk"><![CDATA[Середнє ім'я]]></translation>
+        <translation language="sv"><![CDATA[Mellannamn]]></translation>
+        <translation language="el"><![CDATA[Μεσαίο όνομα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteFamilyName">
+        <translation language="nl"><![CDATA[Achternaam]]></translation>
+        <translation language="en"><![CDATA[Last name]]></translation>
+        <translation language="it"><![CDATA[cognome]]></translation>
+        <translation language="ru"><![CDATA[Фамилия]]></translation>
+        <translation language="zh"><![CDATA[姓]]></translation>
+        <translation language="fr"><![CDATA[nom]]></translation>
+        <translation language="hu"><![CDATA[vezetéknév]]></translation>
+        <translation language="de"><![CDATA[Nachname]]></translation>
+        <translation language="es"><![CDATA[apellido]]></translation>
+        <translation language="uk"><![CDATA[Прізвище]]></translation>
+        <translation language="sv"><![CDATA[Efternamn]]></translation>
+        <translation language="el"><![CDATA[Επώνυμο]]></translation>
+      </item>
+      <item type="label" name="AutocompleteNickname">
+        <translation language="nl"><![CDATA[Nickname]]></translation>
+        <translation language="en"><![CDATA[Nickname]]></translation>
+        <translation language="it"><![CDATA[Soprannome]]></translation>
+        <translation language="ru"><![CDATA[Poreclă]]></translation>
+        <translation language="zh"><![CDATA[昵称]]></translation>
+        <translation language="fr"><![CDATA[Surnom]]></translation>
+        <translation language="hu"><![CDATA[Becenév]]></translation>
+        <translation language="de"><![CDATA[Spitzname]]></translation>
+        <translation language="es"><![CDATA[Apodo]]></translation>
+        <translation language="uk"><![CDATA[Псевдонім]]></translation>
+        <translation language="sv"><![CDATA[smeknamn]]></translation>
+        <translation language="el"><![CDATA[Παρατσούκλι]]></translation>
+      </item>
+      <item type="label" name="AutocompleteEmail">
+        <translation language="nl"><![CDATA[E-mail]]></translation>
+        <translation language="en"><![CDATA[E-mail]]></translation>
+        <translation language="hu"><![CDATA[E-mail]]></translation>
+        <translation language="it"><![CDATA[E-mail]]></translation>
+        <translation language="fr"><![CDATA[E-mail]]></translation>
+        <translation language="ru"><![CDATA[E-mail]]></translation>
+        <translation language="zh"><![CDATA[E-mail]]></translation>
+        <translation language="de"><![CDATA[E-Mail]]></translation>
+        <translation language="es"><![CDATA[E-mail]]></translation>
+        <translation language="uk"><![CDATA[E-mail]]></translation>
+        <translation language="sv"><![CDATA[E-post]]></translation>
+        <translation language="el"><![CDATA[E-mail]]></translation>
+      </item>
+      <item type="label" name="AutocompleteUsername">
+        <translation language="nl"><![CDATA[Een gebruikersnaam of accountnaam]]></translation>
+        <translation language="en"><![CDATA[A username or account name]]></translation>
+        <translation language="it"><![CDATA[Un nome utente o nome account]]></translation>
+        <translation language="ru"><![CDATA[Un nume de utilizator sau un nume de cont]]></translation>
+        <translation language="zh"><![CDATA[用户名或帐户名称]]></translation>
+        <translation language="fr"><![CDATA[Un nom d'utilisateur ou un nom de compte]]></translation>
+        <translation language="hu"><![CDATA[Felhasználónév vagy fiók neve]]></translation>
+        <translation language="de"><![CDATA[Ein Benutzername oder ein Kontoname]]></translation>
+        <translation language="es"><![CDATA[Un nombre de usuario o nombre de cuenta]]></translation>
+        <translation language="uk"><![CDATA[Ім'я користувача або ім'я облікового запису]]></translation>
+        <translation language="sv"><![CDATA[Ett användarnamn eller kontonamn]]></translation>
+        <translation language="el"><![CDATA[Όνομα χρήστη ή όνομα λογαριασμού]]></translation>
+      </item>
+      <item type="label" name="AutocompleteNewPassword">
+        <translation language="nl"><![CDATA[Nieuw paswoord veld]]></translation>
+        <translation language="en"><![CDATA[New password field]]></translation>
+        <translation language="it"><![CDATA[Nuovo campo password]]></translation>
+        <translation language="ru"><![CDATA[Câmp de parolă nouă]]></translation>
+        <translation language="zh"><![CDATA[新密码字段]]></translation>
+        <translation language="fr"><![CDATA[Nouveau champ de mot de passe]]></translation>
+        <translation language="hu"><![CDATA[Új jelszó mező]]></translation>
+        <translation language="de"><![CDATA[Neues Passwortfeld]]></translation>
+        <translation language="es"><![CDATA[Nuevo campo de contraseña]]></translation>
+        <translation language="uk"><![CDATA[Поле нового пароля]]></translation>
+        <translation language="sv"><![CDATA[Nytt lösenordsfält]]></translation>
+        <translation language="el"><![CDATA[Νέο πεδίο κωδικού πρόσβασης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCurrentPassword">
+        <translation language="nl"><![CDATA[Huidig wachtwoord]]></translation>
+        <translation language="en"><![CDATA[Current password]]></translation>
+        <translation language="it"><![CDATA[Password attuale]]></translation>
+        <translation language="ru"><![CDATA[Parola actuală]]></translation>
+        <translation language="zh"><![CDATA[当前密码]]></translation>
+        <translation language="fr"><![CDATA[Mot de passe actuel]]></translation>
+        <translation language="hu"><![CDATA[Jelenlegi jelszó]]></translation>
+        <translation language="de"><![CDATA[Derzeitiges Passwort]]></translation>
+        <translation language="es"><![CDATA[Contraseña actual]]></translation>
+        <translation language="uk"><![CDATA[Поточний пароль]]></translation>
+        <translation language="sv"><![CDATA[Nuvarande lösenord]]></translation>
+        <translation language="el"><![CDATA[Τρέχων κωδικός πρόσβασης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteOrganizationTitle">
+        <translation language="nl"><![CDATA[Functie benaming]]></translation>
+        <translation language="en"><![CDATA[A job title]]></translation>
+        <translation language="it"><![CDATA[Un titolo di lavoro]]></translation>
+        <translation language="ru"><![CDATA[Titlul postului]]></translation>
+        <translation language="zh"><![CDATA[职称]]></translation>
+        <translation language="fr"><![CDATA[Un titre d'emploi]]></translation>
+        <translation language="hu"><![CDATA[A munkahely címe]]></translation>
+        <translation language="de"><![CDATA[Eine Berufsbezeichnung]]></translation>
+        <translation language="es"><![CDATA[Un titulo de trabajo]]></translation>
+        <translation language="uk"><![CDATA[Посада]]></translation>
+        <translation language="sv"><![CDATA[En jobbtitel]]></translation>
+        <translation language="el"><![CDATA[Ένας τίτλος θέσης εργασίας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteOrganization">
+        <translation language="nl"><![CDATA[De naam van een bedrijf of organisatie]]></translation>
+        <translation language="en"><![CDATA[A company or organization name]]></translation>
+        <translation language="it"><![CDATA[Un nome di azienda o organizzazione]]></translation>
+        <translation language="ru"><![CDATA[Numele unei companii sau al unei organizații]]></translation>
+        <translation language="zh"><![CDATA[公司或组织名称]]></translation>
+        <translation language="fr"><![CDATA[Un nom de société ou d'organisation]]></translation>
+        <translation language="hu"><![CDATA[Vállalat vagy szervezet neve]]></translation>
+        <translation language="de"><![CDATA[Name einer Firma oder Organisation]]></translation>
+        <translation language="es"><![CDATA[Un nombre de empresa u organización]]></translation>
+        <translation language="uk"><![CDATA[Назва компанії або організації]]></translation>
+        <translation language="sv"><![CDATA[Ett företags- eller organisationsnamn]]></translation>
+        <translation language="el"><![CDATA[Όνομα επιχείρησης ή οργανισμού]]></translation>
+      </item>
+      <item type="label" name="AutocompleteStreetAddress">
+        <translation language="nl"><![CDATA[Een straat adres]]></translation>
+        <translation language="en"><![CDATA[A street address]]></translation>
+        <translation language="it"><![CDATA[Un indirizzo]]></translation>
+        <translation language="ru"><![CDATA[O adresă stradală]]></translation>
+        <translation language="zh"><![CDATA[街道地址]]></translation>
+        <translation language="fr"><![CDATA[Une adresse]]></translation>
+        <translation language="hu"><![CDATA[Utcai cím]]></translation>
+        <translation language="de"><![CDATA[Eine Adresse]]></translation>
+        <translation language="es"><![CDATA[Una direccion]]></translation>
+        <translation language="uk"><![CDATA[Адреса]]></translation>
+        <translation language="sv"><![CDATA[En gatuadress]]></translation>
+        <translation language="el"><![CDATA[Μια διεύθυνση δρόμου]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCountry">
+        <translation language="nl"><![CDATA[Een land code]]></translation>
+        <translation language="en"><![CDATA[A country code]]></translation>
+        <translation language="it"><![CDATA[Un codice paese]]></translation>
+        <translation language="ru"><![CDATA[Un cod de țară]]></translation>
+        <translation language="zh"><![CDATA[国家代码]]></translation>
+        <translation language="fr"><![CDATA[Un code pays]]></translation>
+        <translation language="hu"><![CDATA[Országkód]]></translation>
+        <translation language="de"><![CDATA[Ein Ländercode]]></translation>
+        <translation language="es"><![CDATA[Un código de país]]></translation>
+        <translation language="uk"><![CDATA[Код країни]]></translation>
+        <translation language="sv"><![CDATA[En landskod]]></translation>
+        <translation language="el"><![CDATA[Ένας κωδικός χώρας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCountryName">
+        <translation language="nl"><![CDATA[Een land naam]]></translation>
+        <translation language="en"><![CDATA[A country name]]></translation>
+        <translation language="it"><![CDATA[Un nome di paese]]></translation>
+        <translation language="ru"><![CDATA[Numele unei țări]]></translation>
+        <translation language="zh"><![CDATA[国名]]></translation>
+        <translation language="fr"><![CDATA[Un nom de pays]]></translation>
+        <translation language="hu"><![CDATA[Egy ország neve]]></translation>
+        <translation language="de"><![CDATA[Ein land name]]></translation>
+        <translation language="es"><![CDATA[Un nombre de pais]]></translation>
+        <translation language="uk"><![CDATA[Назва країни]]></translation>
+        <translation language="sv"><![CDATA[Ett lands namn]]></translation>
+        <translation language="el"><![CDATA[Όνομα χώρας]]></translation>
+      </item>
+      <item type="label" name="AutocompletePostalCode">
+        <translation language="nl"><![CDATA[Een postcode]]></translation>
+        <translation language="en"><![CDATA[A postal code]]></translation>
+        <translation language="it"><![CDATA[Un codice postale]]></translation>
+        <translation language="ru"><![CDATA[Un cod poștal]]></translation>
+        <translation language="zh"><![CDATA[邮政编码]]></translation>
+        <translation language="fr"><![CDATA[Un code postal]]></translation>
+        <translation language="hu"><![CDATA[Postai irányítószám]]></translation>
+        <translation language="de"><![CDATA[Eine Postleitzahl]]></translation>
+        <translation language="es"><![CDATA[Un código postal]]></translation>
+        <translation language="uk"><![CDATA[Поштовий індекс]]></translation>
+        <translation language="sv"><![CDATA[En postnummer]]></translation>
+        <translation language="el"><![CDATA[Ένας ταχυδρομικός κώδικας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcName">
+        <translation language="nl"><![CDATA[De volledige naam zoals opgegeven op een creditcard]]></translation>
+        <translation language="en"><![CDATA[The full name as given on a credit card]]></translation>
+        <translation language="it"><![CDATA[Il nome completo come indicato su una carta di credito]]></translation>
+        <translation language="ru"><![CDATA[Numele complet așa cum este indicat pe un card de credit]]></translation>
+        <translation language="zh"><![CDATA[信用卡上的全名]]></translation>
+        <translation language="fr"><![CDATA[Le nom complet tel qu’indiqué sur une carte de crédit]]></translation>
+        <translation language="hu"><![CDATA[A hitelkártyán megadott teljes név]]></translation>
+        <translation language="de"><![CDATA[Der vollständige Name wie auf einer Kreditkarte angegeben]]></translation>
+        <translation language="es"><![CDATA[El nombre completo que figura en una tarjeta de crédito.]]></translation>
+        <translation language="uk"><![CDATA[Повне ім'я, вказане на кредитній картці]]></translation>
+        <translation language="sv"><![CDATA[Det fullständiga namnet som anges på ett kreditkort]]></translation>
+        <translation language="el"><![CDATA[Το πλήρες όνομα όπως αναγράφεται στην πιστωτική κάρτα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcGivenName">
+        <translation language="nl"><![CDATA[De voornaam zoals opgegeven op een creditcard]]></translation>
+        <translation language="en"><![CDATA[A first name as given on a credit card]]></translation>
+        <translation language="it"><![CDATA[Un nome come indicato su una carta di credito]]></translation>
+        <translation language="ru"><![CDATA[Un prim nume așa cum este indicat pe un card de credit]]></translation>
+        <translation language="zh"><![CDATA[信用卡上的第一个名字]]></translation>
+        <translation language="fr"><![CDATA[Un prénom tel que donné sur une carte de crédit]]></translation>
+        <translation language="hu"><![CDATA[A hitelkártyán megadott név]]></translation>
+        <translation language="de"><![CDATA[Ein Vorname wie auf einer Kreditkarte angegeben]]></translation>
+        <translation language="es"><![CDATA[Un primer nombre como se da en una tarjeta de crédito]]></translation>
+        <translation language="uk"><![CDATA[Ім'я, вказане на кредитній картці]]></translation>
+        <translation language="sv"><![CDATA[Ett förnamn som anges på ett kreditkort]]></translation>
+        <translation language="el"><![CDATA[Ένα πρώτο όνομα όπως αναφέρεται σε μια πιστωτική κάρτα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcAdditionalName">
+        <translation language="nl"><![CDATA[Een midden naam zoals opgegeven op een creditcard]]></translation>
+        <translation language="en"><![CDATA[A middle name as given on a credit card]]></translation>
+        <translation language="it"><![CDATA[Un secondo nome come indicato su una carta di credito]]></translation>
+        <translation language="ru"><![CDATA[Un nume de mijloc așa cum este indicat pe un card de credit]]></translation>
+        <translation language="zh"><![CDATA[信用卡上给出的中间名]]></translation>
+        <translation language="fr"><![CDATA[Un deuxième prénom tel qu’indiqué sur une carte de crédit]]></translation>
+        <translation language="hu"><![CDATA[A hitelkártyán megadott közepes név]]></translation>
+        <translation language="de"><![CDATA[Ein zweiter Vorname, wie auf einer Kreditkarte angegeben]]></translation>
+        <translation language="es"><![CDATA[Un segundo nombre como se da en una tarjeta de crédito]]></translation>
+        <translation language="uk"><![CDATA[Прізвище, вказане на кредитній картці]]></translation>
+        <translation language="sv"><![CDATA[Ett mellannamn som anges på ett kreditkort]]></translation>
+        <translation language="el"><![CDATA[Ένα μεσαίο όνομα όπως αναγράφεται στην πιστωτική κάρτα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcFamilyName">
+        <translation language="nl"><![CDATA[Een familienaam zoals opgegeven op een creditcard]]></translation>
+        <translation language="en"><![CDATA[A family name as given on a credit card]]></translation>
+        <translation language="it"><![CDATA[Un nome di famiglia come indicato su una carta di credito]]></translation>
+        <translation language="ru"><![CDATA[Un nume de familie așa cum este dat pe un card de credit]]></translation>
+        <translation language="zh"><![CDATA[信用卡上的姓氏]]></translation>
+        <translation language="fr"><![CDATA[Un nom de famille tel qu'il apparaît sur une carte de crédit]]></translation>
+        <translation language="hu"><![CDATA[A hitelkártyán megadott családi név]]></translation>
+        <translation language="de"><![CDATA[Ein Familienname wie auf einer Kreditkarte angegeben]]></translation>
+        <translation language="es"><![CDATA[Un nombre de familia como se indica en una tarjeta de crédito]]></translation>
+        <translation language="uk"><![CDATA[Прізвище, вказане на кредитній картці]]></translation>
+        <translation language="sv"><![CDATA[Ett efternamn som anges på ett kreditkort]]></translation>
+        <translation language="el"><![CDATA[Ένα οικογενειακό όνομα όπως αναγράφεται στην πιστωτική κάρτα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcNumber">
+        <translation language="nl"><![CDATA[Een creditcardnummer]]></translation>
+        <translation language="en"><![CDATA[A credit card number]]></translation>
+        <translation language="it"><![CDATA[Un numero di carta di credito]]></translation>
+        <translation language="ru"><![CDATA[Un număr de card de credit]]></translation>
+        <translation language="zh"><![CDATA[信用卡号码]]></translation>
+        <translation language="fr"><![CDATA[Un numéro de carte de crédit]]></translation>
+        <translation language="hu"><![CDATA[Hitelkártyaszám]]></translation>
+        <translation language="de"><![CDATA[Eine Kreditkartennummer]]></translation>
+        <translation language="es"><![CDATA[Un numero de tarjeta de credito]]></translation>
+        <translation language="uk"><![CDATA[Номер кредитної картки]]></translation>
+        <translation language="sv"><![CDATA[Ett kreditkortsnummer]]></translation>
+        <translation language="el"><![CDATA[Ένας αριθμός πιστωτικής κάρτας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcExp">
+        <translation language="nl"><![CDATA[Vervaldatum van een betaalmethode]]></translation>
+        <translation language="en"><![CDATA[A payment method expiration date]]></translation>
+        <translation language="it"><![CDATA[Una data di scadenza del metodo di pagamento]]></translation>
+        <translation language="ru"><![CDATA[O dată de expirare a metodei de plată]]></translation>
+        <translation language="zh"><![CDATA[付款方式到期日]]></translation>
+        <translation language="fr"><![CDATA[Une date d'expiration du moyen de paiement]]></translation>
+        <translation language="hu"><![CDATA[Fizetési mód lejárati dátuma]]></translation>
+        <translation language="de"><![CDATA[Ein Ablaufdatum für eine Zahlungsmethode]]></translation>
+        <translation language="es"><![CDATA[Una fecha de vencimiento del método de pago.]]></translation>
+        <translation language="uk"><![CDATA[Дата закінчення строку дії способу оплати]]></translation>
+        <translation language="sv"><![CDATA[Ett betalningsmetods utgångsdatum]]></translation>
+        <translation language="el"><![CDATA[Ημερομηνία λήξης της μεθόδου πληρωμής]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcExpMonth">
+        <translation language="nl"><![CDATA[De maand waarin de betaalmethode verloopt]]></translation>
+        <translation language="en"><![CDATA[The month in which the payment method expires]]></translation>
+        <translation language="it"><![CDATA[Il mese in cui scade il metodo di pagamento]]></translation>
+        <translation language="ru"><![CDATA[Luna în care expiră metoda de plată]]></translation>
+        <translation language="zh"><![CDATA[付款方式到期的月份]]></translation>
+        <translation language="fr"><![CDATA[Le mois où le mode de paiement expire]]></translation>
+        <translation language="hu"><![CDATA[A fizetési mód lejártának hónapja]]></translation>
+        <translation language="de"><![CDATA[Der Monat, in dem die Zahlungsmethode abläuft]]></translation>
+        <translation language="es"><![CDATA[El mes en que expira el método de pago.]]></translation>
+        <translation language="uk"><![CDATA[Місяць, у якому закінчується термін оплати]]></translation>
+        <translation language="sv"><![CDATA[Den månad då betalningsmetoden löper ut]]></translation>
+        <translation language="el"><![CDATA[Ο μήνας κατά τον οποίο λήγει ο τρόπος πληρωμής]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcExpYear">
+        <translation language="nl"><![CDATA[Het jaar waarin de betaalmethode verloopt]]></translation>
+        <translation language="en"><![CDATA[The year in which the payment method expires]]></translation>
+        <translation language="it"><![CDATA[L'anno in cui scade il metodo di pagamento]]></translation>
+        <translation language="ru"><![CDATA[Anul în care expiră metoda de plată]]></translation>
+        <translation language="zh"><![CDATA[付款方式到期的年份]]></translation>
+        <translation language="fr"><![CDATA[L'année dans laquelle le mode de paiement expire]]></translation>
+        <translation language="hu"><![CDATA[Az a év, amikor a fizetési mód lejár]]></translation>
+        <translation language="de"><![CDATA[Das Jahr, in dem die Zahlungsmethode abläuft]]></translation>
+        <translation language="es"><![CDATA[El año en que expira el método de pago.]]></translation>
+        <translation language="uk"><![CDATA[Рік закінчення терміну дії способу оплати]]></translation>
+        <translation language="sv"><![CDATA[Det år då betalningsmetoden löper ut]]></translation>
+        <translation language="el"><![CDATA[Το έτος κατά το οποίο λήγει ο τρόπος πληρωμής]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcCsc">
+        <translation language="nl"><![CDATA[De beveiligingscode voor de creditcard, dit is het 3-cijferige verificatienummer op de achterkant van de kaart]]></translation>
+        <translation language="en"><![CDATA[The security code for the credit card, this is the 3-digit verification number on the back of the card]]></translation>
+        <translation language="it"><![CDATA[Il codice di sicurezza per la carta di credito, questo è il numero di verifica a 3 cifre sul retro della carta]]></translation>
+        <translation language="ru"><![CDATA[Codul de securitate al cardului de credit, acesta este numărul de verificare din 3 cifre de pe spatele cardului]]></translation>
+        <translation language="zh"><![CDATA[信用卡的安全代码，这是卡背面的3位数验证码]]></translation>
+        <translation language="fr"><![CDATA[Le code de sécurité de la carte de crédit, il s’agit du numéro de vérification à 3 chiffres situé au dos de la carte.]]></translation>
+        <translation language="hu"><![CDATA[A hitelkártya biztonsági kódja, ez a 3-jegyű hitelesítési szám a kártya hátoldalán]]></translation>
+        <translation language="de"><![CDATA[Der Sicherheitscode für die Kreditkarte ist die dreistellige Prüfnummer auf der Rückseite der Karte]]></translation>
+        <translation language="es"><![CDATA[El código de seguridad para la tarjeta de crédito, este es el número de verificación de 3 dígitos en el reverso de la tarjeta]]></translation>
+        <translation language="uk"><![CDATA[Код захисту для кредитної картки - це тризначний контрольний номер на зворотній стороні картки]]></translation>
+        <translation language="sv"><![CDATA[Säkerhetskoden för kreditkortet, det här är det 3-siffriga verifieringsnumret på baksidan av kortet]]></translation>
+        <translation language="el"><![CDATA[Ο κωδικός ασφαλείας για την πιστωτική κάρτα, αυτός είναι ο τριψήφιος αριθμός επαλήθευσης στο πίσω μέρος της κάρτας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteCcType">
+        <translation language="nl"><![CDATA[Het type betaalinstrument (zoals "Visa" of "Master Card")]]></translation>
+        <translation language="en"><![CDATA[The type of payment instrument (such as "Visa" or "Master Card")]]></translation>
+        <translation language="it"><![CDATA[Il tipo di strumento di pagamento (come "Visa" o "Master Card")]]></translation>
+        <translation language="ru"><![CDATA[Tipul de instrument de plată (cum ar fi "Visa" sau "Master Card")]]></translation>
+        <translation language="zh"><![CDATA[支付工具的类型（如“签证”或“万事达卡”）]]></translation>
+        <translation language="fr"><![CDATA[Le type d'instrument de paiement (tel que "Visa" ou "Master Card")]]></translation>
+        <translation language="hu"><![CDATA[A fizetési eszköz típusa (például "Visa" vagy "Master Card")]]></translation>
+        <translation language="de"><![CDATA[Die Art des Zahlungsinstruments (wie "Visa" oder "Master Card")]]></translation>
+        <translation language="es"><![CDATA[El tipo de instrumento de pago (como "Visa" o "Master Card")]]></translation>
+        <translation language="uk"><![CDATA[Тип платіжного інструменту (наприклад, "Visa" або "Master Card")]]></translation>
+        <translation language="sv"><![CDATA[Typ av betalningsinstrument (till exempel "Visa" eller "Master Card")]]></translation>
+        <translation language="el"><![CDATA[Ο τύπος του μέσου πληρωμής (όπως "Visa" ή "Master Card")]]></translation>
+      </item>
+      <item type="label" name="AutocompleteTransactionCurrency">
+        <translation language="nl"><![CDATA[De valuta van de transactie]]></translation>
+        <translation language="en"><![CDATA[The currency of the transaction]]></translation>
+        <translation language="it"><![CDATA[La valuta della transazione]]></translation>
+        <translation language="ru"><![CDATA[Moneda tranzacției]]></translation>
+        <translation language="zh"><![CDATA[交易的货币]]></translation>
+        <translation language="fr"><![CDATA[La devise de la transaction]]></translation>
+        <translation language="hu"><![CDATA[A tranzakció pénzneme]]></translation>
+        <translation language="de"><![CDATA[Die Währung der Transaktion]]></translation>
+        <translation language="es"><![CDATA[La moneda de la transacción.]]></translation>
+        <translation language="uk"><![CDATA[Валюта угоди]]></translation>
+        <translation language="sv"><![CDATA[Transaktionsvaluta]]></translation>
+        <translation language="el"><![CDATA[Το νόμισμα της συναλλαγής]]></translation>
+      </item>
+      <item type="label" name="AutocompleteTransactionAmount">
+        <translation language="nl"><![CDATA[Het bedrag van de transactie]]></translation>
+        <translation language="en"><![CDATA[The amount of the transaction]]></translation>
+        <translation language="it"><![CDATA[L'importo della transazione]]></translation>
+        <translation language="ru"><![CDATA[Valoarea tranzacției]]></translation>
+        <translation language="zh"><![CDATA[交易金额]]></translation>
+        <translation language="fr"><![CDATA[Le montant de la transaction]]></translation>
+        <translation language="hu"><![CDATA[A tranzakció összege]]></translation>
+        <translation language="de"><![CDATA[Der Betrag der Transaktion]]></translation>
+        <translation language="es"><![CDATA[El importe de la transacción.]]></translation>
+        <translation language="uk"><![CDATA[Сума операції]]></translation>
+        <translation language="sv"><![CDATA[Transaktionsbeloppet]]></translation>
+        <translation language="el"><![CDATA[Το ποσό της συναλλαγής]]></translation>
+      </item>
+      <item type="label" name="AutocompleteLanguage">
+        <translation language="nl"><![CDATA[Een voorkeurstaal]]></translation>
+        <translation language="en"><![CDATA[A preferred language]]></translation>
+        <translation language="it"><![CDATA[Una lingua preferita]]></translation>
+        <translation language="ru"><![CDATA[O limbă preferată]]></translation>
+        <translation language="zh"><![CDATA[首选语言]]></translation>
+        <translation language="fr"><![CDATA[Une langue préférée]]></translation>
+        <translation language="hu"><![CDATA[Előnyben részesített nyelv]]></translation>
+        <translation language="de"><![CDATA[Eine bevorzugte Sprache]]></translation>
+        <translation language="es"><![CDATA[Un idioma preferido]]></translation>
+        <translation language="uk"><![CDATA[Бажана мова]]></translation>
+        <translation language="sv"><![CDATA[Ett föredraget språk]]></translation>
+        <translation language="el"><![CDATA[Μια προτιμώμενη γλώσσα]]></translation>
+      </item>
+      <item type="label" name="AutocompleteBday">
+        <translation language="nl"><![CDATA[Een geboortedatum, als een volledige datum]]></translation>
+        <translation language="en"><![CDATA[A birth date, as a full date]]></translation>
+        <translation language="it"><![CDATA[Una data di nascita, come una data completa]]></translation>
+        <translation language="ru"><![CDATA[Data nașterii, ca dată completă]]></translation>
+        <translation language="zh"><![CDATA[出生日期，作为完整日期]]></translation>
+        <translation language="fr"><![CDATA[Une date de naissance, en tant que date complète]]></translation>
+        <translation language="hu"><![CDATA[Születési dátum, teljes dátum]]></translation>
+        <translation language="de"><![CDATA[Ein Geburtsdatum als volles Datum]]></translation>
+        <translation language="es"><![CDATA[Una fecha de nacimiento, como una fecha completa.]]></translation>
+        <translation language="uk"><![CDATA[Дата народження, як повна дата]]></translation>
+        <translation language="sv"><![CDATA[Ett födelsedatum, som ett fullständigt datum]]></translation>
+        <translation language="el"><![CDATA[Ημερομηνία γέννησης, ως πλήρης ημερομηνία]]></translation>
+      </item>
+      <item type="label" name="AutocompleteBdayDay">
+        <translation language="nl"><![CDATA[De dag van de maand van een geboortedatum]]></translation>
+        <translation language="en"><![CDATA[The day of the month of a birth date]]></translation>
+        <translation language="it"><![CDATA[Il giorno del mese di una data di nascita]]></translation>
+        <translation language="ru"><![CDATA[Ziua lunii de naștere]]></translation>
+        <translation language="zh"><![CDATA[出生日期的某一天]]></translation>
+        <translation language="fr"><![CDATA[Le jour du mois d'une date de naissance]]></translation>
+        <translation language="hu"><![CDATA[A születési hónap hónapjának napja]]></translation>
+        <translation language="de"><![CDATA[Der Tag des Monats eines Geburtsdatums]]></translation>
+        <translation language="es"><![CDATA[El día del mes de la fecha de nacimiento.]]></translation>
+        <translation language="uk"><![CDATA[День місяця дати народження]]></translation>
+        <translation language="sv"><![CDATA[Månadens födelsedatum]]></translation>
+        <translation language="el"><![CDATA[Την ημέρα του μήνα της ημερομηνίας γέννησης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteBdayMonth">
+        <translation language="nl"><![CDATA[De maand van een geboortedatum]]></translation>
+        <translation language="en"><![CDATA[The month of a birth date]]></translation>
+        <translation language="it"><![CDATA[Il mese di una data di nascita]]></translation>
+        <translation language="ru"><![CDATA[Luna de la data nașterii]]></translation>
+        <translation language="zh"><![CDATA[出生日期的月份]]></translation>
+        <translation language="fr"><![CDATA[Le mois d'une date de naissance]]></translation>
+        <translation language="hu"><![CDATA[A születési hónap hónapja]]></translation>
+        <translation language="de"><![CDATA[Der Monat eines Geburtsdatums]]></translation>
+        <translation language="es"><![CDATA[El mes de la fecha de nacimiento.]]></translation>
+        <translation language="uk"><![CDATA[Місяць дати народження]]></translation>
+        <translation language="sv"><![CDATA[Månadens födelsedatum]]></translation>
+        <translation language="el"><![CDATA[Ο μήνας της ημερομηνίας γέννησης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteBdayYear">
+        <translation language="nl"><![CDATA[Het jaar van een geboortedatum]]></translation>
+        <translation language="en"><![CDATA[The year of a birth date]]></translation>
+        <translation language="it"><![CDATA[L'anno di una data di nascita]]></translation>
+        <translation language="ru"><![CDATA[Anul datei de naștere]]></translation>
+        <translation language="zh"><![CDATA[出生日期]]></translation>
+        <translation language="fr"><![CDATA[L'année d'une date de naissance]]></translation>
+        <translation language="hu"><![CDATA[A születési év éve]]></translation>
+        <translation language="de"><![CDATA[Das Jahr eines Geburtsdatums]]></translation>
+        <translation language="es"><![CDATA[El año de la fecha de nacimiento.]]></translation>
+        <translation language="uk"><![CDATA[Рік дати народження]]></translation>
+        <translation language="sv"><![CDATA[Födelsedatumets år]]></translation>
+        <translation language="el"><![CDATA[Το έτος της ημερομηνίας γέννησης]]></translation>
+      </item>
+      <item type="label" name="AutocompleteSex">
+        <translation language="nl"><![CDATA[Een genderidentiteit als tekst zonder nieuwe regels]]></translation>
+        <translation language="en"><![CDATA[A gender identity as text without newlines]]></translation>
+        <translation language="it"><![CDATA[Un'identità di genere come testo senza newline]]></translation>
+        <translation language="ru"><![CDATA[O identitate de gen ca text fără linii noi]]></translation>
+        <translation language="zh"><![CDATA[性别标识为没有换行符的文本]]></translation>
+        <translation language="fr"><![CDATA[Une identité de genre en tant que texte sans nouvelles lignes]]></translation>
+        <translation language="hu"><![CDATA[A nemi identitás szövegként új vonalak nélkül]]></translation>
+        <translation language="de"><![CDATA[Eine geschlechtliche Identität als Text ohne Zeilenumbrüche]]></translation>
+        <translation language="es"><![CDATA[Una identidad de género como texto sin nuevas líneas.]]></translation>
+        <translation language="uk"><![CDATA[Гендерна ідентичність як текст без рядків]]></translation>
+        <translation language="sv"><![CDATA[En könsidentitet som text utan nya linjer]]></translation>
+        <translation language="el"><![CDATA[Μια ταυτότητα φύλου ως κείμενο χωρίς νέες γραμμές]]></translation>
+      </item>
+      <item type="label" name="AutocompleteTel">
+        <translation language="nl"><![CDATA[Een volledig telefoonnummer, inclusief de landcode]]></translation>
+        <translation language="en"><![CDATA[A full telephone number, including the country code]]></translation>
+        <translation language="it"><![CDATA[Un numero di telefono completo, incluso il prefisso internazionale]]></translation>
+        <translation language="ru"><![CDATA[Un număr de telefon complet, inclusiv codul țării]]></translation>
+        <translation language="zh"><![CDATA[一个完整的电话号码，包括国家代码]]></translation>
+        <translation language="fr"><![CDATA[Un numéro de téléphone complet, y compris l'indicatif du pays]]></translation>
+        <translation language="hu"><![CDATA[Teljes telefonszám, az országkóddal együtt]]></translation>
+        <translation language="de"><![CDATA[Eine vollständige Telefonnummer einschließlich der Landesvorwahl]]></translation>
+        <translation language="es"><![CDATA[Un número de teléfono completo, incluido el código del país]]></translation>
+        <translation language="uk"><![CDATA[Повний номер телефону, включаючи код країни]]></translation>
+        <translation language="sv"><![CDATA[Ett fullständigt telefonnummer, inklusive landskoden]]></translation>
+        <translation language="el"><![CDATA[Ένας πλήρης αριθμός τηλεφώνου, συμπεριλαμβανομένου του κωδικού χώρας]]></translation>
+      </item>
+      <item type="label" name="AutocompleteUrl">
+        <translation language="nl"><![CDATA[Een URL]]></translation>
+        <translation language="en"><![CDATA[A URL]]></translation>
+        <translation language="it"><![CDATA[Un URL]]></translation>
+        <translation language="ru"><![CDATA[O adresă URL]]></translation>
+        <translation language="zh"><![CDATA[一个URL]]></translation>
+        <translation language="fr"><![CDATA[Une URL]]></translation>
+        <translation language="hu"><![CDATA[URL]]></translation>
+        <translation language="de"><![CDATA[Eine URL]]></translation>
+        <translation language="es"><![CDATA[Una URL]]></translation>
+        <translation language="uk"><![CDATA[URL]]></translation>
+        <translation language="sv"><![CDATA[En URL]]></translation>
+        <translation language="el"><![CDATA[Μια διεύθυνση URL]]></translation>
+      </item>
+      <item type="label" name="AutocompletePhoto">
+        <translation language="nl"><![CDATA[De URL van een afbeelding]]></translation>
+        <translation language="en"><![CDATA[The URL of an image]]></translation>
+        <translation language="it"><![CDATA[L'URL di un'immagine]]></translation>
+        <translation language="ru"><![CDATA[Adresa URL a unei imagini]]></translation>
+        <translation language="zh"><![CDATA[图像的URL]]></translation>
+        <translation language="fr"><![CDATA[L'URL d'une image]]></translation>
+        <translation language="hu"><![CDATA[A kép URL-je]]></translation>
+        <translation language="de"><![CDATA[Die URL eines Bildes]]></translation>
+        <translation language="es"><![CDATA[La URL de una imagen.]]></translation>
+        <translation language="uk"><![CDATA[URL-адреса зображення]]></translation>
+        <translation language="sv"><![CDATA[URL: en av en bild]]></translation>
+        <translation language="el"><![CDATA[Η διεύθυνση URL μιας εικόνας]]></translation>
+      </item>
     </FormBuilder>
   </Backend>
   <Frontend>

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -413,6 +413,7 @@ jsBackend.FormBuilder.Fields = {
                 $('#textboxValue').val(utils.string.htmlDecode(data.data.field.settings.default_values))
                 $('#textboxPlaceholder').val(utils.string.htmlDecode(data.data.field.settings.placeholder))
                 $('#textboxClassname').val(utils.string.htmlDecode(data.data.field.settings.classname))
+                $('#textboxAutocomplete').val(utils.string.htmlDecode(data.data.field.settings.autocomplete))
                 if (data.data.field.settings.reply_to &&
                   data.data.field.settings.reply_to === true
                 ) {
@@ -479,6 +480,7 @@ jsBackend.FormBuilder.Fields = {
                 $('#datetimeValueType').val(utils.string.htmlDecode(data.data.field.settings.value_type))
                 $('#datetimeType').val(utils.string.htmlDecode(data.data.field.settings.input_type))
                 $('#datetimeClassname').val(utils.string.htmlDecode(data.data.field.settings.classname))
+                $('#datetimeAutocomplete').val(utils.string.htmlDecode(data.data.field.settings.autocomplete));
                 $.each(
                   data.data.field.validations,
                   function (k, v) {
@@ -841,6 +843,7 @@ jsBackend.FormBuilder.Fields = {
     var validation = $('#datetimeValidation').val()
     var errorMessage = $('#datetimeErrorMessage').val()
     var classname = $('#datetimeClassname').val()
+    var autocomplete = $('#datetimeAutocomplete').val()
 
     // make the call
     $.ajax(
@@ -857,7 +860,8 @@ jsBackend.FormBuilder.Fields = {
           input_type: inputType,
           validation: validation,
           error_message: errorMessage,
-          classname: classname
+          classname: classname,
+          autocomplete: autocomplete
         }),
         success: function (data, textStatus) {
           // success
@@ -1336,6 +1340,7 @@ jsBackend.FormBuilder.Fields = {
     var validationParameter = $('#textboxValidationParameter').val()
     var errorMessage = $('#textboxErrorMessage').val()
     var classname = $('#textboxClassname').val()
+    var autocomplete = $('#textboxAutocomplete').val()
 
     // make the call
     $.ajax({
@@ -1354,7 +1359,8 @@ jsBackend.FormBuilder.Fields = {
         validation_parameter: validationParameter,
         error_message: errorMessage,
         placeholder: placeholder,
-        classname: classname
+        classname: classname,
+        autocomplete: autocomplete
       }),
       success: function (data, textStatus) {
         // success

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
@@ -338,6 +338,10 @@
                       {% form_field textbox_error_message %}
                     </div>
                   </div>
+                  <div class="form-group">
+                    <label for="textboxAutocomplete" class="control-label">{{ 'lbl.Autocomplete'|trans|ucfirst }}</label>
+                    {% form_field textbox_autocomplete %}
+                  </div>
                 </div>
               </div>
             </div>
@@ -552,6 +556,10 @@
                       <p id="datetimeErrorMessageError" class="text-danger jsFieldError" style="display: none;"></p>
                       {% form_field datetime_error_message %}
                     </div>
+                  </div>
+                  <div class="form-group">
+                    <label for="datetimeAutocomplete" class="control-label">{{ 'lbl.Autocomplete'|trans|ucfirst }}</label>
+                    {% form_field datetime_autocomplete %}
                   </div>
                 </div>
               </div>

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -157,6 +157,7 @@ class Form extends FrontendBaseWidget
                     'label' => $field['settings']['label'] ?? '',
                     'placeholder' => $field['settings']['placeholder'] ?? null,
                     'classname' => $field['settings']['classname'] ?? null,
+                    'autocomplete' => $field['settings']['autocomplete'] ?? null,
                     'required' => isset($field['validations']['required']),
                     'validations' => $field['validations'] ?? [],
                     'html' => '',
@@ -228,6 +229,11 @@ class Form extends FrontendBaseWidget
                         $txt->setAttribute('placeholder', $item['placeholder']);
                     }
 
+                    // add autocomplete attribute
+                    if ($item['autocomplete']) {
+                        $txt->setAttribute('autocomplete', $item['autocomplete']);
+                    }
+
                     $this->setCustomHTML5ErrorMessages($item, $txt);
 
                     // get content
@@ -273,6 +279,11 @@ class Form extends FrontendBaseWidget
                     // add required attribute
                     if ($item['required']) {
                         $datetime->setAttribute('required', null);
+                    }
+
+                    // add autocomplete attribute
+                    if ($item['autocomplete']) {
+                        $datetime->setAttribute('autocomplete', $item['autocomplete']);
                     }
 
                     $this->setCustomHTML5ErrorMessages($item, $datetime);


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Autocomplete attributes are available for the input text and date fields in the Formbuilder module
![screen shot 2019-01-30 at 16 15 07](https://user-images.githubusercontent.com/40020038/51990957-5aec8100-24aa-11e9-90ce-d48326416d4a.png)
![screen shot 2019-01-30 at 16 15 43](https://user-images.githubusercontent.com/40020038/51990962-5d4edb00-24aa-11e9-8326-247513a404f0.png)
