### PR TITLE
Fix broken links in medialibrary docs

### DIFF
--- a/docs/07. media library/01. introduction.md
+++ b/docs/07. media library/01. introduction.md
@@ -26,11 +26,11 @@ In the frontend you can choose how you wish to show the MediaGroup entities.
 
 **Default media widgets**
 
-* **Lightbox** ([php](../../src/Frontend/Modules/MediaLibrary/Widgets/Lightbox.php), [html](../../src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig)) - clicking a thumbnail will open a lightbox
-* **Listing** ([php](../../src/Frontend/Modules/MediaLibrary/Widgets/Listing.php), [html](../../src/Frontend/Modules/MediaLibrary/Layout/Widgets/Listing.html.twig)) - a list `<ul>` containing the links to the source files
-* **OneImage** ([php](../../src/Frontend/Modules/MediaLibrary/Widgets/OneImage.php), [html](../../src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneImage.html.twig)) - the first image will be shown
-* **OneRandomImage** ([php](../../src/Frontend/Modules/MediaLibrary/Widgets/OneRandomImage.php), [html](../../src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneRandomImage.html.twig)) - randomly pick one image from your MediaGroup
-* **Slider** ([php](../../src/Frontend/Modules/MediaLibrary/Widgets/Slider.php), [html](../../src/Frontend/Modules/MediaLibrary/Layout/Widgets/Slider.html.twig)) - thumbnails will be created to show a slider
+* **Lightbox** ([php](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Widgets/Lightbox.php), [html](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Lightbox.html.twig)) - clicking a thumbnail will open a lightbox
+* **Listing** ([php](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Widgets/Listing.php), [html](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Listing.html.twig)) - a list `<ul>` containing the links to the source files
+* **OneImage** ([php](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Widgets/OneImage.php), [html](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneImage.html.twig)) - the first image will be shown
+* **OneRandomImage** ([php](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Widgets/OneRandomImage.php), [html](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Layout/Widgets/OneRandomImage.html.twig)) - randomly pick one image from your MediaGroup
+* **Slider** ([php](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Widgets/Slider.php), [html](https://github.com/forkcms/forkcms/blob/master/src/Frontend/Modules/MediaLibrary/Layout/Widgets/Slider.html.twig)) - thumbnails will be created to show a slider
 
 **Custom media widgets**
 

--- a/docs/07. media library/02. module structure.md
+++ b/docs/07. media library/02. module structure.md
@@ -11,13 +11,13 @@
 
 `MediaFolder` <---> contains multiple `MediaItem` entities
 
-> This is purely for your own internal usage in the backend. [View MediaFolder entity](../../src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php).
+> This is purely for your own internal usage in the backend. [View MediaFolder entity](https://github.com/forkcms/forkcms/blob/master/src/Backend/Modules/MediaLibrary/Domain/MediaFolder/MediaFolder.php).
 
 **MediaGroup**
 
 `MediaGroup` <---> contains multiple `MediaItem` entities using `MediaGroupMediaItem`.
 
-> Any custom module entity can have one or more MediaGroup entities. [View MediaGroup entity](../../src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php).
+> Any custom module entity can have one or more MediaGroup entities. [View MediaGroup entity](https://github.com/forkcms/forkcms/blob/master/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php).
 
 ## Example
 ```php


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
Stops me from getting 500 error emails on the docs website :) 
https://docs.fork-cms.com/documentation/detail/media-library/introduction

![image](https://user-images.githubusercontent.com/1352979/64926998-0d3c4300-d805-11e9-8264-1feb5a520b07.png)



## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Fix the links on the docs site, so they actually point to somewhere instead of giving a 500 error.

