### PR TITLE
Media Helper JS triggered twice

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -161,9 +161,6 @@ jsBackend.mediaLibraryHelper.group = {
       $addMediaDialog.modal('hide')
     })
 
-    // on show
-    $addMediaDialog.on('show.bs.modal', jsBackend.mediaLibraryHelper.upload.init)
-
     // bind click when opening "add media dialog"
     $('.addMediaButton').on('click', function (e) {
       // prevent default


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When opening the model the fineuploader gets triggered once again, but it's already been trigger the moment the page was loaded. This causes two dropzone's and when dragging in images it uploads each image twice or more depending on how many times you trigger the modal.

