### PR TITLE
Convert + to %20 in mailto urls

### DIFF
--- a/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
+++ b/src/Backend/Core/Js/ckeditor/plugins/medialibrary/dialogs/linkDialog.js
@@ -208,8 +208,9 @@ CKEDITOR.dialog.add(
                                     url.searchParams.append('body', this.getDialog().getValueOf('tab', 'content'));
                                 }
 
-                                element.setAttribute('href', url.toString());
-                                element.setAttribute('data-cke-saved-href', url.toString());
+                                var href = url.toString().replace(/\+/g, '%20');
+                                element.setAttribute('href', href);
+                                element.setAttribute('data-cke-saved-href', href);
                             }
                         },
                         {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Previously, if you created a mailto link with spaces in the subject and/or body, the url would contain "+" instead of spaces (because of `url.toString()`) and those "+"'s would end up in the mail clients.

This pull request converts those "+"'s to "%20" which get converted to actual spaces by the mail clients.

