### PR TITLE
Fix wrong month in blog archive breadcrumb

### DIFF
--- a/src/Frontend/Modules/Blog/Actions/Archive.php
+++ b/src/Frontend/Modules/Blog/Actions/Archive.php
@@ -4,6 +4,7 @@ namespace Frontend\Modules\Blog\Actions;
 
 use DateTimeImmutable;
 use Frontend\Core\Engine\Base\Block as FrontendBaseBlock;
+use Frontend\Core\Engine\Model;
 use Frontend\Core\Engine\Navigation;
 use Frontend\Core\Language\Language as FL;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
@@ -169,7 +170,7 @@ class Archive extends FrontendBaseBlock
         $this->header->setPageTitle($this->startDate->format('Y'));
         if ($this->hasMonth) {
             $this->header->setPageTitle(
-                \SpoonDate::getDate('F', $this->startDate->getTimestamp(), LANGUAGE, true)
+                \SpoonDate::getDate('F', $this->startDate->getTimestamp(), LANGUAGE)
             );
         }
     }
@@ -180,7 +181,11 @@ class Archive extends FrontendBaseBlock
         $this->breadcrumb->addElement($this->startDate->format('Y'));
         if ($this->hasMonth) {
             $this->breadcrumb->addElement(
-                \SpoonDate::getDate('F', $this->startDate->getTimestamp(), LANGUAGE, true)
+                \SpoonDate::getDate(
+                    'F',
+                    $this->startDate->getTimestamp(),
+                    LANGUAGE
+                )
             );
         }
     }


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #2833

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
The wrong month was shown in the breadcrumb because of timezone issues
