### PR TITLE
Fix the media url when adding link to file

### DIFF
--- a/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
+++ b/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
@@ -153,7 +153,7 @@ CKEDITOR.dialog.add(
 
                                         window.onmessage = function (event) {
                                             if (event.data) {
-                                                this.setValueOf('tab', 'url', event.data);
+                                                this.setValueOf('tab', 'url', event.data['media-url']);
                                             }
                                         }.bind(this.getDialog());
                                     },


### PR DESCRIPTION
When we receive the event when a file is selected in the media library, we set the event (object) in the input field. The event contains a `media-url` and that is the one we want to fill into the input field.

Closes #2749
