### PR TITLE
Reset login attempts on unblock

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/Block.php
+++ b/src/Backend/Modules/Profiles/Actions/Block.php
@@ -29,6 +29,9 @@ class Block extends BackendBaseActionDelete
                 // set profile status to active
                 BackendProfilesModel::update($this->id, ['status' => 'active']);
 
+                // reset login attempts, because profile gets blocked when it has 10 or more login attempts
+                BackendProfilesModel::setSetting($this->id, 'login_attempts', 0);
+
                 // redirect
                 $this->redirect(
                     BackendModel::createUrlForAction('Index') . '&report=profile-unblocked&var=' . rawurlencode(


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When a profile gets blocked because of too many login attempts, there is no way of resetting the login attempts in the settings. This fixes the issue by resetting the login attempts when unblocking a profile.
