### PR TITLE
Fix wrong tab content shown when first tab is disabled in media library

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -727,7 +727,7 @@ jsBackend.mediaLibraryHelper.group = {
     if (disabled !== '') {
       $tabs.children(disabled).addClass('disabled').children('a').removeAttr('data-toggle')
     }
-    $tabs.children(enabled).addClass('active').children('a').attr('data-toggle', 'tab')
+    $tabs.children(enabled).children('a').attr('data-toggle', 'tab').first().tab('show')
 
     // get table
     var $tables = $('.mediaTable')


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix


## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

In some cases the wrong tab content was shown when the first tab was disabled in the media library

initial
<img width="829" alt="Screenshot 2019-10-09 at 17 27 50" src="https://user-images.githubusercontent.com/3634654/66496502-52c5f600-eabb-11e9-8054-6bab245a5c2c.png">

after fix
<img width="814" alt="Screenshot 2019-10-09 at 17 24 06" src="https://user-images.githubusercontent.com/3634654/66496501-52c5f600-eabb-11e9-9033-267c8e8d9588.png">
