### PR TITLE
Use form_widget(form) instead of block('form_widget')

### DIFF
--- a/src/Backend/Core/Layout/Templates/FormLayout.html.twig
+++ b/src/Backend/Core/Layout/Templates/FormLayout.html.twig
@@ -374,7 +374,7 @@
       {{- form_label(form) -}}
     </div>
     <div class="panel-body">
-      {{- block('form_widget') -}}
+      {{- form_widget(form) -}}
     </div>
   </div>
 {%- endblock collection_row -%}


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
I'm not really sure what the difference is but one works and one doesn't

Changing this makes sure the "add button" in collections gets shown

