### PR TITLE
Allow Core actions for frontend ajax calls

### DIFF
--- a/src/Frontend/Core/Engine/Ajax.php
+++ b/src/Frontend/Core/Engine/Ajax.php
@@ -122,6 +122,10 @@ class Ajax extends KernelLoader implements ApplicationInterface
     public function setAction(string $action): void
     {
         $ajaxActionClass = 'Frontend\\Modules\\' . $this->getModule() . '\\Ajax\\' . $action;
+        if ($this->getModule() === 'Core') {
+            $ajaxActionClass = 'Frontend\\Core\\Ajax\\' . $action;
+        }
+
         if (!class_exists($ajaxActionClass)) {
             throw new BadRequestHttpException('Action class ' . $ajaxActionClass . ' does not exist');
         }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When adding frontend ajax calls, the AjaxAction allows for Core ajax actions (see https://github.com/forkcms/forkcms/blob/master/src/Frontend/Core/Engine/AjaxAction.php#L32), but the frontend ajax handler doesn't allow it, this fixes the problem.
