### PR TITLE
Beter exception handeling in frontend ajax calls

### DIFF
--- a/src/Frontend/Core/Engine/Ajax.php
+++ b/src/Frontend/Core/Engine/Ajax.php
@@ -7,6 +7,8 @@ use ForkCMS\App\KernelLoader;
 use Frontend\Core\Engine\Base\AjaxAction as FrontendBaseAJAXAction;
 use Frontend\Core\Language\Language;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * FrontendAJAX
@@ -84,6 +86,14 @@ class Ajax extends KernelLoader implements ApplicationInterface
 
             $this->ajaxAction = new AjaxAction($this->getKernel(), $this->getAction(), $this->getModule());
             $this->response = $this->ajaxAction->getContent();
+        } catch (BadRequestHttpException | AccessDeniedHttpException $httpException) {
+            $this->ajaxAction = new FrontendBaseAJAXAction($this->getKernel(), '', '');
+            $this->ajaxAction->output(
+                $httpException->getStatusCode(),
+                null,
+                $httpException->getMessage()
+            );
+            $this->response = $this->ajaxAction->getContent();
         } catch (\Exception $exception) {
             $this->ajaxAction = new FrontendBaseAJAXAction($this->getKernel(), '', '');
             $this->ajaxAction->output(
@@ -103,7 +113,7 @@ class Ajax extends KernelLoader implements ApplicationInterface
     public function getModule(): string
     {
         if ($this->module === null) {
-            throw new Exception('Module has not yet been set.');
+            throw new BadRequestHttpException('Module has not yet been set.');
         }
 
         return $this->module;
@@ -113,7 +123,7 @@ class Ajax extends KernelLoader implements ApplicationInterface
     {
         $ajaxActionClass = 'Frontend\\Modules\\' . $this->getModule() . '\\Ajax\\' . $action;
         if (!class_exists($ajaxActionClass)) {
-            throw new Exception('Action class ' . $ajaxActionClass . ' does not exist');
+            throw new BadRequestHttpException('Action class ' . $ajaxActionClass . ' does not exist');
         }
 
         $this->action = $action;
@@ -149,7 +159,7 @@ class Ajax extends KernelLoader implements ApplicationInterface
     public function setModule(string $module): void
     {
         if (!in_array($module, Model::getModules())) {
-            throw new Exception('Module not correct');
+            throw new AccessDeniedHttpException('Module not allowed');
         }
 
         $this->module = $module;

--- a/src/Frontend/Core/Tests/Engine/AjaxTest.php
+++ b/src/Frontend/Core/Tests/Engine/AjaxTest.php
@@ -3,6 +3,7 @@
 namespace Frontend\Core\Tests\Engine;
 
 use Common\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
 class AjaxTest extends WebTestCase
 {
@@ -12,11 +13,11 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax');
         self::assertEquals(
-            500,
+            Response::HTTP_FORBIDDEN,
             $client->getResponse()->getStatusCode()
         );
         self::assertContains(
-            'Module not correct',
+            'Module not allowed',
             $client->getResponse()->getContent()
         );
     }
@@ -27,11 +28,11 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax?action=Test');
         self::assertEquals(
-            500,
+            Response::HTTP_FORBIDDEN,
             $client->getResponse()->getStatusCode()
         );
         self::assertContains(
-            'Module not correct',
+            'Module not allowed',
             $client->getResponse()->getContent()
         );
     }
@@ -42,11 +43,11 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax?module=Test');
         self::assertEquals(
-            500,
+            Response::HTTP_FORBIDDEN,
             $client->getResponse()->getStatusCode()
         );
         self::assertContains(
-            'Module not correct',
+            'Module not allowed',
             $client->getResponse()->getContent()
         );
     }
@@ -57,7 +58,7 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax?module=Blog');
         self::assertEquals(
-            500,
+            Response::HTTP_BAD_REQUEST,
             $client->getResponse()->getStatusCode()
         );
         self::assertContains(
@@ -72,7 +73,7 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax?module=Blog&action=Test');
         self::assertEquals(
-            500,
+            Response::HTTP_BAD_REQUEST,
             $client->getResponse()->getStatusCode()
         );
         self::assertContains(


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
A 500 was returned instead of a more appropriate 4XX