### PR TITLE
Show the user template that is used in the dialog to edit it

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -615,6 +615,9 @@ jsBackend.pages.extras = {
 
     var templateUrl
 
+    // Set the title of the modal to the title of the user template
+    $('[data-fork-cms-role=user-template-title]').text(jsBackend.pages.template.userTemplates[userTemplateId].title)
+
     // if there already was content, use this.
     if (previousContent !== '') {
       $('#userTemplateHiddenPlaceholder').html(previousContent)

--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -375,7 +375,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans|ucfirst }}"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title" id="addUserTemplateTitle">{{ 'lbl.Content'|trans|capitalize }}</h4>
+          <h4 class="modal-title" id="addUserTemplateTitle">{{ 'lbl.UserTemplate'|trans|capitalize }}: <span data-fork-cms-role="user-template-title"></span></h4>
         </div>
         <div class="modal-body">
           <div id="userTemplateHiddenPlaceholder" style="display:none;"></div>

--- a/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Edit.html.twig
@@ -474,7 +474,7 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans|ucfirst }}">
             <span aria-hidden="true">&times;</span>
           </button>
-          <h4 class="modal-title" id="addUserTemplateTitle">{{ 'lbl.Content'|trans|capitalize }}</h4>
+          <h4 class="modal-title" id="addUserTemplateTitle">{{ 'lbl.UserTemplate'|trans|capitalize }}: <span data-fork-cms-role="user-template-title"></span></h4>
         </div>
         <div class="modal-body">
           <div id="userTemplateHiddenPlaceholder" style="display:none;"></div>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #2723 
## Pull request description
<!-- Describe what your pull request will fix / add / … -->
This pr makes it possible to view the title of the user template you are using while editing the content.

####Before
<img width="935" alt="Screenshot 2019-07-02 at 11 45 34" src="https://user-images.githubusercontent.com/3634654/60503416-026f1900-9cc0-11e9-8489-69589356a8e8.png">

#### After
<img width="958" alt="Screenshot 2019-07-02 at 11 50 45" src="https://user-images.githubusercontent.com/3634654/60503428-0733cd00-9cc0-11e9-94c6-4046063fe96b.png">

