### PR TITLE
Partly fixed deprecations of Twig #2777

### DIFF
--- a/src/Common/Core/Twig/Extensions/TwigFilters.php
+++ b/src/Common/Core/Twig/Extensions/TwigFilters.php
@@ -5,9 +5,10 @@ namespace Common\Core\Twig\Extensions;
 /**
  * Contains all Forkcms filters for Twig
  */
-use Twig_Environment;
-use Twig_SimpleFilter;
-use Twig_SimpleFunction;
+
+use Twig\Environment;
+use \Twig\TwigFilter;
+use \Twig\TwigFunction;
 
 class TwigFilters
 {
@@ -15,50 +16,50 @@ class TwigFilters
      * //http://twig.sensiolabs.org/doc/advanced.html#id2
      * returns a collection of Twig SimpleFilters
      *
-     * @param Twig_Environment $twig
+     * @param Environment $twig
      * @param string $app
      */
-    public static function addFilters(Twig_Environment $twig, string $app): void
+    public static function addFilters(Environment $twig, string $app): void
     {
         $app .= '\Core\Engine\TemplateModifiers';
-        $twig->addFilter(new Twig_SimpleFilter('getpageinfo', $app.'::getPageInfo'));
-        $twig->addFilter(new Twig_SimpleFilter('highlight', $app.'::highlightCode'));
-        $twig->addFilter(new Twig_SimpleFilter('profilesetting', $app.'::profileSetting'));
-        $twig->addFilter(new Twig_SimpleFilter('formatcurrency', $app.'::formatCurrency', ['is_safe' => ['html']]));
-        $twig->addFilter(new Twig_SimpleFilter('usersetting', $app.'::userSetting'));
-        $twig->addFilter(new Twig_SimpleFilter('uppercase', $app.'::uppercase'));
-        $twig->addFilter(new Twig_SimpleFilter('rand', $app.'::random'));
-        $twig->addFilter(new Twig_SimpleFilter('formatfloat', $app.'::formatFloat'));
-        $twig->addFilter(new Twig_SimpleFilter('truncate', $app.'::truncate'));
-        $twig->addFilter(new Twig_SimpleFilter('camelcase', $app.'::camelCase'));
-        $twig->addFilter(new Twig_SimpleFilter('snakeCase', $app.'::snakeCase'));
-        $twig->addFilter(new Twig_SimpleFilter('stripnewlines', $app.'::stripNewlines'));
-        $twig->addFilter(new Twig_SimpleFilter('formatnumber', $app.'::formatNumber'));
-        $twig->addFilter(new Twig_SimpleFilter('tolabel', $app.'::toLabel'));
-        $twig->addFilter(new Twig_SimpleFilter('cleanupplaintext', $app.'::cleanupPlainText'));
+        $twig->addFilter(new TwigFilter('getpageinfo', $app.'::getPageInfo'));
+        $twig->addFilter(new TwigFilter('highlight', $app.'::highlightCode'));
+        $twig->addFilter(new TwigFilter('profilesetting', $app.'::profileSetting'));
+        $twig->addFilter(new TwigFilter('formatcurrency', $app.'::formatCurrency', ['is_safe' => ['html']]));
+        $twig->addFilter(new TwigFilter('usersetting', $app.'::userSetting'));
+        $twig->addFilter(new TwigFilter('uppercase', $app.'::uppercase'));
+        $twig->addFilter(new TwigFilter('rand', $app.'::random'));
+        $twig->addFilter(new TwigFilter('formatfloat', $app.'::formatFloat'));
+        $twig->addFilter(new TwigFilter('truncate', $app.'::truncate'));
+        $twig->addFilter(new TwigFilter('camelcase', $app.'::camelCase'));
+        $twig->addFilter(new TwigFilter('snakeCase', $app.'::snakeCase'));
+        $twig->addFilter(new TwigFilter('stripnewlines', $app.'::stripNewlines'));
+        $twig->addFilter(new TwigFilter('formatnumber', $app.'::formatNumber'));
+        $twig->addFilter(new TwigFilter('tolabel', $app.'::toLabel'));
+        $twig->addFilter(new TwigFilter('cleanupplaintext', $app.'::cleanupPlainText'));
 
         // exposed PHP functions
 
-        $twig->addFilter(new Twig_SimpleFilter('urlencode', 'urlencode'));
-        $twig->addFilter(new Twig_SimpleFilter('rawurlencode', 'rawurlencode'));
-        $twig->addFilter(new Twig_SimpleFilter('striptags', 'strip_tags'));
-        $twig->addFilter(new Twig_SimpleFilter('addslashes', 'addslashes'));
-        $twig->addFilter(new Twig_SimpleFilter('count', 'count'));
-        $twig->addFilter(new Twig_SimpleFilter('is_array', 'is_array'));
-        $twig->addFilter(new Twig_SimpleFilter('ucfirst', 'ucfirst'));
+        $twig->addFilter(new TwigFilter('urlencode', 'urlencode'));
+        $twig->addFilter(new TwigFilter('rawurlencode', 'rawurlencode'));
+        $twig->addFilter(new TwigFilter('striptags', 'strip_tags'));
+        $twig->addFilter(new TwigFilter('addslashes', 'addslashes'));
+        $twig->addFilter(new TwigFilter('count', 'count'));
+        $twig->addFilter(new TwigFilter('is_array', 'is_array'));
+        $twig->addFilter(new TwigFilter('ucfirst', 'ucfirst'));
 
         // Functions navigation
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'getnavigation',
             $app.'::getNavigation',
             ['is_safe' => ['html']]
         ));
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'getsubnavigation',
             $app.'::getSubNavigation',
             ['is_safe' => ['html']]
         ));
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'parsewidget',
             $app.'::parseWidget',
             ['is_safe' => ['html']]
@@ -66,22 +67,22 @@ class TwigFilters
 
         // Function URL
 
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'geturl',
             $app.'::getUrl'
         ));
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'geturlforextraid',
             $app.'::getUrlForExtraId'
         ));
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'geturlforblock',
             $app.'::getUrlForBlock'
         ));
 
         // boolean functions
 
-        $twig->addFunction(new Twig_SimpleFunction(
+        $twig->addFunction(new TwigFunction(
             'showbool',
             $app.'::showBool',
             ['is_safe' => ['html']]
@@ -90,10 +91,10 @@ class TwigFilters
         // @Deprecated We should look for replacements because they run on spoon library
         // after we have those we can remove them
 
-        $twig->addFilter(new Twig_SimpleFilter('spoondate', $app.'::spoonDate'));
-        $twig->addFilter(new Twig_SimpleFilter('formatdate', $app.'::formatDate'));
-        $twig->addFilter(new Twig_SimpleFilter('formattime', $app.'::formatTime'));
-        $twig->addFilter(new Twig_SimpleFilter('timeago', $app.'::timeAgo'));
-        $twig->addFilter(new Twig_SimpleFilter('formatdatetime', $app.'::formatDateTime'));
+        $twig->addFilter(new TwigFilter('spoondate', $app.'::spoonDate'));
+        $twig->addFilter(new TwigFilter('formatdate', $app.'::formatDate'));
+        $twig->addFilter(new TwigFilter('formattime', $app.'::formatTime'));
+        $twig->addFilter(new TwigFilter('timeago', $app.'::timeAgo'));
+        $twig->addFilter(new TwigFilter('formatdatetime', $app.'::formatDateTime'));
     }
 }

--- a/src/Frontend/Core/Engine/FormTokenParser.php
+++ b/src/Frontend/Core/Engine/FormTokenParser.php
@@ -2,26 +2,30 @@
 
 namespace Frontend\Core\Engine;
 
+use Twig\Error\SyntaxError;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
 /**
  * Twig template tag for the start/opening element of a form tag.
  */
-class FormTokenParser extends \Twig_TokenParser
+class FormTokenParser extends AbstractTokenParser
 {
     /**
-     * @param \Twig_Token $token
+     * @param Token $token
      *
-     * @throws \Twig_Error_Syntax
-     *
-     * @return \Twig_Node
+     * @return Node
+     * @throws SyntaxError
      */
-    public function parse(\Twig_Token $token): \Twig_Node
+    public function parse(Token $token): Node
     {
         $stream = $this->parser->getStream();
-        $form = $stream->expect(\Twig_Token::NAME_TYPE)->getValue();
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $form = $stream->expect(Token::NAME_TYPE)->getValue();
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         if (FormState::$current !== null) {
-            throw new \Twig_Error_Syntax(
+            throw new SyntaxError(
                 sprintf(
                     'form [%s] not closed while opening form [%s]',
                     FormState::$current,

--- a/src/Frontend/Core/Engine/TwigTemplate.php
+++ b/src/Frontend/Core/Engine/TwigTemplate.php
@@ -11,8 +11,10 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Bridge\Twig\Extension\FormExtension as SymfonyFormExtension;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Templating\TemplateNameParserInterface;
-use Twig_Environment;
-use Twig_FactoryRuntimeLoader;
+use Twig\Environment;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
+use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
 /**
  * This is a twig template wrapper
@@ -26,7 +28,7 @@ class TwigTemplate extends BaseTwigTemplate
     private $themePath;
 
     public function __construct(
-        Twig_Environment $environment,
+        Environment $environment,
         TemplateNameParserInterface $parser,
         FileLocatorInterface $locator
     ) {
@@ -58,8 +60,8 @@ class TwigTemplate extends BaseTwigTemplate
     {
         $this->themePath = FRONTEND_PATH . '/Themes/' . $theme;
         $this->environment->setLoader(
-            new \Twig_Loader_Chain(
-                [$this->environment->getLoader(), new \Twig_Loader_Filesystem($this->getLoadingFolders())]
+            new ChainLoader(
+                [$this->environment->getLoader(), new FilesystemLoader($this->getLoadingFolders())]
             )
         );
     }
@@ -69,7 +71,7 @@ class TwigTemplate extends BaseTwigTemplate
         $rendererEngine = new TwigRendererEngine($this->getFormTemplates('FormLayout.html.twig'), $this->environment);
         $csrfTokenManager = Model::get('security.csrf.token_manager');
         $this->environment->addRuntimeLoader(
-            new Twig_FactoryRuntimeLoader(
+            new FactoryRuntimeLoader(
                 [
                     FormRenderer::class => function () use ($rendererEngine, $csrfTokenManager): FormRenderer {
                         return new FormRenderer($rendererEngine, $csrfTokenManager);


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
Partly fixes #2777

## Pull request description
I'm not done with all deprecations, some of them are a bit harder, like
`User Deprecated: The "Symfony\Bridge\Twig\Extension\FormExtension" class implements "Twig\Extension\InitRuntimeInterface" that is deprecated since Twig 2.7, to be removed in 3.0.`
