### PR TITLE
Fix required tooltip not showing when tabbing

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -209,6 +209,21 @@ jsFrontend.forms = {
     jsFrontend.forms.filled()
     jsFrontend.forms.datePicker()
     jsFrontend.forms.imagePreview()
+    jsFrontend.forms.requiredTooltip()
+  },
+
+  requiredTooltip: function () {
+    $(document).on('focus', '.form-control', function (event) {
+      var id = $(event.currentTarget).attr('id')
+
+      // show tooltip
+      $('label[for="' + id + '"]').find('abbr').tooltip('show')
+
+      // hide tooltip after 1 second
+      setTimeout(() => {
+        $('label[for="' + id + '"]').find('abbr').tooltip('hide')
+      }, 1000)
+    })
   },
 
   imagePreview: function () {

--- a/src/Frontend/Core/Layout/Templates/Macros.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Macros.html.twig
@@ -18,7 +18,7 @@
 {% endmacro %}
 
 {% macro required() %}
-  <abbr tabindex="0" data-toggle="tooltip" aria-label="{{ 'lbl.RequiredField'|trans|ucfirst }}" title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr>
+  <abbr data-toggle="tooltip" aria-label="{{ 'lbl.RequiredField'|trans|ucfirst }}" title="{{ 'lbl.RequiredField'|trans|ucfirst }}">*</abbr>
 {% endmacro %}
 
 {% macro icon(icon) %}


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
Improvement for screenreader users who fill in a form.

## Pull request description
When filling in a form using tab, the tooltip for a required field will be shown. 

