### PR TITLE
Add trim to user content template's text value

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -744,22 +744,27 @@ jsBackend.pages.extras = {
    * Creates the html for a text field
    */
   getTextFieldHtml: function (text, label, key) {
-    return `
-      <div class="panel panel-default" id="user-template-text-${key}">
-        <div class="panel-heading">
-          <h2 class="panel-title">${label}</h2>
-        </div>
-        <div class="panel-body">
-          <div class="form-group last">
-            <input data-ft-label="${label}" type="text" class="form-control" value="${text.trim()}" />
-          </div>
-        </div>
-      </div>
-    `
+    var html = '<div class="panel panel-default" id="user-template-text-' + key + '">'
+
+    html += '<div class="panel-heading">'
+    html += '<h2 class="panel-title">' + label + '</h2>'
+    html += '</div>'
+
+    html += '<div class="panel-body">'
+
+    html += '<div class="form-group last">'
+    html += '<input data-ft-label="' + label + '" type="text" class="form-control" value="' + text.trim() + '" />'
+    html += '</div>'
+
+    html += '</div>'
+
+    html += '</div>'
+
+    return html
   },
 
   /**
-   * Creates the html for an editor
+   * Creates the html for a text area
    */
   getTextAreaFieldHtml: function (text, label, key) {
     var html = '<div class="panel panel-default panel-editor" id="user-template-textarea-' + key + '">'
@@ -771,7 +776,7 @@ jsBackend.pages.extras = {
     html += '<div class="panel-body">'
 
     html += '<div class="form-group last">'
-    html += '<textarea class="form-control" data-ft-label="' + label + '" cols="83" rows="15">' + text + '</textarea>'
+    html += '<textarea class="form-control" data-ft-label="' + label + '" cols="83" rows="15">' + text.trim() + '</textarea>'
     html += '</div>'
 
     html += '</div>'
@@ -794,7 +799,7 @@ jsBackend.pages.extras = {
     html += '<div class="panel-body">'
 
     html += '<div class="form-group last">'
-    html += '<textarea id="user-template-cke-' + key + '" data-ft-label="' + label + '" cols="83" rows="15" class="inputEditor form-control">' + text + '</textarea>'
+    html += '<textarea id="user-template-cke-' + key + '" data-ft-label="' + label + '" cols="83" rows="15" class="inputEditor form-control">' + text.trim() + '</textarea>'
     html += '</div>'
 
     html += '</div>'

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -744,23 +744,18 @@ jsBackend.pages.extras = {
    * Creates the html for a text field
    */
   getTextFieldHtml: function (text, label, key) {
-    var html = '<div class="panel panel-default" id="user-template-text-' + key + '">'
-
-    html += '<div class="panel-heading">'
-    html += '<h2 class="panel-title">' + label + '</h2>'
-    html += '</div>'
-
-    html += '<div class="panel-body">'
-
-    html += '<div class="form-group last">'
-    html += '<input data-ft-label="' + label + '" type="text" class="form-control" value="' + text + '" />'
-    html += '</div>'
-
-    html += '</div>'
-
-    html += '</div>'
-
-    return html
+    return `
+      <div class="panel panel-default" id="user-template-text-${key}">
+        <div class="panel-heading">
+          <h2 class="panel-title">${label}</h2>
+        </div>
+        <div class="panel-body">
+          <div class="form-group last">
+            <input data-ft-label="${label}" type="text" class="form-control" value="${text.trim()}" />
+          </div>
+        </div>
+      </div>
+    `
   },
 
   /**


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

When my user content template contains this (auto-formatted) html:

```
<h5 class="text-blue-darkest font-medium uppercase text-lg" data-ft-label="Naam" data-ft-type="text">
    Firstname Lastname
</h5>
```

There are spaces in the html. However, these spaces are copied in the rendering of the field:

![image](https://user-images.githubusercontent.com/1352979/64988651-383d9a00-d8cc-11e9-8c39-d28af6621270.png)



## Pull request description
<!-- Describe what your pull request will fix / add / … -->
- ✅ Add a `trim()` to the value of the user content text field html method
- ✅ Use a ES6 [Template Literals](https://caniuse.com/#feat=template-literals) to return the snippet of HTML. We lose IE11 support by doing that, but I guess we should stop supporting IE11 in the backend? ⚠️   This is the backend and any admin is most likely using an evergreen browser? Should I make all the methods that return html in this class, use template literals? 


After the fix: no added whitespace in the default values visible 

![image](https://user-images.githubusercontent.com/1352979/64988880-b13cf180-d8cc-11e9-88f0-63a710edb332.png)
