### PR TITLE
Restrict upload of new media to the selected type in CKEditor

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -532,8 +532,8 @@ jsBackend.ckeditor = {
             editor.popup(window.location.origin + jsData.MediaLibrary.browseActionVideos, 800, 800)
 
             window.onmessage = function (event) {
-              if (event.data) {
-                this.setValueOf('general', 'embedCode', event.data)
+              if (event.data && typeof event.data === 'object' && 'media-url' in event.data) {
+                this.setValueOf('general', 'embedCode', event.data['media-url'])
               }
             }.bind(this.getDialog())
           },

--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -518,8 +518,6 @@ jsBackend.ckeditor = {
     }
 
     if (evt.data.name === 'oembed') {
-      debugger
-
       dialogDefinition.getContents('general').elements.splice(
         2,
         0,

--- a/src/Backend/Modules/MediaLibrary/Actions/MediaBrowserImages.php
+++ b/src/Backend/Modules/MediaLibrary/Actions/MediaBrowserImages.php
@@ -26,6 +26,7 @@ class MediaBrowserImages extends MediaBrowser
         $mediaFolderId = ($this->mediaFolder instanceof MediaFolder) ? $this->mediaFolder->getId() : null;
 
         $this->template->assign('folderId', $mediaFolderId);
+        $this->template->assign('mediaType', 'image');
         $this->template->assign('tree', $this->get('media_library.manager.tree_media_browser_images')->getHTML());
         $this->header->addJsData('MediaLibrary', 'openedFolderId', $mediaFolderId);
     }

--- a/src/Backend/Modules/MediaLibrary/Actions/MediaBrowserVideos.php
+++ b/src/Backend/Modules/MediaLibrary/Actions/MediaBrowserVideos.php
@@ -26,6 +26,7 @@ class MediaBrowserVideos extends MediaBrowser
         $mediaFolderId = ($this->mediaFolder instanceof MediaFolder) ? $this->mediaFolder->getId() : null;
 
         $this->template->assign('folderId', $mediaFolderId);
+        $this->template->assign('mediaType', 'video');
         $this->template->assign('tree', $this->get('media_library.manager.tree_media_browser_videos')->getHTML());
         $this->header->addJsData('MediaLibrary', 'openedFolderId', $mediaFolderId);
     }

--- a/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaLibraryUpload.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaLibraryUpload.html.twig
@@ -79,7 +79,7 @@
 <div data-role="uploadMediaStep1">
   {# Choose type #}
   <div class="row fork-module-content">
-    <div id="uploadMediaTypeBox">
+    <div id="uploadMediaTypeBox" {% if mediaType is defined %}class="hidden"{% endif %}>
       <div class="col-md-6">
         <div class="panel panel-default">
           <div class="panel-heading">
@@ -89,10 +89,10 @@
             <div class="form-group last">
               <ul class="list-unstyled">
                 <li class="radiobutton">
-                  <label><input type="radio" name="uploading_type" id="uploadTypeDefault" value="all" checked="checked" /> {{ 'msg.MediaUploadTypeFiles'|trans }}</label>
+                  <label><input type="radio" name="uploading_type" id="uploadTypeDefault" value="all" {% if mediaType is not defined or mediaType == 'image' %}checked="checked"{% endif %} /> {{ 'msg.MediaUploadTypeFiles'|trans }}</label>
                 </li>
                 <li class="radiobutton">
-                  <label><input type="radio" name="uploading_type" value="movie" /> {{ 'msg.MediaUploadTypeMovies'|trans }}</label>
+                  <label><input type="radio" name="uploading_type" value="movie" {% if mediaType is defined and mediaType == 'video' %}checked="checked"{% endif %} /> {{ 'msg.MediaUploadTypeMovies'|trans }}</label>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description
If a user inserts an image or a video into an editor by using the Browse server button, in the dialog that gets opened, the user will have the possibility to add new media and use that same uploaded media in the editor. The problem is the if the user clicks to add an image to the editor and then within the dialog he adds a video, the video gets then added to the editor with an `<img>` tag. Example: `<img src="https://www.youtube.com/watch?v=EoJyHgLG4XI">`. The same type of behaviour also exists when adding a video to the editor and the user adds a new image, which is also not correct.

This PR removes the possibility to upload new images when adding videos or upload videos when adding images. 

Initially:
![image](https://user-images.githubusercontent.com/848112/64861614-acf4a800-d630-11e9-86aa-5b380dd2e348.png)

Removed the possibility to change the type of uploaded media. The type gets now automatically selected according to the type of media being added to the editor.
![image](https://user-images.githubusercontent.com/848112/64861528-761e9200-d630-11e9-823a-a925ef182b52.png)