### PR TITLE
Show session timeout warning 15min after page load

### DIFF
--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -221,6 +221,7 @@ final class Header extends KernelLoader
 
         $this->jsData->add('site', 'domain', SITE_DOMAIN);
         $this->jsData->add('editor', 'language', $this->getCKEditorLanguage());
+        $this->jsData->add('Core', 'session_timeout', $this->getFirstPossibleSessionTimeout());
 
         if (!empty($this->get('fork.settings')->get('Core', 'theme'))) {
             $this->jsData->add('theme', 'theme', $this->get('fork.settings')->get('Core', 'theme'));
@@ -230,6 +231,18 @@ final class Header extends KernelLoader
             $this->jsData->add('theme', 'has_editor_css', is_file($themePath . '/Core/Layout/Css/editor_content.css'));
         }
         $this->template->assign('jsData', $this->jsData);
+    }
+
+    private function getFirstPossibleSessionTimeout(): int
+    {
+        $garbageCollectionMaxLifeTime = (int) ini_get('session.gc_maxlifetime');
+        $cookieLifetime = (int) ini_get('session.cookie_lifetime');
+
+        if ($cookieLifetime === 0 || $cookieLifetime < $garbageCollectionMaxLifeTime) {
+            return $garbageCollectionMaxLifeTime;
+        }
+
+        return $cookieLifetime;
     }
 
     /**

--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -11670,6 +11670,10 @@
         <translation language="el"><![CDATA[Οι αλλαγές θα χαθούν.]]></translation>
         <translation language="pl"><![CDATA[Zmiany zostaną utracone]]></translation>
       </item>
+      <item type="message" name="SessionTimeoutWarning">
+        <translation language="nl"><![CDATA[Je sessie gaat verlopen, we raden je aan uw wijzigingen (tijdelijk) op te slaan]]></translation>
+        <translation language="en"><![CDATA[Your session will expire, we recommend you to save your changes (temporarily)]]></translation>
+      </item>
       <item type="error" name="ActionNotAllowed">
         <translation language="nl"><![CDATA[Je hebt onvoldoende rechten voor deze actie.]]></translation>
         <translation language="en"><![CDATA[You have insufficient rights for this action.]]></translation>

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -2068,7 +2068,7 @@ jsBackend.session = {
 
   sessionTimeoutPopup: function () {
     // show alert with warnign 15min after page load
-    setTimeout(function () {
+    setInterval(function () {
       window.alert(jsBackend.locale.msg('SessionTimeoutWarning'))
     }, 15 * 60 * 1000)
   }

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -2066,11 +2066,11 @@ jsBackend.session = {
     jsBackend.session.sessionTimeoutPopup()
   },
 
+  // Display a session timeout warning 1 minute before the session might actually expire
   sessionTimeoutPopup: function () {
-    // show alert with warnign 15min after page load
     setInterval(function () {
       window.alert(jsBackend.locale.msg('SessionTimeoutWarning'))
-    }, 15 * 60 * 1000)
+    }, (jsBackend.Core.session_timeout - 60) * 1000)
   }
 }
 

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -51,6 +51,7 @@ var jsBackend =
       if (jsData.Core.preferred_editor === 'ck-editor') jsBackend.ckeditor.init()
       jsBackend.resizeFunctions.init()
       jsBackend.navigation.init()
+      jsBackend.session.init()
 
       // do not move, should be run as the last item.
       if (!jsBackend.data.get('debug')) jsBackend.forms.unloadWarning()
@@ -2057,6 +2058,19 @@ jsBackend.resizeFunctions = {
     return $(window).on('load resize', function () {
       return tick()
     })
+  }
+}
+
+jsBackend.session = {
+  init: function () {
+    jsBackend.session.sessionTimeoutPopup()
+  },
+
+  sessionTimeoutPopup: function () {
+    // show alert with warnign 15min after page load
+    setTimeout(function () {
+      window.alert(jsBackend.locale.msg('SessionTimeoutWarning'))
+    }, 15 * 60 * 1000)
   }
 }
 


### PR DESCRIPTION
## Type
- Enhancement

## Resolves the following issues
Losing changes because your session expired without any warning.

## Pull request description
Now there will appear a warning 15 minutes after page load, with the message to recommend the user to (temporary) save the changes that are made.

