### PR TITLE
Bugfix: Make medialibrary modal scrollable

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Layout/Css/MediaLibrary.css
+++ b/src/Backend/Modules/MediaLibrary/Layout/Css/MediaLibrary.css
@@ -180,6 +180,11 @@
 /**
  * Media Dialog
  */
+#addMediaDialog .modal-dialog,
+#cropperMediaDialog .modal-dialog {
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+}
 #addMediaDialog .modal-body,
 #cropperMediaDialog .modal-body {
   padding: 0;


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
When you create a media gallery and upload a bunch of files, the modal becomes bigger than the screen and does not allow for scrolling towards the Save button.

### Before
![before](https://user-images.githubusercontent.com/1352979/67624031-4caa7600-f82c-11e9-9792-a326c44fff25.gif)


### After
![after](https://user-images.githubusercontent.com/1352979/67624036-503dfd00-f82c-11e9-94db-80da3c870d7a.gif)
