### PR TITLE
Fix English translation for template image checkbox

### DIFF
--- a/src/Backend/Modules/Extensions/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Extensions/Installer/Data/locale.xml
@@ -69,7 +69,7 @@
       </item>
       <item type="message" name="ShowImageForm">
         <translation language="nl"><![CDATA[De gebruiker mag een afbeelding toevoegen.]]></translation>
-        <translation language="en"><![CDATA[The user can upload a file.]]></translation>
+        <translation language="en"><![CDATA[Allow the user to upload an image.]]></translation>
         <translation language="ru"><![CDATA[Пользователь может загрузить файл.]]></translation>
         <translation language="de"><![CDATA[Der Benutzer kann eine Datei hochladen.]]></translation>
         <translation language="es"><![CDATA[El usuario puede subir un archivo.]]></translation>


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description

Was testing an issue when I came across a wrong translation from Dutch to English
