### PR TITLE
Fix env variables loading in test mode

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -32,8 +32,8 @@ if ('prod' !== $_SERVER['FORK_ENV']) {
     }
 }
 
-$_SERVER['FORK_ENV'] = $_ENV['FORK_ENV'] = $_SERVER['FORK_ENV'] ?: $_ENV['FORK_ENV'] ?: 'dev';
+$_SERVER['FORK_ENV'] = $_ENV['FORK_ENV'] = $_SERVER['APP_ENV'] = $_SERVER['FORK_ENV'] ?: $_ENV['FORK_ENV'] ?: 'dev';
 $_SERVER['FORK_DEBUG'] = $_SERVER['FORK_DEBUG'] ?? $_ENV['FORK_DEBUG'] ?? 'prod' !== $_SERVER['FORK_ENV'];
-$_SERVER['FORK_DEBUG'] = $_ENV['FORK_DEBUG'] = (int) $_SERVER['FORK_DEBUG'] || filter_var($_SERVER['FORK_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['FORK_DEBUG'] = $_ENV['FORK_DEBUG'] = $_SERVER['APP_DEBUG'] = (int) $_SERVER['FORK_DEBUG'] || filter_var($_SERVER['FORK_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 
 return $loader;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -86,5 +86,6 @@
     </filter>
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="FORK_ENV" value="test" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -87,5 +87,6 @@
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
         <env name="FORK_ENV" value="test" />
+        <env name="FORK_DEBUG" value="1" />
     </php>
 </phpunit>

--- a/src/Frontend/Core/Tests/Engine/AjaxTest.php
+++ b/src/Frontend/Core/Tests/Engine/AjaxTest.php
@@ -12,8 +12,6 @@ class AjaxTest extends WebTestCase
 
         $client->request('GET', '/frontend/ajax');
 
-        var_dump((string) $client->getResponse()->getContent());
-
         self::assertEquals(
             500,
             $client->getResponse()->getStatusCode()

--- a/src/Frontend/Core/Tests/Engine/AjaxTest.php
+++ b/src/Frontend/Core/Tests/Engine/AjaxTest.php
@@ -11,6 +11,9 @@ class AjaxTest extends WebTestCase
         $client = static::createClient();
 
         $client->request('GET', '/frontend/ajax');
+
+        var_dump((string) $client->getResponse()->getContent());
+
         self::assertEquals(
             500,
             $client->getResponse()->getStatusCode()


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

This PR sets the values of `FORK_ENV` and `FORK_DEBUG` in the PHPUnit configuration.
The values of `$_SERVER['APP_ENV]` and `$_SERVER['APP_DEBUG]` are also set to the same value as `$_SERVER['FORK_ENV]` and `$_SERVER['FORK_DEBUG]` respectively. The Symfony kernel makes some initialisation decisions based on these variables.
