### PR TITLE
Fix bad value for time element

### DIFF
--- a/src/Frontend/Modules/Blog/Layout/Templates/Archive.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Archive.html.twig
@@ -41,7 +41,7 @@
             {% for item in items %}
               <tr>
                 <td class="date">
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s' ) }}">
                     {{ item.publish_on|spoondate(dateFormatShort,LANGUAGE ) }}
                   </time>
                 </td>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Category.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Category.html.twig
@@ -32,7 +32,7 @@
                 <div class="col-xs-12">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s' ) }}">
                     {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Detail.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Detail.html.twig
@@ -23,7 +23,7 @@
           <div class="col-xs-12">
             {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
             {{ 'lbl.On'|trans }}
-            <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
+            <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s' ) }}">
               {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
             </time>
           </div>

--- a/src/Frontend/Modules/Blog/Layout/Templates/Index.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Templates/Index.html.twig
@@ -31,7 +31,7 @@
                 <div class="col-xs-12 col-md-8">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s.vP' ) }}">
+                  <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s' ) }}">
                     {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
                   </time>
                 </div>

--- a/src/Frontend/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
+++ b/src/Frontend/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
@@ -29,7 +29,7 @@
                 <div class="col-xs-12 col-md-8">
                   {{ 'msg.WrittenBy'|trans|ucfirst|format(post.user_id|usersetting('nickname')) }}
                   {{ 'lbl.On'|trans }}
-                  <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\\TH:i:s.vP') }}">
+                  <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\\TH:i:s') }}">
                     {{ post.publish_on|spoondate(dateFormatLong, LANGUAGE ) }}
                   </time>
                 </div>

--- a/src/Frontend/Themes/Fork/Modules/Blog/Layout/Templates/Detail.html.twig
+++ b/src/Frontend/Themes/Fork/Modules/Blog/Layout/Templates/Detail.html.twig
@@ -10,7 +10,7 @@
       <div class="col-xs-12 col-md-6">
         {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
         {{ 'lbl.On'|trans }}
-        <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+        <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s') }}">
           {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
         </time>
       </div>

--- a/src/Frontend/Themes/Fork/Modules/Blog/Layout/Templates/Index.html.twig
+++ b/src/Frontend/Themes/Fork/Modules/Blog/Layout/Templates/Index.html.twig
@@ -18,7 +18,7 @@
             <div class="col-xs-12 col-md-8">
               {{ 'msg.WrittenBy'|trans|ucfirst|format(item.user_id|usersetting('nickname')) }}
               {{ 'lbl.On'|trans }}
-              <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\TH,i,s' ) }}">
+              <time itemprop="datePublished" datetime="{{ item.publish_on|date('Y-m-d\\TH:i:s') }}">
                 {{ item.publish_on|spoondate(dateFormatLong, LANGUAGE) }}
               </time>
             </div>

--- a/src/Frontend/Themes/Fork/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
+++ b/src/Frontend/Themes/Fork/Modules/Blog/Layout/Widgets/RecentArticlesFull.html.twig
@@ -18,7 +18,7 @@
             <div class="col-xs-12 col-md-8">
               {{ 'msg.WrittenBy'|trans|ucfirst|format(post.user_id|usersetting('nickname')) }}
               {{ 'lbl.On'|trans }}
-              <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\TH,i,s') }}">
+              <time itemprop="datePublished" datetime="{{ post.publish_on|trans|date('Y-m-d\\TH:i:s') }}">
                 {{ post.publish_on|spoondate(dateFormatLong, LANGUAGE ) }}
               </time>
             </div>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
validator.W3.org reports this error:
Bad value 2019-02-04CET09,35,00 for attribute datetime on element time: The literal did not satisfy the time-datetime format.
Also removed the milliseconds modifier, second should be fine.
