### PR TITLE
Make adding a timestamp in the php work

### DIFF
--- a/src/Frontend/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Head.html.twig
@@ -20,7 +20,7 @@
 
   {# Stylesheets #}
   {% for cssFiles in cssFiles %}
-    <link rel="stylesheet" href="{{ cssFiles.file }}" />
+    <link rel="stylesheet" href="{{ cssFiles }}" />
   {% endfor %}
 
   {# Site wide HTML #}

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Base.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Base.html.twig
@@ -74,7 +74,7 @@
 
 {# General Javascript #}
 {% for js in jsFiles %}
-  <script src="{{ js.file }}"></script>
+  <script src="{{ js }}"></script>
 {% endfor %}
 <script src="/js/vendors/bootstrap.min.js"></script>
 <script src="/js/vendors/bootstrap-accessibility.min.js"></script>


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues

If the addTimestamp option was set true with the addJS function i wasn't working because of the way we rendered the script tags in the template