### PR TITLE
Fix issue #2860 : Formbuilder : Not possible to add checkboxes

### DIFF
--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -210,7 +210,7 @@ jsBackend.FormBuilder.Fields = {
             case 'mailmotorDialog':
               jsBackend.FormBuilder.Fields.saveMailmotorbutton()
               break
-            case 'checkboxDialogcheckboxDialog':
+            case 'checkboxDialog':
               jsBackend.FormBuilder.Fields.saveCheckbox()
               break
           }


### PR DESCRIPTION
## Type
- Critical bugfix

## Resolves the following issues
#2860 Formbuilder : Not possible to add checkboxes

