### PR TITLE
Formbuilder success type (message/page)

### DIFF
--- a/src/Backend/Modules/FormBuilder/Installer/Data/install.sql
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/install.sql
@@ -1,18 +1,20 @@
-CREATE TABLE IF NOT EXISTS `forms` (
+CREATE TABLE `forms` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `language` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int(11) unsigned NOT NULL,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `method` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'database_email',
   `email` text COLLATE utf8mb4_unicode_ci,
+  `success_type` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `success_message` text COLLATE utf8mb4_unicode_ci,
+  `success_page` int(11) NOT NULL DEFAULT '0',
   `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `email_template` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'Form.html.twig',
   `email_subject` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_on` datetime NOT NULL,
   `edited_on` datetime NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `forms_data` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -386,6 +386,11 @@
         <translation language="el"><![CDATA[Πριν 1 δευτερόλεπτο]]></translation>
         <translation language="pl"><![CDATA[1 sekundę temu]]></translation>
       </item>
+      <item type="label" name="OtherPage">
+        <translation language="nl"><![CDATA[andere pagina]]></translation>
+        <translation language="fr"><![CDATA[autre page]]></translation>
+        <translation language="en"><![CDATA[other page]]></translation>
+      </item>
       <item type="label" name="Paragraph">
         <translation language="nl"><![CDATA[paragraaf]]></translation>
         <translation language="en"><![CDATA[paragraph]]></translation>
@@ -534,6 +539,11 @@
         <translation language="el"><![CDATA[Απαιτείται]]></translation>
         <translation language="pl"><![CDATA[wymagane]]></translation>
       </item>
+      <item type="label" name="SamePageWithConfirmBox">
+        <translation language="nl"><![CDATA[Huidige pagina met bevestigingsboodschap]]></translation>
+        <translation language="fr"><![CDATA[Page actuelle avec message de confirmation]]></translation>
+        <translation language="en"><![CDATA[Current page with confirmation message]]></translation>
+      </item>
       <item type="label" name="SecondsAgo">
         <translation language="nl"><![CDATA[%1$s seconden geleden]]></translation>
         <translation language="en"><![CDATA[%1$s seconds ago]]></translation>
@@ -548,6 +558,11 @@
         <translation language="sv"><![CDATA[%1$s sekunder sen]]></translation>
         <translation language="el"><![CDATA[Πριν από %1$s δευτερόλεπτα]]></translation>
         <translation language="pl"><![CDATA[%1$s sekund temu]]></translation>
+      </item>
+      <item type="label" name="SelectConfirmationPage">
+        <translation language="nl"><![CDATA[selecteer bevestigingspagina]]></translation>
+        <translation language="fr"><![CDATA[sélectionner la page de confirmation]]></translation>
+        <translation language="en"><![CDATA[select confirmation page]]></translation>
       </item>
       <item type="label" name="SenderInformation">
         <translation language="nl"><![CDATA[afzender informatie]]></translation>
@@ -623,6 +638,11 @@
         <translation language="sv"><![CDATA[lyckat meddelande]]></translation>
         <translation language="el"><![CDATA[Μήνυμα επιτυχίας]]></translation>
         <translation language="pl"><![CDATA[wiadomość powodzenia]]></translation>
+      </item>
+      <item type="label" name="SuccessPage">
+        <translation language="nl"><![CDATA[succes pagina]]></translation>
+        <translation language="en"><![CDATA[success page]]></translation>
+        <translation language="fr"><![CDATA[page de réussite]]></translation>
       </item>
       <item type="label" name="Textarea">
         <translation language="nl"><![CDATA[tekstgebied]]></translation>

--- a/src/Backend/Modules/FormBuilder/Installer/Installer.php
+++ b/src/Backend/Modules/FormBuilder/Installer/Installer.php
@@ -70,6 +70,7 @@ class Installer extends ModuleInstaller
             $form['name'] = \SpoonFilter::ucfirst($this->getLocale('Contact', 'Core', $language, 'lbl', 'Frontend'));
             $form['method'] = 'database_email';
             $form['email'] = serialize([$this->getVariable('email')]);
+            $form['success_type'] = 'message';
             $form['success_message'] = $this->getLocale('ContactMessageSent', 'Core', $language, 'msg', 'Frontend');
             $form['identifier'] = 'contact-' . $language;
             $form['created_on'] = gmdate('Y-m-d H:i:s');

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -32,6 +32,21 @@ jsBackend.FormBuilder = {
       removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('Delete')),
       canAddNew: true
     })
+
+    jsBackend.FormBuilder.handleSuccessType()
+    $('input[name="success_type"]').change(function(e) {
+      jsBackend.FormBuilder.handleSuccessType()
+    });
+  },
+
+  handleSuccessType: function() {
+    if ($('input[name="success_type"]:checked').val() == 'page') {
+      $('.js-success-page').removeClass('hide');
+      $('.js-success-message').addClass('hide');
+    } else {
+      $('.js-success-page').addClass('hide');
+      $('.js-success-message').removeClass('hide');
+    }
   },
 
   /**

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Add.html.twig
@@ -64,7 +64,25 @@
                 </div>
               </div>
               <div class="col-lg-6">
-                <div class="panel panel-default panel-editor">
+                <div class="panel panel-default">
+                  <div class="panel-heading">
+                    <label for="successPage" class="control-label">
+                      {{ 'lbl.SuccessPage'|trans|ucfirst }}
+                    </label>
+                  </div>
+                  <div class="panel-body">
+                    <div class="form-group last">
+                      <ul class="list-unstyled">
+                        {% for option in success_type %}
+                          <li class="radio">
+                            <label for="{{ option.id }}">{{ option.rbtSuccessType|raw }} {{ option.label }}</label>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div class="panel panel-default panel-editor js-success-message">
                   <div class="panel-heading">
                     <label for="successMessage" class="control-label">
                       {{ 'lbl.SuccessMessage'|trans|ucfirst }}
@@ -81,6 +99,19 @@
                       {% form_field_error success_message %}
                     </div>
                   {% endif %}
+                </div>
+                <div class="panel panel-default hide js-success-page">
+                  <div class="panel-heading">
+                    <label for="successPage" class="control-label">
+                      {{ 'lbl.SuccessPage'|trans|ucfirst }}
+                    </label>
+                  </div>
+                  <div class="panel-body">
+                    <div class="form-group last">
+                      <label for="successPage" class="control-label">{{ 'lbl.SelectConfirmationPage'|trans|ucfirst }}</label>
+                      {% form_field success_page %}{% form_field_error success_page %}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
@@ -81,7 +81,25 @@
                 </div>
               </div>
               <div class="col-lg-6">
-                <div class="panel panel-default panel-editor">
+                <div class="panel panel-default">
+                  <div class="panel-heading">
+                    <label for="successPage" class="control-label">
+                      {{ 'lbl.SuccessPage'|trans|ucfirst }}
+                    </label>
+                  </div>
+                  <div class="panel-body">
+                    <div class="form-group last">
+                      <ul class="list-unstyled">
+                        {% for option in success_type %}
+                          <li class="radio">
+                            <label for="{{ option.id }}">{{ option.rbtSuccessType|raw }} {{ option.label }}</label>
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div class="panel panel-default panel-editor js-success-message">
                   <div class="panel-heading">
                     <label for="successMessage" class="control-label">
                       {{ 'lbl.SuccessMessage'|trans|ucfirst }}
@@ -89,13 +107,28 @@
                     </label>
                   </div>
                   <div class="panel-body">
-                    {% form_field success_message %}
+                    <div class="form-group last">
+                      {% form_field success_message %}
+                    </div>
                   </div>
                   {% if txtSuccessMessageError %}
                     <div class="panel-footer">
                       {% form_field_error success_message %}
                     </div>
                   {% endif %}
+                </div>
+                <div class="panel panel-default hide js-success-page">
+                  <div class="panel-heading">
+                    <label for="successPage" class="control-label">
+                      {{ 'lbl.SuccessPage'|trans|ucfirst }}
+                    </label>
+                  </div>
+                  <div class="panel-body">
+                    <div class="form-group last">
+                      <label for="successPage" class="control-label">{{ 'lbl.SelectConfirmationPage'|trans|ucfirst }}</label>
+                      {% form_field success_page %}{% form_field_error success_page %}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/Frontend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Frontend/Modules/FormBuilder/Engine/Model.php
@@ -14,7 +14,7 @@ class Model
         // get form
         $form = (array) FrontendModel::getContainer()->get('database')->getRecord(
             'SELECT i.id, i.email_subject, i.email_template, i.language, i.method, i.name, i.email,
-                    i.success_message, i.identifier
+                    i.success_type, i.success_message, i.success_page, i.identifier
              FROM forms AS i
              WHERE i.id = ?',
             $id

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -5,6 +5,7 @@ namespace Frontend\Modules\FormBuilder\Widgets;
 use Common\Exception\RedirectException;
 use Frontend\Core\Engine\Base\Widget as FrontendBaseWidget;
 use Frontend\Core\Engine\Form as FrontendForm;
+use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Core\Language\Language as FL;
 use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Core\Language\Locale;
@@ -328,8 +329,12 @@ class Form extends FrontendBaseWidget
         // form name
         $formName = 'form' . $this->item['id'];
         $this->template->assign('formName', $formName);
-        $this->template->assign('formAction', $this->createAction() . '#' . $formName);
         $this->template->assign('successMessage', false);
+        $formAction = $this->createAction();
+        if ($this->item['success_type'] == 'message') {
+            $formAction .= '#' . $formName;
+        }
+        $this->template->assign('formAction', $formAction);
 
         if ($this->hasRecaptchaField) {
             $this->header->addJS('https://www.google.com/recaptcha/api.js?hl=' . Locale::frontendLanguage());
@@ -545,10 +550,14 @@ class Form extends FrontendBaseWidget
                 FrontendModel::getSession()->set('formbuilder_' . $this->item['id'], time());
 
                 // redirect
-                $redirect = SITE_URL . $this->url->getQueryString();
-                $redirect .= (stripos($redirect, '?') === false) ? '?' : '&';
-                $redirect .= 'identifier=' . $this->item['identifier'];
-                $redirect .= '#' . $this->formName;
+                if ($this->item['success_type'] == 'page') {
+                    $redirect = FrontendNavigation::getUrl($this->item['success_page']);
+                } else {
+                    $redirect = SITE_URL . $this->url->getQueryString();
+                    $redirect .= (stripos($redirect, '?') === false) ? '?' : '&';
+                    $redirect .= 'identifier=' . $this->item['identifier'];
+                    $redirect .= '#' . $this->formName;
+                }
 
                 throw new RedirectException(
                     'Redirect',


### PR DESCRIPTION
## Type
- Bugfix
- Feature

## Pull request description
**Commit f0b1f5b : Bugfix**
- see other PR #2763 

**Commit c7ba0c2**
- It could be handy to choose between a message box on the same page, or redirecting to another page after submitting a form
- Its easier for tracking in Google Analytics if you have seperate url
- Also, redirecting to another page, gives you the possibility to add other info like widgets to that page

![schermafbeelding 2019-02-23 om 10 00 38](https://user-images.githubusercontent.com/4540274/53287104-fc988280-3777-11e9-903a-b30ba2cb3837.png)

![schermafbeelding 2019-02-23 om 10 01 09](https://user-images.githubusercontent.com/4540274/53287106-01f5cd00-3778-11e9-9cda-c46680ddc6f5.png)

