### PR TITLE
Dont show hidden content blocks

### DIFF
--- a/src/Frontend/Modules/ContentBlocks/Layout/Widgets/Default.html.twig
+++ b/src/Frontend/Modules/ContentBlocks/Layout/Widgets/Default.html.twig
@@ -2,7 +2,7 @@
   variables that are available:
   - {{ widgetContentBlocks }}:
 #}
-{% if widgetContentBlocks.text %}
+{% if not widgetContentBlocks.isHidden and widgetContentBlocks.text %}
   <div class="module-content-blocks widget-content-blocks-default contentBlock{{ widgetContentBlocks.id }}">
     {{ widgetContentBlocks.text|raw }}
   </div>

--- a/src/Frontend/Modules/ContentBlocks/Layout/Widgets/Default.html.twig
+++ b/src/Frontend/Modules/ContentBlocks/Layout/Widgets/Default.html.twig
@@ -2,7 +2,7 @@
   variables that are available:
   - {{ widgetContentBlocks }}:
 #}
-{% if not widgetContentBlocks.isHidden and widgetContentBlocks.text %}
+{% if widgetContentBlocks.text %}
   <div class="module-content-blocks widget-content-blocks-default contentBlock{{ widgetContentBlocks.id }}">
     {{ widgetContentBlocks.text|raw }}
   </div>

--- a/src/Frontend/Modules/ContentBlocks/Widgets/Detail.php
+++ b/src/Frontend/Modules/ContentBlocks/Widgets/Detail.php
@@ -19,6 +19,10 @@ class Detail extends FrontendBaseWidget
             Locale::frontendLanguage()
         );
 
+        if ($contentBlock->isHidden()) {
+            return;
+        }
+
         $this->template->assign('widgetContentBlocks', $contentBlock);
     }
 }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Contentblocks are still visible after we uncheck the checkbox "Visible on site"

## Pull request description
Check the contentblock hidden value on the twig template and hide the contentblock when the isHidden value is true

