### PR TITLE
Require ext-json in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
         "behat/transliterator": "~1.0",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description

When implementing the JsonSerializable interface PhpStorm was giving warnings that ext-json wasn't required in composer.json