### PR TITLE
Breadcrumb. Remove link in last page, for CORE pages.

### DIFF
--- a/src/Frontend/Core/Engine/Breadcrumb.php
+++ b/src/Frontend/Core/Engine/Breadcrumb.php
@@ -59,7 +59,7 @@ class Breadcrumb extends KernelLoader
 
         array_map(
             function (array $breadcrumb) {
-                $this->addElement($breadcrumb['title'], $breadcrumb['url']);
+                $this->addElement($breadcrumb['title']);
             },
             $breadcrumbs
         );
@@ -92,7 +92,7 @@ class Breadcrumb extends KernelLoader
                 $pageUrl = null;
             }
 
-            $breadcrumbs[] = ['title' => $pageInfo['navigation_title'], 'url' => $pageUrl];
+            $breadcrumbs[] = ['title' => $pageInfo['navigation_title']];
 
             array_pop($pages);
         }


### PR DESCRIPTION
Breadcrumb. Remove link in last page, for CORE pages.



## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #2824

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
This small fix remove link for the last page in breadcrumb. This fix for CORE page like "Contact", "Disclaimer" and so on ONLY. Not for Modules and Widgets.

**Before fix**

![bc1](https://user-images.githubusercontent.com/5456419/58621982-493dad80-82d3-11e9-934d-2549e98983b5.jpg)


**After fix**

![bc3](https://user-images.githubusercontent.com/5456419/58621955-31662980-82d3-11e9-8ed1-d5bc49f2178d.jpg)
