### PR TITLE
Bugfix broken alert on Add Page

### DIFF
--- a/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/Pages/Layout/Templates/Add.html.twig
@@ -90,28 +90,34 @@
 
               <div id="templateVisualFallback" style="display: none">
                 <div id="fallback" class="generalMessage singleMessage infoMessage">
-                  <div id="fallbackInfo">
-                    {{ 'msg.FallbackInfo'|trans }}
-                  </div>
-                  <table cellspacing="2">
-                    <tbody>
-                      <tr>
-                        <td data-position="fallback" id="templatePosition-fallback"
-                          colspan="1" class="box">
-                          <div class="panel panel-default panel-pages-block">
-                            <div class="panel-heading">
-                              <h2 class="panel-title">{{ 'lbl.Fallback'|trans|ucfirst }}</h2>
-                            </div>
-                            <div class="panel-body">
-                              <div class="linkedBlocks">
-                                <!-- linked blocks will be added here -->
+                  <div class="row">
+                    <div class="col-md-6">
+                      <div id="fallbackInfo">
+                        <div class="alert alert-warning">
+                          {{ macro.icon('exclamation-triangle') }}{{ 'msg.FallbackInfo'|trans|raw }}
+                        </div>
+                      </div>
+                    </div>
+                    <div class="col-md-6">
+                      <table cellspacing="2">
+                        <tbody>
+                        <tr>
+                          <td data-position="fallback" id="templatePosition-fallback"
+                              colspan="1" class="box">
+                            <div class="panel panel-default panel-pages-block">
+                              <div class="panel-heading">
+                                <h2 class="panel-title">{{ 'lbl.Fallback'|trans|ucfirst }}</h2>
+                              </div>
+                              <div class="panel-body">
+                                <div class="linkedBlocks"><!-- linked blocks will be added here --></div>
                               </div>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                          </td>
+                        </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div id="templateVisualLarge">


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
On the Add Page layout, if you add a block and change the template, you get a raw html error. 

The template position fallback message did not have `|raw` and lacked the proper layout so I copied the piece of code from `Edit.html.twig` for consistency...

### Before:

![image](https://user-images.githubusercontent.com/1352979/67162788-ede68780-f367-11e9-9cf3-91ad536155ee.png)


### After:

![image](https://user-images.githubusercontent.com/1352979/67162793-f50d9580-f367-11e9-8b22-89403d425ac0.png)

