### PR TITLE
Fix the pages installer locale

### DIFF
--- a/src/Backend/Modules/Pages/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Pages/Installer/Data/locale.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <locale>
   <Backend>
     <Pages>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
I have removed a whitespace in the xml header that breaks the locale file.