### PR TITLE
Fix Form validation : Deprecated .context

### DIFF
--- a/src/Frontend/Core/Js/jquery/jquery.frontend.js
+++ b/src/Frontend/Core/Js/jquery/jquery.frontend.js
@@ -334,10 +334,10 @@
     options = $.extend(defaults, options)
 
     $input.on('invalid', function (e) {
-      if ($input.context.validity.valueMissing) {
+      if ($input[0].validity.valueMissing) {
         errorMessage = options.required
-      } else if (!$input.context.validity.valid) {
-        type = $input.context.type
+      } else if (!$input[0].validity.valid) {
+        type = $input[0].type
         errorMessage = options.value
 
         if (options[type]) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
Jquery .context is deprecated in Jquery 3.x
https://jquery.com/upgrade-guide/3.0/#breaking-change-deprecated-context-and-selector-properties-removed
Adding validation classes generating JS error

## Pull request description
The $input is a single array, so replacing $input.context by $input[0] does the trick.

