### PR TITLE
Bugfix: Add single Github PR template back

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Type
+
+<!-- Remove the types that don't apply -->
+<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
+
+- Critical bugfix
+- Non critical bugfix
+- Enhancement
+- Feature
+
+## Resolves the following issues
+
+<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
+<!-- Use the following format: fixes #[issue_number] -->
+
+## Pull request description
+
+<!-- Provide a summary of the pull request you are submitting. -->


### PR DESCRIPTION
Bugfix for PR #2905

Apparently, the menu to display a selection of Github PR templates does not work. It seems to be an issue others have as well. 
See: https://github.community/t5/How-to-use-Git-and-GitHub/Multiple-Pull-Request-Templates/td-p/20909

![image](https://user-images.githubusercontent.com/1352979/65583520-aa267b00-df7f-11e9-8010-0127d2ff960b.png)


I'm adding back a single PR template like before. I left the PR templates folder in there, maybe it will work again someday?