### PR TITLE
Change arrow function to a plain old function

### DIFF
--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -220,7 +220,7 @@ jsFrontend.forms = {
       $('label[for="' + id + '"]').find('abbr').tooltip('show')
 
       // hide tooltip after 1 second
-      setTimeout(() => {
+      setTimeout(function () {
         $('label[for="' + id + '"]').find('abbr').tooltip('hide')
       }, 1000)
     })


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description
An arrow style function was present in frontend.js but Internet Explorer (all versions) can't handle this so it breaks all JavaScript on the frontend. This pull request reverts it to a plain old `function () {}` so it works on all browsers.

