### PR TITLE
Use and display a file or image maxSize constraint if the value is lower than the server value

### DIFF
--- a/app/config/form.yml
+++ b/app/config/form.yml
@@ -23,14 +23,12 @@ services:
             - "@translator"
         tags:
             - { name: form.type, alias: meta}
-    form.type.image:
-        class: Common\Form\ImageType
+    Common\Form\ImageType:
         arguments:
             - "@validator"
         tags:
             - { name: form.type, alias: image}
-    form.type.file:
-        class: Common\Form\FileType
+    Common\Form\FileType:
         arguments:
             - "@validator"
         tags:

--- a/app/config/form.yml
+++ b/app/config/form.yml
@@ -29,3 +29,9 @@ services:
             - "@validator"
         tags:
             - { name: form.type, alias: image}
+    form.type.file:
+        class: Common\Form\FileType
+        arguments:
+            - "@validator"
+        tags:
+            - { name: form.type, alias: file}

--- a/app/config/form.yml
+++ b/app/config/form.yml
@@ -23,3 +23,9 @@ services:
             - "@translator"
         tags:
             - { name: form.type, alias: meta}
+    form.type.image:
+        class: Common\Form\ImageType
+        arguments:
+            - "@validator"
+        tags:
+            - { name: form.type, alias: image}

--- a/src/Common/Core/Model.php
+++ b/src/Common/Core/Model.php
@@ -323,4 +323,27 @@ class Model extends BaseModel
 
         return self::get('fork.mock.session');
     }
+
+    /**
+     * This method returns the filesize in a human readable format according to the value
+     *
+     * @param int $fileSize
+     * @return string
+     */
+    public static function prettyPrintFileSize(int $fileSize): string
+    {
+        if ($fileSize > 999999999) {
+            return number_format($fileSize / 1000000000, 2, ',', ' ') . ' GB';
+        }
+
+        if ($fileSize > 999999) {
+            return number_format($fileSize / 1000000, 2, ',', ' ') . ' MB';
+        }
+
+        if ($fileSize > 999) {
+            return number_format($fileSize / 1000, 2, ',', ' ') . ' KB';
+        }
+
+        return $fileSize . ' bytes';
+    }
 }

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -146,7 +147,9 @@ class FileType extends AbstractType
                 'constraints' => array(new Valid()),
                 'error_bubbling' => false,
                 'help_text_message' => 'msg.HelpMaxFileSize',
-                'help_text_argument' => $this->getUploadMaxFileSize(),
+                'help_text_argument' => function (Options $options) {
+                    return $this->getUploadMaxFileSize($options['file_class']);
+                },
             ]
         );
     }

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -186,34 +186,35 @@ class FileType extends AbstractType
         );
     }
 
-    private function getUploadMaxFileSize(): ?string
+    private function getMaxFileSizeServerValue(): ?int
     {
         $uploadMaxFileSize = ini_get('upload_max_filesize');
+
         if ($uploadMaxFileSize === false) {
             return null;
         }
 
         // reformat if defined as an integer
         if (is_numeric($uploadMaxFileSize)) {
-            return $uploadMaxFileSize / 1024 . 'MB';
+            return $uploadMaxFileSize;
         }
 
         // reformat if specified in kB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'K') {
-            return mb_substr($uploadMaxFileSize, 0, -1) . 'kB';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000;
         }
 
         // reformat if specified in MB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'M') {
-            return $uploadMaxFileSize . 'B';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000 * 1000;
         }
 
         // reformat if specified in GB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'G') {
-            return $uploadMaxFileSize . 'B';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000 * 1000 * 1000;
         }
 
-        return $uploadMaxFileSize;
+        return null;
     }
 
     private function getMaxFileSizeConstraintValue(string $fileClass): ?int

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -2,6 +2,7 @@
 
 namespace Common\Form;
 
+use Common\Core\Model;
 use Common\Doctrine\ValueObject\AbstractFile;
 use stdClass;
 use Symfony\Component\Form\AbstractType;
@@ -256,34 +257,16 @@ class FileType extends AbstractType
         // return the server value if the constraint value is to high
         if (is_numeric($constraintValue) && is_numeric($serverValue)) {
             if ($constraintValue < $serverValue) {
-                return $this->prettyPrintFileSize($constraintValue);
+                return Model::prettyPrintFileSize($constraintValue);
             }
 
-            return $this->prettyPrintFileSize($serverValue);
+            return Model::prettyPrintFileSize($serverValue);
         }
 
         if (is_numeric($constraintValue)) {
-            return $this->prettyPrintFileSize($constraintValue);
+            return Model::prettyPrintFileSize($constraintValue);
         }
 
-        return $this->prettyPrintFileSize($serverValue);
-    }
-
-    private function prettyPrintFileSize(int $fileSize): string
-    {
-        // return the filesize in a human readable format according to the value
-        if ($fileSize > 999999999) {
-            return number_format($fileSize / 1000000000, 2, ',', ' ') . ' GB';
-        }
-
-        if ($fileSize > 999999) {
-            return number_format($fileSize / 1000000, 2, ',', ' ') . ' MB';
-        }
-
-        if ($fileSize > 999) {
-            return number_format($fileSize / 1000, 2, ',', ' ') . ' KB';
-        }
-
-        return $fileSize . ' bytes';
+        return Model::prettyPrintFileSize($serverValue);
     }
 }

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -16,11 +16,24 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class FileType extends AbstractType
 {
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($options['show_remove_file']) {
@@ -201,5 +214,29 @@ class FileType extends AbstractType
         }
 
         return $uploadMaxFileSize;
+    }
+
+    private function getMaxFileSizeConstraintValue(string $fileClass): ?int
+    {
+        // use the metaData to find the file data
+        /** @var ClassMetadata $metaData */
+        $metaData = $this->validator->getMetadataFor($fileClass);
+        $members = $metaData->getPropertyMetadata('file');
+
+        // the constraints can be found in the property meta data members
+        foreach ($members as $member) {
+            $constraints = $member->getConstraints();
+
+            if (count($constraints) === 1) {
+                /** @var File $fileConstraint */
+                $fileConstraint = $constraints[0];
+
+                if ($fileConstraint instanceof File) {
+                    return $fileConstraint->maxSize;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Common/Form/FileType.php
+++ b/src/Common/Form/FileType.php
@@ -240,4 +240,47 @@ class FileType extends AbstractType
 
         return null;
     }
+
+    private function getUploadMaxFileSize(string $fileClass): ?string
+    {
+        $constraintValue = $this->getMaxFileSizeConstraintValue($fileClass);
+        $serverValue = $this->getMaxFileSizeServerValue();
+
+        if (!is_numeric($constraintValue) && !is_numeric($serverValue)) {
+            return null;
+        }
+
+        // return the server value if the constraint value is to high
+        if (is_numeric($constraintValue) && is_numeric($serverValue)) {
+            if ($constraintValue < $serverValue) {
+                return $this->prettyPrintFileSize($constraintValue);
+            }
+
+            return $this->prettyPrintFileSize($serverValue);
+        }
+
+        if (is_numeric($constraintValue)) {
+            return $this->prettyPrintFileSize($constraintValue);
+        }
+
+        return $this->prettyPrintFileSize($serverValue);
+    }
+
+    private function prettyPrintFileSize(int $fileSize): string
+    {
+        // return the filesize in a human readable format according to the value
+        if ($fileSize > 999999999) {
+            return number_format($fileSize / 1000000000, 2, ',', ' ') . ' GB';
+        }
+
+        if ($fileSize > 999999) {
+            return number_format($fileSize / 1000000, 2, ',', ' ') . ' MB';
+        }
+
+        if ($fileSize > 999) {
+            return number_format($fileSize / 1000, 2, ',', ' ') . ' KB';
+        }
+
+        return $fileSize . ' bytes';
+    }
 }

--- a/src/Common/Form/ImageType.php
+++ b/src/Common/Form/ImageType.php
@@ -246,4 +246,47 @@ class ImageType extends AbstractType
 
         return null;
     }
+
+    private function getUploadMaxFileSize(string $imageClass): ?string
+    {
+        $constraintValue = $this->getMaxFileSizeConstraintValue($imageClass);
+        $serverValue = $this->getMaxFileSizeServerValue();
+
+        if (!is_numeric($constraintValue) && !is_numeric($serverValue)) {
+            return null;
+        }
+
+        // return the server value if the constraint value is to high
+        if (is_numeric($constraintValue) && is_numeric($serverValue)) {
+            if ($constraintValue < $serverValue) {
+                return $this->prettyPrintFileSize($constraintValue);
+            }
+
+            return $this->prettyPrintFileSize($serverValue);
+        }
+
+        if (is_numeric($constraintValue)) {
+            return $this->prettyPrintFileSize($constraintValue);
+        }
+
+        return $this->prettyPrintFileSize($serverValue);
+    }
+
+    private function prettyPrintFileSize(int $fileSize): string
+    {
+        // return the filesize in a human readable format according to the value
+        if ($fileSize > 999999999) {
+            return number_format($fileSize / 1000000000, 2, ',', ' ') . ' GB';
+        }
+
+        if ($fileSize > 999999) {
+            return number_format($fileSize / 1000000, 2, ',', ' ') . ' MB';
+        }
+
+        if ($fileSize > 999) {
+            return number_format($fileSize / 1000, 2, ',', ' ') . ' KB';
+        }
+
+        return $fileSize . ' bytes';
+    }
 }

--- a/src/Common/Form/ImageType.php
+++ b/src/Common/Form/ImageType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -151,7 +152,9 @@ class ImageType extends AbstractType
                 'constraints' => [new Valid()],
                 'error_bubbling' => false,
                 'help_text_message' => 'msg.HelpImageFieldWithMaxFileSize',
-                'help_text_argument' => $this->getUploadMaxFileSize(),
+                'help_text_argument' => function (Options $options) {
+                    return $this->getUploadMaxFileSize($options['image_class']);
+                },
             ]
         );
     }

--- a/src/Common/Form/ImageType.php
+++ b/src/Common/Form/ImageType.php
@@ -192,34 +192,35 @@ class ImageType extends AbstractType
         );
     }
 
-    private function getUploadMaxFileSize(): ?string
+    private function getMaxFileSizeServerValue(): ?int
     {
         $uploadMaxFileSize = ini_get('upload_max_filesize');
+
         if ($uploadMaxFileSize === false) {
             return null;
         }
 
         // reformat if defined as an integer
         if (is_numeric($uploadMaxFileSize)) {
-            return $uploadMaxFileSize / 1024 . 'MB';
+            return $uploadMaxFileSize;
         }
 
         // reformat if specified in kB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'K') {
-            return mb_substr($uploadMaxFileSize, 0, -1) . 'kB';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000;
         }
 
         // reformat if specified in MB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'M') {
-            return $uploadMaxFileSize . 'B';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000 * 1000;
         }
 
         // reformat if specified in GB
         if (mb_strtoupper(mb_substr($uploadMaxFileSize, -1)) === 'G') {
-            return $uploadMaxFileSize . 'B';
+            return mb_substr($uploadMaxFileSize, 0, -1) * 1000 * 1000 * 1000;
         }
 
-        return $uploadMaxFileSize;
+        return null;
     }
 
     private function getMaxFileSizeConstraintValue(string $imageClass): ?int

--- a/src/Common/Form/ImageType.php
+++ b/src/Common/Form/ImageType.php
@@ -2,6 +2,7 @@
 
 namespace Common\Form;
 
+use Common\Core\Model;
 use Common\Doctrine\ValueObject\AbstractImage;
 use stdClass;
 use Symfony\Component\Form\AbstractType;
@@ -262,34 +263,16 @@ class ImageType extends AbstractType
         // return the server value if the constraint value is to high
         if (is_numeric($constraintValue) && is_numeric($serverValue)) {
             if ($constraintValue < $serverValue) {
-                return $this->prettyPrintFileSize($constraintValue);
+                return Model::prettyPrintFileSize($constraintValue);
             }
 
-            return $this->prettyPrintFileSize($serverValue);
+            return Model::prettyPrintFileSize($serverValue);
         }
 
         if (is_numeric($constraintValue)) {
-            return $this->prettyPrintFileSize($constraintValue);
+            return Model::prettyPrintFileSize($constraintValue);
         }
 
-        return $this->prettyPrintFileSize($serverValue);
-    }
-
-    private function prettyPrintFileSize(int $fileSize): string
-    {
-        // return the filesize in a human readable format according to the value
-        if ($fileSize > 999999999) {
-            return number_format($fileSize / 1000000000, 2, ',', ' ') . ' GB';
-        }
-
-        if ($fileSize > 999999) {
-            return number_format($fileSize / 1000000, 2, ',', ' ') . ' MB';
-        }
-
-        if ($fileSize > 999) {
-            return number_format($fileSize / 1000, 2, ',', ' ') . ' KB';
-        }
-
-        return $fileSize . ' bytes';
+        return Model::prettyPrintFileSize($serverValue);
     }
 }


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
When a maxSize constraint is set for a file or image then the default argument text is still displayed as the server max filesize

## Pull request description
Get the value of a maxSize constraint and compare it to the server max filesize setting from the php ini file. If the constraint is higher then the server value we use the server value otherwise we display and use the constraint value.

![screen shot 2019-02-14 at 11 17 48](https://user-images.githubusercontent.com/40020038/52780331-3b2c8f80-304a-11e9-9e42-ff2d704d3e77.png)


