### PR TITLE
jsFrontend.locale fixes

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -521,6 +521,10 @@ jsFrontend.locale = {
 
   // init, something like a constructor
   init: function () {
+    if (typeof jsFrontend.current.language == 'undefined') {
+      return
+    }
+
     $.ajax({
       url: '/src/Frontend/Cache/Locale/' + jsFrontend.current.language + '.json',
       type: 'GET',

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -546,7 +546,10 @@ jsFrontend.locale = {
     if (!jsFrontend.locale.initialized) jsFrontend.locale.init()
 
     // validate
-    if (typeof jsFrontend.locale.data[type][key] === 'undefined') return '{$' + type + key + '}'
+    if (typeof jsFrontend.locale.data[type] === 'undefined'
+      || typeof jsFrontend.locale.data[type][key] === 'undefined') {
+      return '{$' + type + key + '}'
+    }
 
     return jsFrontend.locale.data[type][key]
   },

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -517,6 +517,7 @@ jsFrontend.gravatar = {
  */
 jsFrontend.locale = {
   initialized: false,
+  initializing: false,
   data: {},
 
   // init, something like a constructor
@@ -524,6 +525,8 @@ jsFrontend.locale = {
     if (typeof jsFrontend.current.language == 'undefined') {
       return
     }
+
+    jsFrontend.locale.initializing = true
 
     $.ajax({
       url: '/src/Frontend/Cache/Locale/' + jsFrontend.current.language + '.json',
@@ -533,6 +536,7 @@ jsFrontend.locale = {
       success: function (data) {
         jsFrontend.locale.data = data
         jsFrontend.locale.initialized = true
+        jsFrontend.locale.initializing = true
       },
       error: function (jqXHR, textStatus, errorThrown) {
         throw new Error('Regenerate your locale-files.')
@@ -543,7 +547,18 @@ jsFrontend.locale = {
   // get an item from the locale
   get: function (type, key) {
     // initialize if needed
-    if (!jsFrontend.locale.initialized) jsFrontend.locale.init()
+    if (!jsFrontend.locale.initialized && !jsFrontend.locale.initializing) jsFrontend.locale.init()
+
+    if (!jsFrontend.locale.initialized) {
+      setTimeout(
+        function () {
+          return jsFrontend.locale.get(type, key)
+        },
+        30
+      )
+
+      return;
+    }
 
     // validate
     if (typeof jsFrontend.locale.data[type] === 'undefined'


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description
Previously, we assumed that, as soon as `jsFrontend.locale.init()` was executed, the locale would be available. Since `jsFrontend.locale.init()` runs an asynchronous ajax request that isn't the case.

This PR changes the code so we keep 'getting' the requested locale until the locale is actually initialized.

I've also added some other fixes that caused issues in browsers like Safari when the locale was _not_ initialized. So they're no longer actually necessary but I've included them anyway as a sort of defensive programming addition.

