### PR TITLE
Give a max width to the image thumbnail to respect the quality and ratio

### DIFF
--- a/src/Backend/Core/Layout/Sass/components/_themes.scss
+++ b/src/Backend/Core/Layout/Sass/components/_themes.scss
@@ -5,5 +5,5 @@
 .img-thumbnail {
   display: block;
   margin: 0 auto;
-  width: 100%;
+  max-width: 100%;
 }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
The blog edit image is adjusting to the width of the container instead of keeping the proper width and height of the image

## Pull request description
The blog image has a max width so it will not be as big as the container and will not lose any quality

