### PR TITLE
Dont show empty divs when there is no content

### DIFF
--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Default.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Default.html.twig
@@ -9,18 +9,26 @@
 {% endblock %}
 
 {% block main %}
+{% set renderSection = false %}
+  {% for content in positions.main %}
+    {% if not renderSection and content.html %}
+      {% set renderSection = true %}
+    {% endif %}
+  {% endfor %}
 
+  {% if renderSection %}
   <div class="section-default">
     <div class="row">
       {# Main positions #}
       {% for content in positions.main %}
-        <div class="col-lg-offset-2 col-lg-8">
-          {% if content.html %}
+        {% if content.html %}
+          <div class="col-lg-offset-2 col-lg-8">
             {{ content.html|raw }}
-          {% endif %}
-        </div>
+          </div>
+        {% endif %}
       {% endfor %}
     </div>
   </div>
+  {% endif %}
 
 {% endblock %}

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Home.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Home.html.twig
@@ -8,13 +8,13 @@
   <div class="row">
     {# Main positions #}
     {% for content in positions.main %}
-      <div class="col-lg-offset-2 col-lg-8">
-        <div class="section-home font-size-large">
-          {% if content.html %}
+      {% if content.html %}
+        <div class="col-lg-offset-2 col-lg-8">
+          <div class="section-home font-size-large">
             {{ content.html|raw }}
-          {% endif %}
+          </div>
         </div>
-      </div>
+      {% endif %}
     {% endfor %}
   </div>
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Empty divs containing classes with margin or padding are being rendered when all content inside is hidden.
![screen shot 2019-02-11 at 10 40 59](https://user-images.githubusercontent.com/40020038/52555309-9f9ce400-2de9-11e9-89ea-6fb9793ccefa.png)


## Pull request description
When there is content inside the block the divs will be rendered

