### PR TITLE
Use Symfony's Dotenv so Symfony Server is more convenient

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,7 @@
 **/.gitignore
 **/Dockerfile
 **/Thumbs.db
-*.env.dist
+.env.local
 *.sublime-project
 *.sublime-workspace
 .editorconfig

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+FORK_ENV=prod
+FORK_DEBUG=0

--- a/.env.dist
+++ b/.env.dist
@@ -1,8 +1,0 @@
-# Use this file to set your environment variables for Docker
-
-# XDebug variables
-# Configure the IP of your hostmachine, or use the special Mac-only DNS name which will resolve to the internal IP of the host.
-DOCKER_HOST_IP=docker.for.mac.localhost
-PHP_IDE_CONFIG=serverName=localhost
-XDEBUG_IDEKEY=PHPSTORM
-XDEBUG_PORT=9000

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@
 # Docker
 var/docker/db/data/*
 docker-compose.override.yml
-.env
+
+# Symfony's dotenv
+/.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="Fork CMS <info@fork-cms.com>"
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite
 
+# Run apt from fresh debian sources
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Install GD2
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libfreetype6-dev \

--- a/autoload.php
+++ b/autoload.php
@@ -1,6 +1,9 @@
 <?php
 
+// @TODO rename this file to bootstrap.php to better reflect its function
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Symfony\Component\Dotenv\Dotenv;
 
 // use vendor generated autoloader
 $loader = require __DIR__ . '/vendor/autoload.php';
@@ -9,5 +12,28 @@ AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 // Spoon is not autoloaded via Composer but uses its own old skool autoloader
 set_include_path(__DIR__ . '/vendor/spoon/library' . PATH_SEPARATOR . get_include_path());
 require_once 'spoon/spoon.php';
+
+// load server variables
+if (!array_key_exists('FORK_ENV', $_SERVER)) {
+    $_SERVER['FORK_ENV'] = $_ENV['FORK_ENV'] ?? null;
+}
+
+if ('prod' !== $_SERVER['FORK_ENV']) {
+    if (!class_exists(Dotenv::class)) {
+        throw new RuntimeException('The "FORK_ENV" environment variable is not set to "prod". Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+    }
+    $dotenv = new Dotenv();
+
+    $dotenv->load(__DIR__ . '/.env');
+
+    // @TODO when updating to Fork 6, using Symfony 4, check if we still need to check the file's existence
+    if (file_exists(__DIR__ . '/.env.local')) {
+        $dotenv->load(__DIR__ . '/.env.local');
+    }
+}
+
+$_SERVER['FORK_ENV'] = $_ENV['FORK_ENV'] = $_SERVER['FORK_ENV'] ?: $_ENV['FORK_ENV'] ?: 'dev';
+$_SERVER['FORK_DEBUG'] = $_SERVER['FORK_DEBUG'] ?? $_ENV['FORK_DEBUG'] ?? 'prod' !== $_SERVER['FORK_ENV'];
+$_SERVER['FORK_DEBUG'] = $_ENV['FORK_DEBUG'] = (int) $_SERVER['FORK_DEBUG'] || filter_var($_SERVER['FORK_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 
 return $loader;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         volumes:
             - .:/var/www/html:cached
             - ./src/Frontend/Files:/var/www/html/src/Frontend/Files:cached
+        env_file:
+          - ./var/docker/.env
 
     db:
         image: "mariadb:latest"

--- a/docs/01. installation/07. docker.md
+++ b/docs/01. installation/07. docker.md
@@ -151,21 +151,9 @@ You can easily use different credentials by adjusting them in the `docker-compos
 ### General setup and XDebug
 [Video - watch how to setup PHPStorm and Xdebug](https://d.pr/v/6OXvva)
 
-It's easy to setup PHPStorm in combination with Docker and Xdebug, one of the most popular tools to debug your PHP application.
+It's easy to setup PHPStorm in combination with Docker and Xdebug, one of the most popular tools to debug your PHP application. In the `var/docker` folder you will find a `.env` file containing some defaults for Docker.
 
-- First create a file called .env.local in the root folder of your project and paste these lines in them
-```
-# Use this file to set your environment variables for Docker
-
-# XDebug variables
-# Configure the IP of your hostmachine, or use the special Mac-only DNS name which will resolve to the internal IP of the host.
-DOCKER_HOST_IP=docker.for.mac.localhost
-PHP_IDE_CONFIG=serverName=localhost
-XDEBUG_IDEKEY=PHPSTORM
-XDEBUG_PORT=9000
-```
-
-- You can edit the `.env.local` file to fill in some host-specific information and configure XDebug. By default it contains a special
+- You can edit the `.env` file to add or change in some information for your system and configure XDebug. By default it contains a special
 hostname available for Docker for Mac users, but you can change it to point to your own Docker host IP.
 - Recreate your Docker containers, because you modified the environment variables.
 ```

--- a/docs/01. installation/07. docker.md
+++ b/docs/01. installation/07. docker.md
@@ -153,12 +153,19 @@ You can easily use different credentials by adjusting them in the `docker-compos
 
 It's easy to setup PHPStorm in combination with Docker and Xdebug, one of the most popular tools to debug your PHP application.
 
-- First copy the .env.dist to .env in the root folder of your project
+- First create a file called .env.local in the root folder of your project and paste these lines in them
 ```
-cp .env.dist .env
+# Use this file to set your environment variables for Docker
+
+# XDebug variables
+# Configure the IP of your hostmachine, or use the special Mac-only DNS name which will resolve to the internal IP of the host.
+DOCKER_HOST_IP=docker.for.mac.localhost
+PHP_IDE_CONFIG=serverName=localhost
+XDEBUG_IDEKEY=PHPSTORM
+XDEBUG_PORT=9000
 ```
 
-- You can edit the `.env` file to fill in some host-specific information and configure XDebug. By default it contains a special
+- You can edit the `.env.local` file to fill in some host-specific information and configure XDebug. By default it contains a special
 hostname available for Docker for Mac users, but you can change it to point to your own Docker host IP.
 - Recreate your Docker containers, because you modified the environment variables.
 ```

--- a/index.php
+++ b/index.php
@@ -21,8 +21,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
 // get environment and debug mode from environment variables
-$env = getenv('FORK_ENV') ?: 'prod';
-$debug = getenv('FORK_DEBUG') === '1';
+$env = $_SERVER['FORK_ENV'] ?: 'prod';
+$debug = $_SERVER['FORK_DEBUG'] === '1';
 
 // Fork has not yet been installed
 $parametersFile = __DIR__ . '/app/config/parameters.yml';

--- a/var/docker/.env
+++ b/var/docker/.env
@@ -1,0 +1,8 @@
+# Use this file to set your environment variables for Docker
+
+# XDebug variables
+# Configure the IP of your hostmachine, or use the special Mac-only DNS name which will resolve to the internal IP of the host.
+DOCKER_HOST_IP=docker.for.mac.localhost
+PHP_IDE_CONFIG=serverName=localhost
+XDEBUG_IDEKEY=PHPSTORM
+XDEBUG_PORT=9000


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description
We've been using [Symfony server](https://symfony.com/doc/current/setup/symfony_server.html) in favor of [Docker](https://www.docker.com/) for the past few months now as it boasts quite a bit of advantages (not least of all a serious speed improvement).

The main disadvantage here was how Fork handles environments and debugging. In Docker, a virtual machine would be booted containing some environment variables: `FORK_ENV` and `FORK_DEBUG`. Fork would then read these using PHP's `getenv()` method. This poses a problem for Symfony server since it doesn't run a virtual machine but rather a local PHP instance, thus setting environment variables would be very cumbersome and not very dynamic. 

Using [Symfony's Dotenv](https://symfony.com/doc/current/components/dotenv.html) we can set environment variables for each project or even environment or machine individually.

A perfect example might be something like this: By default, Fork ships in production mode without debugging. If you'd like to run in dev mode with debugging on, simply create a `.env.local` file with this content:

```
FORK_ENV=dev
FORK_DEBUG=1
```