### PR TITLE
Prevent mixed content because of livereload on https in debug mode

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Head.html.twig
@@ -27,6 +27,6 @@
   {{ siteHTMLHeader|raw }}
 
   {% if debug %}
-    <script src="http://localhost:35729/livereload.js?snipver=1"></script>
+    <script src="//localhost:35729/livereload.js?snipver=1"></script>
   {% endif %}
 </head>

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
@@ -31,6 +31,6 @@
   <link href="https://fonts.googleapis.com/css?family=Courgette|Roboto:300,400,500,700,900" rel="stylesheet">
 
   {% if debug %}
-    <script src="http://localhost:35729/livereload.js?snipver=1"></script>
+    <script src="localhost:35729/livereload.js?snipver=1"></script>
   {% endif %}
 </head>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

Livereload.js was hardcoded to http, this resulted in mixed content when using https during development
