### PR TITLE
Use the correct icon for deleting a ContentBlock

### DIFF
--- a/src/Backend/Modules/ContentBlocks/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/ContentBlocks/Layout/Templates/Edit.html.twig
@@ -53,7 +53,7 @@
       <div class="btn-toolbar">
         <div class="btn-group pull-left" role="group">
           {% if showContentBlocksDelete %}
-            {{ macro.buttonIcon('', 'plus-square', 'lbl.Delete'|trans|ucfirst, 'btn-danger', {"type":"button", "data-toggle":"modal", "data-target":"#confirmDelete"}) }}
+            {{ macro.buttonIcon('', 'trash', 'lbl.Delete'|trans|ucfirst, 'btn-danger', {"type":"button", "data-toggle":"modal", "data-target":"#confirmDelete"}) }}
           {% endif %}
           {{ macro.buttonIcon(geturl('Index'), 'times', 'lbl.Cancel'|trans|ucfirst, 'btn-default') }}
         </div>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
Don't use a plus icon for deleting stuff... use trash. Literal trash.

