### PR TITLE
Improve checking the use of SSL

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -80,7 +80,8 @@ deny from env=stayout
     # <IfModule headers_module>
     #   Header set Strict-Transport-Security "max-age=31536000; includeSubDomains" env=HTTPS
     # </IfModule>
-    # RewriteCond %{HTTPS} !=on
+    # RewriteCond %{HTTP:X-Forwarded-Proto} !https
+    # RewriteCond %{HTTPS} off
     # RewriteCond %{HTTP_HOST} !.*\.dev [NC]
     # RewriteCond %{HTTP_HOST} !.*localhost(:\d+)?$ [NC]
     # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Servers that are behind a proxy will always have `%{HTTPS} === off`.
To prevent infinite redirect loops in this scenario this commit adds a
check on the
[X-Forwarded-Proto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto)
header before defaulting back to the `%{HTTPS}` check. This should cover
about 99% of possible htaccess/ssl related scenarios.

