### PR TITLE
Fix button color Publish of FAQ module

### DIFF
--- a/src/Backend/Modules/Faq/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Faq/Layout/Templates/Edit.html.twig
@@ -159,7 +159,7 @@
           {{ macro.buttonIcon(geturl('Index'), 'times', 'lbl.Cancel'|trans|ucfirst, 'btn-default' ) }}
         </div>
         <div class="btn-group pull-right" role="group">
-          {{ macro.buttonIcon('', 'check', 'lbl.Publish'|trans|ucfirst, 'btn-danger', { "id":"editButton", "type":"submit", "name":"edit" } ) }}
+          {{ macro.buttonIcon('', 'check', 'lbl.Publish'|trans|ucfirst, 'btn-primary', { "id":"editButton", "type":"submit", "name":"edit" } ) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type
<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues
<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description
<!-- Describe what your pull request will fix / add / … -->
Fixes the color of the Publish button, for consistency reasons with other modules

![image](https://user-images.githubusercontent.com/1352979/65094791-afebf180-d9be-11e9-8be9-22bdb59572bb.png)


Should be blue (`btn-primary`)
