### PR TITLE
Add missing translation

### DIFF
--- a/src/Backend/Modules/Extensions/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Extensions/Installer/Data/locale.xml
@@ -891,6 +891,11 @@
         <translation language="el"><![CDATA[Το όνομα φακέλου του θέματος δεν ταιριάζει με το όνομα του θέματος στο αρχείο info.xml.]]></translation>
         <translation language="pl"><![CDATA[Nazwa folderu motywu nie jest zgodna z nazwą motywu w pliku info.xml.]]></translation>
       </item>
+      <item type="label" name="DetailModule">
+        <translation language="nl"><![CDATA[Module details]]></translation>
+        <translation language="en"><![CDATA[Module details]]></translation>
+        <translation language="fr"><![CDATA[Détails du module]]></translation>
+      </item>
     </Extensions>
   </Backend>
 </locale>


### PR DESCRIPTION
## Type

- Enhancement

## Pull request description

This PR adds a missing translation in the breadcrumb of the module detail screen.

![image](https://user-images.githubusercontent.com/848112/66580534-d85eaa00-eb7e-11e9-964d-058abf8c267e.png)

