### PR TITLE
2782 use preferred editor in user templates

### DIFF
--- a/docs/03. user guide/03. pages.md
+++ b/docs/03. user guide/03. pages.md
@@ -105,7 +105,7 @@ currently supported:
     <h2 data-ft-label="Title voor dit blokje" data-ft-type="text">Dit is een titel</h2>
     <p data-ft-label="beschrijving" data-ft-type="textarea">Dit is de beschrijving</p>
     <div data-ft-label="editor" data-ft-type="editor">Dit is de editor</div>
-    <img src="http://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
+    <img src="https://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
     <div class="image-holder" data-src="https://placehold.it/200x200" data-ft-label="Background image" data-ft-type="image-background" data-ft-block-optional="true" style="background-image: url('https://placehold.it/200x200');"></div>
 
     

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -796,7 +796,7 @@ jsBackend.pages.extras = {
     html += '<div class="panel-body">'
 
     html += '<div class="form-group last">'
-    html += '<textarea id="user-template-cke-' + key + '" data-ft-label="' + label + '" cols="83" rows="15" class="inputEditor">' + text + '</textarea>'
+    html += '<textarea id="user-template-cke-' + key + '" data-ft-label="' + label + '" cols="83" rows="15" class="inputEditor form-control">' + text + '</textarea>'
     html += '</div>'
 
     html += '</div>'

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -1006,10 +1006,12 @@ jsBackend.pages.extras = {
     }
 
     // replace editor
-    if ($element.is('[data-ft-type="editor"]') && jsData.Core.preferred_editor === 'ck-editor') {
+    if ($element.is('[data-ft-type="editor"]')) {
       $placeholder.append(jsBackend.pages.extras.getEditorFieldHtml($element.html(), $element.data('ft-label'), key))
 
-      jsBackend.ckeditor.load()
+      if (jsData.Core.preferred_editor === 'ck-editor') {
+        jsBackend.ckeditor.load()
+      }
     }
   },
 
@@ -1088,15 +1090,17 @@ jsBackend.pages.extras = {
       return
     }
 
-    if ($element.is('[data-ft-type="editor"]') && jsData.Core.preferred_editor === 'ck-editor') {
+    if ($element.is('[data-ft-type="editor"]')) {
       $textarea = $placeholder.find('#user-template-editor-' + key + ' textarea[data-ft-label]')
 
       $element.html($textarea.val())
 
-      // destroy the editor
-      var editor = CKEDITOR.instances['user-template-cke-' + key]
-      if (editor) {
-        editor.destroy(true)
+      if (jsData.Core.preferred_editor === 'ck-editor') {
+        // destroy the editor
+        var editor = CKEDITOR.instances['user-template-cke-' + key]
+        if (editor) {
+          editor.destroy(true)
+        }
       }
     }
   },

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/quote.html
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/quote.html
@@ -1,7 +1,7 @@
 <blockquote>
   <div class="row">
     <div class="col-sm-2">
-      <img src="http://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
+      <img src="https://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
     </div>
     <div class="col-sm-10">
       <p data-ft-type="textarea" data-ft-label="Quote text">The only way to do great work is to love what you do</p>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #2782 
## Pull request description
<!-- Describe what your pull request will fix / add / … -->
The code used to stop ckeditor from launching in user templates was flawed and resulted in the entire field being skipped instead of showing a normal text area