### PR TITLE
Fix session timeout popup

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -2068,7 +2068,7 @@ jsBackend.session = {
   sessionTimeoutPopup: function () {
     setInterval(function () {
       window.alert(jsBackend.locale.msg('SessionTimeoutWarning'))
-    }, (jsBackend.Core.session_timeout - 60) * 1000)
+    }, (jsData.Core.session_timeout - 60) * 1000)
   }
 }
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
In https://github.com/forkcms/forkcms/pull/2858 the session timeout popup was added, but the `session_timout` variable is saved in the jsData (see https://github.com/forkcms/forkcms/pull/2858/files#diff-4fb0e3a8ed70071edbb74cdf222a7af6R224) not in `jsBackend`.