### PR TITLE
Make the PageContextDataCollector ignore all errors

### DIFF
--- a/src/Common/DataCollector/PageContextDataCollector.php
+++ b/src/Common/DataCollector/PageContextDataCollector.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class PageContextDataCollector extends DataCollector
 {

--- a/src/Common/DataCollector/PageContextDataCollector.php
+++ b/src/Common/DataCollector/PageContextDataCollector.php
@@ -39,18 +39,22 @@ class PageContextDataCollector extends DataCollector
             return;
         }
 
-        $pageRecord = $this->page->getRecord();
+        try {
+            $pageRecord = $this->page->getRecord();
 
-        $this->data = [
-            'page' => [
-                'id' => $this->page->getId(),
-                'title' => $pageRecord['title'],
-                'template' => $this->getFullTemplatePath($pageRecord['template_path']),
-            ],
-            'widgets' => $this->collectWidgets($this->page->getExtras()),
-            'block' => $this->collectBlock($this->page->getExtras()),
-            'theme' => $this->theme,
-        ];
+            $this->data = [
+                'page' => [
+                    'id' => $this->page->getId(),
+                    'title' => $pageRecord['title'],
+                    'template' => $this->getFullTemplatePath($pageRecord['template_path']),
+                ],
+                'widgets' => $this->collectWidgets($this->page->getExtras()),
+                'block' => $this->collectBlock($this->page->getExtras()),
+                'theme' => $this->theme,
+            ];
+        } catch (Throwable $throwable) {
+            // do nothing
+        }
     }
 
     private function collectWidgets(array $pageExtras): ?array


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix
## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
There are cases when the page id isn't set because something went wrong, but that made the PageContextDataCollector throw errors so now we catch them all and ignore them since that is not the job of that collector
