### PR TITLE
Formbuilder confirmation mail message

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Edit.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Edit.php
@@ -95,6 +95,7 @@ class Edit extends BackendBaseActionEdit
         );
         $this->form->addCheckbox('textbox_send_confirmation_mail_to');
         $this->form->addText('textbox_confirmation_mail_subject');
+        $this->form->addEditor('textbox_confirmation_mail_message');
         $this->form->addText('textbox_validation_parameter');
         $this->form->addText('textbox_error_message');
 

--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -66,6 +66,7 @@ class SaveField extends BackendBaseAJAXAction
         $useToSubscribeWithMailmotor = $this->getRequest()->request->getBoolean('use_to_subscribe_with_mailmotor');
         $sendConfirmationMailTo = $this->getRequest()->request->getBoolean('send_confirmation_mail_to');
         $confirmationMailSubject = trim($this->getRequest()->request->get('confirmation_mail_subject'));
+        $confirmationMailMessage = trim($this->getRequest()->request->get('confirmation_mail_message'));
 
         // special fields for datetime
         $inputType = $this->getRequest()->request->get('input_type');
@@ -125,10 +126,17 @@ class SaveField extends BackendBaseAJAXAction
                     'ActivateEmailValidationToUseThisOption'
                 );
             }
-            if ($sendConfirmationMailTo && empty($confirmationMailSubject)) {
-                $errors['confirmation_mail_subject_error_message'] = BL::getError(
-                    'ConfirmationSubjectIsEmpty'
-                );
+            if ($sendConfirmationMailTo) {
+                if (empty($confirmationMailSubject)) {
+                    $errors['confirmation_mail_subject_error_message'] = BL::getError(
+                        'ConfirmationSubjectIsEmpty'
+                    );
+                }
+                if (empty($confirmationMailMessage)) {
+                    $errors['confirmation_mail_message_error_message'] = BL::getError(
+                        'ConfirmationMessageIsEmpty'
+                    );
+                }
             }
         } elseif ($type === 'textarea') {
             // validate textarea
@@ -276,6 +284,7 @@ class SaveField extends BackendBaseAJAXAction
             $settings['reply_to'] = $replyTo;
             $settings['send_confirmation_mail_to'] = $sendConfirmationMailTo;
             $settings['confirmation_mail_subject'] = $confirmationMailSubject;
+            $settings['confirmation_mail_message'] = $confirmationMailMessage;
             $settings['use_to_subscribe_with_mailmotor'] = $useToSubscribeWithMailmotor;
         }
 

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -1215,10 +1215,22 @@
         <translation language="en"><![CDATA[email subject]]></translation>
         <translation language="pl"><![CDATA[temat wiadomości]]></translation>
       </item>
+      <item type="label" name="ConfirmationMailMessage">
+        <translation language="nl"><![CDATA[bericht bevestigingsmail]]></translation>
+        <translation language="en"><![CDATA[message confirmation mail]]></translation>
+      </item>
       <item type="label" name="ConfirmationMailSubject">
         <translation language="nl"><![CDATA[onderwerp bevestigingsmail]]></translation>
         <translation language="en"><![CDATA[subject confirmation mail]]></translation>
         <translation language="pl"><![CDATA[temat emaila z potwierdzeniem]]></translation>
+      </item>
+      <item type="error" name="ConfirmationMessageIsEmpty">
+        <translation language="nl"><![CDATA[Gelieve een bericht in te geven]]></translation>
+        <translation language="en"><![CDATA[Please fill in a message]]></translation>
+      </item>
+      <item type="error" name="ConfirmationSubjectIsEmpty">
+        <translation language="nl"><![CDATA[Gelieve een onderwerp in te geven]]></translation>
+        <translation language="en"><![CDATA[Please fill in a subject]]></translation>
       </item>
       <item type="label" name="Autocomplete">
         <translation language="nl"><![CDATA[Autocomplete waarde]]></translation>

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -437,6 +437,7 @@ jsBackend.FormBuilder.Fields = {
                   $('#textboxSendConfirmationMailTo').prop('checked', true)
                 }
                 $('#textboxConfirmationMailSubject').val(utils.string.htmlDecode(data.data.field.settings.confirmation_mail_subject))
+                $('#textboxConfirmationMailMessage').val(data.data.field.settings.confirmation_mail_message)
                 $.each(
                   data.data.field.validations,
                   function (k, v) {
@@ -1417,6 +1418,7 @@ jsBackend.FormBuilder.Fields = {
     var replyTo = $('#textboxReplyTo').is(':checked')
     var sendConfirmationMailTo = $('#textboxSendConfirmationMailTo').is(':checked')
     var confirmationMailSubject = $('#textboxConfirmationMailSubject').val()
+    var confirmationMailMessage = $('#textboxConfirmationMailMessage').val()
     var required = $('#textboxRequired').is(':checked')
     var requiredErrorMessage = $('#textboxRequiredErrorMessage').val()
     var validation = $('#textboxValidation').val()
@@ -1438,6 +1440,7 @@ jsBackend.FormBuilder.Fields = {
         use_to_subscribe_with_mailmotor: mailmotor,
         send_confirmation_mail_to: sendConfirmationMailTo,
         confirmation_mail_subject: confirmationMailSubject,
+        confirmation_mail_message: confirmationMailMessage,
         required: required,
         required_error_message: requiredErrorMessage,
         validation: validation,
@@ -1479,6 +1482,9 @@ jsBackend.FormBuilder.Fields = {
             }
             if (typeof data.data.errors.confirmation_mail_subject_error_message !== 'undefined') {
               $('#textboxConfirmationMailSubjectErrorMessageError').html(data.data.errors.confirmation_mail_subject_error_message)
+            }
+            if (typeof data.data.errors.confirmation_mail_message_error_message !== 'undefined') {
+              $('#textboxConfirmationMailMessageErrorMessageError').html(data.data.errors.confirmation_mail_message_error_message)
             }
 
             // toggle error messages

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
@@ -315,6 +315,13 @@
                     {% form_field textbox_confirmation_mail_subject %}
                     <p id="textboxConfirmationMailSubjectErrorMessageError" class="text-danger jsFieldError" style="display: none;"></p>
                   </div>
+                  <div class="form-group">
+                    <label for="textboxConfirmationMailMessage" class="control-label">
+                      {{ 'lbl.ConfirmationMailMessage'|trans|ucfirst }}
+                    </label>
+                    {% form_field textbox_confirmation_mail_message %}
+                    <p id="textboxConfirmationMailMessageErrorMessageError" class="text-danger jsFieldError" style="display: none;"></p>
+                  </div>
                   <div class="jsValidation">
                     <ul class="list-unstyled">
                       <li class="checkbox">


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
There was already a field for the subject of the formbuilder confirmation mail (to the visitor). Perhaps it is useful to also make the message customizable.

![Schermafbeelding 2019-10-25 om 21 19 00](https://user-images.githubusercontent.com/4540274/67598332-92543980-f76d-11e9-99ac-bf167f3aacd3.png)