### PR TITLE
Fix "Notice: Array to string conversion" on EditGroup

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/EditGroup.php
+++ b/src/Backend/Modules/Profiles/Actions/EditGroup.php
@@ -87,7 +87,7 @@ class EditGroup extends BackendBaseActionEdit
                 $values = ['name' => $txtName->getValue()];
 
                 // update values
-                BackendProfilesModel::updateGroup($this->id, ['name' => $values]);
+                BackendProfilesModel::updateGroup($this->id, $values);
 
                 // everything is saved, so redirect to the overview
                 $this->redirect(


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
When editing a usergroup of the profiles module, this happens:
`Notice: Array to string conversion`

![image](https://user-images.githubusercontent.com/1352979/56173386-97ca0d80-5fed-11e9-9e31-9c26876c7973.png)
