### PR TITLE
Add fallback to jquery-ui on IE and default values

### DIFF
--- a/app/config/form.yml
+++ b/app/config/form.yml
@@ -33,3 +33,6 @@ services:
             - "@validator"
         tags:
             - { name: form.type, alias: file}
+    Common\Form\Extension\DateTypeExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\DateType }

--- a/src/Common/Form/Extension/DateTypeExtension.php
+++ b/src/Common/Form/Extension/DateTypeExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Common\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+final class DateTypeExtension extends AbstractTypeExtension
+{
+    public function getExtendedType(): string
+    {
+        return DateType::class;
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $attr = $view->vars['attr'];
+
+        if (!array_key_exists('class', $attr)) {
+            $attr['class'] = '';
+        }
+
+        $classes = explode(' ', $attr['class']);
+        if (!in_array('inputDatefield', $classes, true)) {
+            $classes[] = 'inputDatefield';
+        }
+
+        $attr['class'] = implode(' ', $classes);
+
+        if (!array_key_exists('data-mask', $attr)) {
+            $attr['data-mask'] = 'dd/mm/yy';
+        }
+
+        if (!array_key_exists('data-firstday', $attr)) {
+            $attr['data-firstday'] = '1';
+        }
+
+        if (!array_key_exists('data-year', $attr)) {
+            $attr['data-year'] = 'Y';
+        }
+
+        if (!array_key_exists('data-month', $attr)) {
+            $attr['data-month'] = date('n') - 1;
+        }
+
+        if (!array_key_exists('data-day', $attr)) {
+            $attr['data-day'] = date('j');
+        }
+
+        if (!array_key_exists('autocomplete', $attr)) {
+            $attr['autocomplete'] = 'off';
+        }
+
+        $view->vars['attr'] = $attr;
+    }
+}


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
This PR add a fallback to jQuery-UI for date input elements. IE doesn't support `<input type="date">` therefore no native date picker will be rendered by the browser. By adding a class to our element, jQuery-UI will render its datepicker widget as a fallback.

In this PR I also added some default attributes that should be used to render the input type. Thx to @Katrienvh 
