### PR TITLE
Fix error when there is no category slug

### DIFF
--- a/src/Frontend/Modules/Blog/Actions/Category.php
+++ b/src/Frontend/Modules/Blog/Actions/Category.php
@@ -26,7 +26,12 @@ class Category extends FrontendBaseBlock
 
     private function getCategory(): array
     {
-        $category = FrontendBlogModel::getCategory($this->url->getParameter(1));
+        $slug = $this->url->getParameter(1);
+        if (empty($slug)) {
+            throw new NotFoundHttpException();
+        }
+
+        $category = FrontendBlogModel::getCategory($slug);
 
         if (empty($category)) {
             throw new NotFoundHttpException();


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
<!-- Describe what your pull request will fix / add / … -->

Going to the category link without a slug resulted in a 500 error: https://demo.fork-cms.com/en/modules/blog/category

