### PR TITLE
Get the display name from the profile array

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/Edit.php
+++ b/src/Backend/Modules/Profiles/Actions/Edit.php
@@ -188,7 +188,7 @@ class Edit extends BackendBaseActionEdit
             $this->template->assign('blocked', true);
         }
 
-        $this->header->appendDetailToBreadcrumbs($this->record['display_name']);
+        $this->header->appendDetailToBreadcrumbs($this->profile['display_name']);
     }
 
     private function validateForm(): void


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
We get an error when we add a profile in the backend. The error states that the display name given to the breadcrumb is null.
![screen shot 2019-02-06 at 09 32 57](https://user-images.githubusercontent.com/40020038/52329155-3e909d00-29f2-11e9-9df5-cb8e191422e3.png)


## Pull request description
Change the array name to the correct profile array to fix this issue.
![screen shot 2019-02-06 at 09 37 55](https://user-images.githubusercontent.com/40020038/52329395-f6be4580-29f2-11e9-955c-8e66402cffa4.png)

