### PR TITLE
Fix broken translation in Pagination template

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Pagination.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Pagination.html.twig
@@ -49,10 +49,10 @@
         <li{% if not pagination.show_next %} class="disabled" {% endif %}>
           {% if pagination.show_next %}
             <a href="{{ pagination.next_url }}" rel="next nofollow" title="{{ 'lbl.NextPage'|trans|ucfirst }}">
-              <span class="sr-only">{{ 'lbl.NextPage' }} </span>&rarr;
+              <span class="sr-only">{{ 'lbl.NextPage'|trans|ucfirst }} </span>&rarr;
             </a>
           {% else %}
-            <span><span class="sr-only">{{ 'lbl.NextPage' }} </span>&rarr;</span>
+            <span><span class="sr-only">{{ 'lbl.NextPage'|trans|ucfirst }} </span>&rarr;</span>
           {% endif %}
         </li>
       </ul>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
The translation in the base pagination template was broken and was showing literal string "lbl.NextPage". This should fix it
