### PR TITLE
Don't use a link for the last item of a breadcrumb

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Breadcrumb.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Breadcrumb.html.twig
@@ -3,7 +3,7 @@
   {% for breadcrumb in breadcrumb %}
     <li{% if loop.last %} class="active"{% endif %} itemprop="itemListElement" itemscope
       itemtype="https://schema.org/ListItem">
-      {% if breadcrumb.url %}
+      {% if breadcrumb.url and not loop.last %}
         {# set the full url or the item link will not validate #}
         <a href="{{ SITE_URL }}{{ breadcrumb.url }}" title="{{ breadcrumb.title }}" itemtype="http://schema.org/Thing"
           itemprop="item">


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #2824
## Pull request description
<!-- Describe what your pull request will fix / add / … -->

We shouldn't use a link as the last item of a breadcrumb since it is the current page. I fixed it in the template instead of the php so people still have the option to access the url if they want in their theme

