### PR TITLE
Formbuilder multiple emails

### DIFF
--- a/src/Backend/Modules/FormBuilder/Actions/Add.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Add.php
@@ -36,17 +36,7 @@ class Add extends BackendBaseActionAdd
     {
         $this->form = new BackendForm('add');
         $this->form->addText('name')->makeRequired();
-        $this->form->addDropdown(
-            'method',
-            [
-                'database' => BL::getLabel('MethodDatabase'),
-                'database_email' => BL::getLabel('MethodDatabaseEmail'),
-                'email' => BL::getLabel('MethodEmail'),
-            ],
-            'database_email'
-        )->makeRequired();
-        $this->form->addText('email');
-        $this->form->addText('email_subject');
+        $this->form->addCheckbox('database');
         $this->form->addText('identifier', BackendFormBuilderModel::createIdentifier());
         $this->form->addEditor('success_message')->makeRequired();
 
@@ -63,35 +53,13 @@ class Add extends BackendBaseActionAdd
 
             // shorten the fields
             $txtName = $this->form->getField('name');
-            $txtEmail = $this->form->getField('email');
-            $txtEmailSubject = $this->form->getField('email_subject');
-            $ddmMethod = $this->form->getField('method');
+            $chkDatabase = $this->form->getField('database');
             $txtSuccessMessage = $this->form->getField('success_message');
             $txtIdentifier = $this->form->getField('identifier');
-
-            $emailAddresses = (array) explode(',', $txtEmail->getValue());
 
             // validate fields
             $txtName->isFilled(BL::getError('NameIsRequired'));
             $txtSuccessMessage->isFilled(BL::getError('SuccessMessageIsRequired'));
-            if ($ddmMethod->isFilled(BL::getError('NameIsRequired')) && $ddmMethod->getValue() == 'database_email') {
-                $error = false;
-
-                // check the addresses
-                foreach ($emailAddresses as $address) {
-                    $address = trim($address);
-
-                    if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
-                        $error = true;
-                        break;
-                    }
-                }
-
-                // add error
-                if ($error) {
-                    $txtEmail->addError(BL::getError('EmailIsInvalid'));
-                }
-            }
 
             // identifier
             if ($txtIdentifier->isFilled()) {
@@ -110,12 +78,7 @@ class Add extends BackendBaseActionAdd
                 $values['language'] = BL::getWorkingLanguage();
                 $values['user_id'] = BackendAuthentication::getUser()->getUserId();
                 $values['name'] = $txtName->getValue();
-                $values['method'] = $ddmMethod->getValue();
-                $values['email'] = ($ddmMethod->getValue() === 'database_email' || $ddmMethod->getValue() === 'email')
-                    ? serialize($emailAddresses) : null;
-                $values['email_subject'] = empty($txtEmailSubject->getValue()) ? null : $txtEmailSubject->getValue();
-                $values['email_template'] = count($this->templates) > 1
-                    ? $this->form->getField('template')->getValue() : $this->templates[0];
+                $values['database'] = (int) $chkDatabase->isChecked();
                 $values['success_message'] = $txtSuccessMessage->getValue(true);
                 $values['identifier'] = ($txtIdentifier->isFilled() ?
                     $txtIdentifier->getValue() :

--- a/src/Backend/Modules/FormBuilder/Actions/AddEmail.php
+++ b/src/Backend/Modules/FormBuilder/Actions/AddEmail.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Actions;
+
+use Backend\Core\Engine\Base\ActionAdd as BackendBaseActionAdd;
+use Backend\Core\Engine\Authentication as BackendAuthentication;
+use Backend\Core\Engine\Model as BackendModel;
+use Backend\Core\Engine\Form as BackendForm;
+use Backend\Core\Language\Language as BL;
+use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
+
+/**
+ * This is the add-action, it will display a form to create a new item.
+ */
+class AddEmail extends BackendBaseActionAdd
+{
+    /**
+     * The available templates
+     *
+     * @var array
+     */
+    private $templates = [];
+
+    public function execute(): void
+    {
+        $this->id = $this->getRequest()->query->getInt('id');
+
+        // does the item exist
+        if ($this->id !== 0 && BackendFormBuilderModel::exists($this->id)) {
+            parent::execute();
+            $this->getData();
+            $this->templates = BackendFormBuilderModel::getTemplates();
+            $this->loadForm();
+            $this->validateForm();
+            $this->parse();
+            $this->display();
+        } else {
+            // no item found, throw an exceptions, because somebody is fucking with our url
+            $this->redirect(BackendModel::createUrlForAction('Index') . '&error=non-existing');
+        }
+    }
+
+    private function getData(): void
+    {
+        $this->record = BackendFormBuilderModel::get($this->id);
+    }
+
+    private function loadForm(): void
+    {
+        // set hidden values
+        $rbtRecipientOptions = [
+            ['label' => BL::lbl('Email'), 'value' => 'email'],
+            ['label' => BL::lbl('ValueOfAField'), 'value' => 'field'],
+        ];
+
+        // set field values
+        $ddnFormFieldsOptions = BackendFormBuilderModel::getRecipientFieldsForDropdown($this->id);
+
+        $this->form = new BackendForm('add');
+        $mailerFrom = $this->get('fork.settings')->get('Core', 'mailer_from');
+        $this->form->addText('from_name', (isset($mailerFrom['name'])) ? $mailerFrom['name'] : '');
+        $this->form
+            ->addText('from_email', (isset($mailerFrom['email'])) ? $mailerFrom['email'] : '')
+            ->setAttribute('type', 'email')
+        ;
+        $this->form->addRadiobutton('recipient', $rbtRecipientOptions, 'email');
+        $this->form->addText('email_addresses');
+        $this->form->addDropdown('email_fields', $ddnFormFieldsOptions)->setDefaultElement('');
+        $this->form->addCheckbox('email_data', 0);
+        $this->form->addText('email_subject');
+        $this->form->addEditor('email_body');
+
+        // if we have multiple templates, add a dropdown to select them
+        if (count($this->templates) > 1) {
+            $this->form->addDropdown('template', array_combine($this->templates, $this->templates));
+        }
+    }
+
+    private function validateForm(): void
+    {
+        if ($this->form->isSubmitted()) {
+            $this->form->cleanupFields();
+
+            // shorten the fields
+            $chkEmailData = $this->form->getField('email_data');
+            $txtEmailSubject = $this->form->getField('email_subject');
+            $rbtRecipient = $this->form->getField('recipient');
+            $txtEmailToAddresses = $this->form->getField('email_addresses');
+            $ddnEmailToField = $this->form->getField('email_fields');
+            $txtFromName = $this->form->getField('from_name');
+            $txtFromEmail = $this->form->getField('from_email');
+            $txtEmailBody = $this->form->getField('email_body');
+
+            $emailAddresses = (array) explode(',', $txtEmailToAddresses->getValue());
+
+            // validate fields
+            $txtEmailSubject->isFilled(BL::err('FieldIsRequired'));
+            $rbtRecipient->isFilled(BL::err('FieldIsRequired'));
+            $txtFromName->isFilled(BL::err('FieldIsRequired'));
+            $txtFromEmail->isFilled(BL::err('FieldIsRequired'));
+            $txtEmailBody->isFilled(BL::err('FieldIsRequired'));
+
+            if ($rbtRecipient->getValue() == 'email') {
+                $txtEmailToAddresses->isFilled(BL::err('FieldIsRequireed'));
+
+                $error = false;
+
+                // check the addresses
+                foreach ($emailAddresses as $address) {
+                    $address = trim($address);
+
+                    if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
+                        $error = true;
+                        break;
+                    }
+                }
+
+                // add error
+                if ($error) {
+                    $txtEmailToAddresses->addError(BL::getError('EmailIsInvalid'));
+                }
+            }
+            if ($rbtRecipient->getValue() == 'field') {
+                $ddnEmailToField->isFilled(BL::err('FieldIsRequireed'));
+            }
+
+            // save
+            if ($this->form->isCorrect()) {
+                // build array
+                $values = [];
+                $values['language'] = BL::getWorkingLanguage();
+                $values['form_id'] = $this->id;
+                $values['email_data'] = (int) $chkEmailData->isChecked();
+                $values['email_subject'] = $txtEmailSubject->getValue();
+                $values['email_recipient'] = $rbtRecipient->getValue();
+                $values['email_to_field'] = $ddnEmailToField->getValue();
+                $values['email_to_addresses'] = serialize($emailAddresses);
+                $values['email_from'] = serialize(
+                    [
+                        'name' => $txtFromName->getValue(),
+                        'email' => $txtFromEmail->getValue(),
+                    ]
+                );
+                $values['email_body'] = $txtEmailBody->getValue();
+                $values['email_template'] = count($this->templates) > 1
+                    ? $this->form->getField('template')->getValue() : $this->templates[0];
+                $values['created_on'] = BackendModel::getUTCDate();
+                $values['edited_on'] = BackendModel::getUTCDate();
+
+                // insert the item
+                BackendFormBuilderModel::insertEmail($values);
+
+                // redirect
+                $this->redirect(
+                    BackendModel::createUrlForAction('Emails') . '&id=' . $this->id .
+                    '&report=added-email'
+                );
+            }
+        }
+    }
+
+    protected function parse(): void
+    {
+        parent::parse();
+
+        $this->template->assign('item', $this->record);
+
+        // add form name to the breadcrumb
+        $this->header->appendDetailToBreadcrumbs($this->record['name']);
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Actions/Data.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Data.php
@@ -106,10 +106,6 @@ class Data extends BackendBaseActionIndex
     private function getData(): void
     {
         $this->record = BackendFormBuilderModel::get($this->id);
-
-        if ($this->record['method'] === 'email') {
-            $this->redirect(BackendModel::createUrlForAction('Index') . '&error=non-existing');
-        }
     }
 
     private function loadDataGrid(): void

--- a/src/Backend/Modules/FormBuilder/Actions/DeleteEmail.php
+++ b/src/Backend/Modules/FormBuilder/Actions/DeleteEmail.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Actions;
+
+use Backend\Core\Engine\Base\ActionDelete as BackendBaseActionDelete;
+use Backend\Core\Engine\Model as BackendModel;
+use Backend\Form\Type\DeleteType;
+use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
+
+/**
+ * This action will delete a category
+ */
+class DeleteEmail extends BackendBaseActionDelete
+{
+    public function execute(): void
+    {
+        $deleteForm = $this->createForm(
+            DeleteType::class,
+            null,
+            ['module' => $this->getModule(), 'action' => 'DeleteEmail']
+        );
+        $deleteForm->handleRequest($this->getRequest());
+        if (!$deleteForm->isSubmitted() || !$deleteForm->isValid()) {
+            $this->redirect(BackendModel::createUrlForAction(
+                'Emails',
+                null,
+                null,
+                ['error' => 'something-went-wrong']
+            ));
+
+            return;
+        }
+        $deleteFormData = $deleteForm->getData();
+
+        $this->id = (int) $deleteFormData['id'];
+
+        // does the item exist
+        if ($this->id === 0 || !BackendFormBuilderModel::existsEmail($this->id)) {
+            $this->redirect(BackendModel::createUrlForAction('Emails', null, null, ['error' => 'non-existing']));
+
+            return;
+        }
+
+        $this->record = (array) BackendFormBuilderModel::getEmail($this->id);
+
+        parent::execute();
+
+        BackendFormBuilderModel::deleteEmail($this->id);
+
+        $this->redirect(BackendModel::createUrlForAction(
+            'Emails',
+            null,
+            null,
+            ['report' => 'deleted-email', 'id' => $this->record['form_id']]
+        ));
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Actions/EditEmail.php
+++ b/src/Backend/Modules/FormBuilder/Actions/EditEmail.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Actions;
+
+use Backend\Core\Engine\Base\ActionEdit as BackendBaseActionEdit;
+use Backend\Core\Engine\Model as BackendModel;
+use Backend\Core\Engine\Form as BackendForm;
+use Backend\Core\Language\Language as BL;
+use Backend\Form\Type\DeleteType;
+use Backend\Modules\FormBuilder\Engine\Autocomplete;
+use Frontend\Core\Language\Language as FL;
+use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
+use Backend\Modules\FormBuilder\Engine\Helper as FormBuilderHelper;
+
+/**
+ * This is the edit-action, it will display a form to edit an existing item
+ */
+class EditEmail extends BackendBaseActionEdit
+{
+    /**
+     * The available templates
+     *
+     * @var array
+     */
+    private $templates = [];
+
+    public function execute(): void
+    {
+        $this->id = $this->getRequest()->query->getInt('id');
+        $this->formId = $this->getRequest()->query->getInt('formId');
+
+        // does the item exist
+        if ($this->formId !== 0 && $this->id !== 0 && BackendFormBuilderModel::exists($this->formId) && BackendFormBuilderModel::existsEmail($this->id)) {
+            parent::execute();
+            $this->getData();
+            $this->loadForm();
+            $this->validateForm();
+            $this->loadDeleteForm();
+            $this->parse();
+            $this->display();
+        } else {
+            // no item found, throw an exceptions, because somebody is fucking with our url
+            $this->redirect(BackendModel::createUrlForAction('Emails') . '&error=non-existing&id=' . $this->formId);
+        }
+    }
+
+    private function getData(): void
+    {
+        $this->record = BackendFormBuilderModel::get($this->formId);
+        $this->email = BackendFormBuilderModel::getEmail($this->id);
+        $this->templates = BackendFormBuilderModel::getTemplates();
+    }
+
+    private function loadForm(): void
+    {
+        // set hidden values
+        $rbtRecipientOptions = [
+            ['label' => BL::lbl('Email'), 'value' => 'email'],
+            ['label' => BL::lbl('ValueOfAField'), 'value' => 'field'],
+        ];
+
+        // set field values
+        $ddnFormFieldsOptions = BackendFormBuilderModel::getRecipientFieldsForDropdown($this->record['id']);
+
+        $this->form = new BackendForm('edit');
+        $this->form->addText('from_name', $this->email['email_from']['name']);
+        $this->form
+            ->addText('from_email', $this->email['email_from']['email'])
+            ->setAttribute('type', 'email')
+        ;
+        $this->form->addRadiobutton('recipient', $rbtRecipientOptions, $this->email['email_recipient']);
+        $this->form->addText('email_addresses', implode(',', (array) $this->email['email_to_addresses']));
+        $this->form->addDropdown('email_fields', $ddnFormFieldsOptions, $this->email['email_to_field'])->setDefaultElement('');
+        $this->form->addCheckbox('email_data', $this->email['email_data']);
+        $this->form->addText('email_subject', $this->email['email_subject']);
+        $this->form->addEditor('email_body', $this->email['email_body']);
+
+        // if we have multiple templates, add a dropdown to select them
+        if (count($this->templates) > 1) {
+            $this->form->addDropdown('template', array_combine($this->templates, $this->templates), $this->email['email_template']);
+        }
+    }
+
+    protected function parse(): void
+    {
+        parent::parse();
+
+        $this->template->assign('item', $this->record);
+
+        // add form name to the breadcrumb
+        $this->header->appendDetailToBreadcrumbs($this->record['name']);
+    }
+
+    private function validateForm(): void
+    {
+        if ($this->form->isSubmitted()) {
+            $this->form->cleanupFields();
+
+            // shorten the fields
+            $chkEmailData = $this->form->getField('email_data');
+            $txtEmailSubject = $this->form->getField('email_subject');
+            $rbtRecipient = $this->form->getField('recipient');
+            $txtEmailToAddresses = $this->form->getField('email_addresses');
+            $ddnEmailToField = $this->form->getField('email_fields');
+            $txtFromName = $this->form->getField('from_name');
+            $txtFromEmail = $this->form->getField('from_email');
+            $txtEmailBody = $this->form->getField('email_body');
+
+            $emailAddresses = (array) explode(',', $txtEmailToAddresses->getValue());
+
+            // validate fields
+            $txtEmailSubject->isFilled(BL::err('FieldIsRequired'));
+            $rbtRecipient->isFilled(BL::err('FieldIsRequired'));
+            $txtFromName->isFilled(BL::err('FieldIsRequired'));
+            $txtFromEmail->isFilled(BL::err('FieldIsRequired'));
+            $txtEmailBody->isFilled(BL::err('FieldIsRequired'));
+
+            if ($rbtRecipient->getValue() == 'email') {
+                $txtEmailToAddresses->isFilled(BL::err('FieldIsRequired'));
+
+                $error = false;
+
+                // check the addresses
+                foreach ($emailAddresses as $address) {
+                    $address = trim($address);
+
+                    if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
+                        $error = true;
+                        break;
+                    }
+                }
+
+                // add error
+                if ($error) {
+                    $txtEmailToAddresses->addError(BL::getError('EmailIsInvalid'));
+                }
+            }
+            if ($rbtRecipient->getValue() == 'field') {
+                $ddnEmailToField->isFilled(BL::err('FieldIsRequired'));
+            }
+
+            if ($this->form->isCorrect()) {
+                // build array
+                $values = [];
+                $values['id'] = $this->id;
+                $values['email_data'] = (int) $chkEmailData->isChecked();
+                $values['email_subject'] = $txtEmailSubject->getValue();
+                $values['email_recipient'] = $rbtRecipient->getValue();
+                $values['email_to_field'] = ($rbtRecipient->getValue() == 'field') ? $ddnEmailToField->getValue() : 0;
+                $values['email_to_addresses'] = ($rbtRecipient->getValue() == 'email') ? serialize($emailAddresses) : null;
+                $values['email_from'] = serialize(
+                    [
+                        'name' => $txtFromName->getValue(),
+                        'email' => $txtFromEmail->getValue(),
+                    ]
+                );
+                $values['email_body'] = $txtEmailBody->getValue();
+                $values['email_template'] = count($this->templates) > 1
+                    ? $this->form->getField('template')->getValue() : $this->templates[0];
+                $values['edited_on'] = BackendModel::getUTCDate();
+
+                // insert the item
+                BackendFormBuilderModel::updateEmail($values);
+
+                // redirect
+                $this->redirect(
+                    BackendModel::createUrlForAction('Emails') . '&id=' . $this->formId .
+                    '&report=edited-email'
+                );
+            }
+        }
+    }
+
+    private function loadDeleteForm(): void
+    {
+        $deleteForm = $this->createForm(
+            DeleteType::class,
+            ['id' => $this->id],
+            ['module' => $this->getModule(), 'action' => 'DeleteEmail']
+        );
+        $this->template->assign('deleteForm', $deleteForm->createView());
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Actions/Emails.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Emails.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Actions;
+
+use Backend\Core\Engine\Base\ActionIndex as BackendBaseActionIndex;
+use Backend\Core\Engine\Authentication as BackendAuthentication;
+use Backend\Core\Engine\Model as BackendModel;
+use Backend\Core\Language\Language as BL;
+use Backend\Core\Engine\DataGridDatabase as BackendDataGridDatabase;
+use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
+
+/**
+ * This is the index-action (default), it will display the overview
+ */
+class Emails extends BackendBaseActionIndex
+{
+    public function execute(): void
+    {
+        $this->id = $this->getRequest()->query->getInt('id');
+
+        // does the item exist
+        if ($this->id !== 0 && BackendFormBuilderModel::exists($this->id)) {
+            parent::execute();
+            $this->getData();
+            $this->loadDataGrid();
+            $this->parse();
+            $this->display();
+        } else {
+            // no item found, throw an exceptions, because somebody is fucking with our url
+            $this->redirect(BackendModel::createUrlForAction('Index') . '&error=non-existing');
+        }
+    }
+
+    private function getData(): void
+    {
+        $this->record = BackendFormBuilderModel::get($this->id);
+    }
+
+    private function loadDataGrid(): void
+    {
+        $this->dataGrid = new BackendDataGridDatabase(
+            BackendFormBuilderModel::QUERY_BROWSE_EMAILS,
+            [BL::getWorkingLanguage(), $this->id]
+        );
+        $this->dataGrid->setHeaderLabels([
+            'email_to_addresses' => \SpoonFilter::ucfirst(BL::getLabel('Recipient'))
+        ]);
+        $this->dataGrid->setColumnFunction(
+            [new BackendFormBuilderModel(), 'formatRecipients'],
+            ['[email_to_addresses]'],
+            'email_to_addresses'
+        );
+
+        // check if edit action is allowed
+        if (BackendAuthentication::isAllowedAction('EditEmail')) {
+            $this->dataGrid->setColumnURL(
+                'email_subject',
+                BackendModel::createUrlForAction('EditEmail') . '&amp;id=[id]&amp;formId=' . $this->record['id']
+            );
+            $this->dataGrid->addColumn(
+                'edit',
+                null,
+                BL::getLabel('Edit'),
+                BackendModel::createUrlForAction('EditEmail') . '&amp;id=[id]&amp;formId=' . $this->record['id'],
+                BL::getLabel('Edit')
+            );
+        }
+    }
+
+    protected function parse(): void
+    {
+        parent::parse();
+
+        $this->template->assign('item', $this->record);
+
+        // add datagrid
+        $this->template->assign('dataGrid', (string) $this->dataGrid->getContent());
+
+        // add form name to the breadcrumb
+        $this->header->appendDetailToBreadcrumbs($this->record['name']);
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Actions/Index.php
+++ b/src/Backend/Modules/FormBuilder/Actions/Index.php
@@ -28,11 +28,18 @@ class Index extends BackendBaseActionIndex
             BackendFormBuilderModel::QUERY_BROWSE,
             [BL::getWorkingLanguage()]
         );
+        $this->dataGrid->addColumn(
+            'emails',
+            null,
+            ucfirst(BL::lbl('Emails')),
+            BackendModel::createUrlForAction('Emails') .
+            '&amp;id=[id]',
+            BL::lbl('Emails')
+        );
         $this->dataGrid->setHeaderLabels([
-            'email' => \SpoonFilter::ucfirst(BL::getLabel('Recipient')),
             'sent_forms' => '',
         ]);
-        $this->dataGrid->setSortingColumns(['name', 'email', 'method', 'sent_forms'], 'name');
+        $this->dataGrid->setSortingColumns(['name', 'sent_forms'], 'name');
         $this->dataGrid->setColumnFunction(
             [new BackendFormBuilderModel(), 'formatRecipients'],
             ['[email]'],

--- a/src/Backend/Modules/FormBuilder/Installer/Data/install.sql
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/install.sql
@@ -3,12 +3,9 @@ CREATE TABLE IF NOT EXISTS `forms` (
   `language` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int(11) unsigned NOT NULL,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `method` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'database_email',
-  `email` text COLLATE utf8mb4_unicode_ci,
+  `database` tinyint(1) NOT NULL DEFAULT '0',
   `success_message` text COLLATE utf8mb4_unicode_ci,
   `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `email_template` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'Form.html.twig',
-  `email_subject` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_on` datetime NOT NULL,
   `edited_on` datetime NOT NULL,
   PRIMARY KEY (`id`)
@@ -32,6 +29,23 @@ CREATE TABLE IF NOT EXISTS `forms_data_fields` (
   PRIMARY KEY (`id`),
   KEY `data_id` (`data_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `forms_emails` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `language` varchar(5) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `form_id` int(11) unsigned NOT NULL,
+  `email_data` tinyint(1) NOT NULL DEFAULT '0',
+  `email_subject` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `email_recipient` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT 'Form.html.twig',
+  `email_to_field` int(11) DEFAULT NULL,
+  `email_to_addresses` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email_from` text COLLATE utf8mb4_unicode_ci,
+  `email_body` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email_template` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT 'Form.html.twig',
+  `created_on` datetime NOT NULL,
+  `edited_on` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `forms_fields` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
+++ b/src/Backend/Modules/FormBuilder/Installer/Data/locale.xml
@@ -18,6 +18,15 @@
         <translation language="el"><![CDATA[Προσθήκη]]></translation>
         <translation language="pl"><![CDATA[dodaj]]></translation>
       </item>
+      <item type="message" name="AddedEmail">
+        <translation language="nl"><![CDATA[De email werd toegevoegd.]]></translation>
+        <translation language="en"><![CDATA[The email has been added.]]></translation>
+        <translation language="fr"><![CDATA[L'email a été ajouté.]]></translation>
+      </item>
+      <item type="label" name="AddEmail">
+        <translation language="nl"><![CDATA[email toevoegen]]></translation>
+        <translation language="en"><![CDATA[add email]]></translation>
+      </item>
       <item type="label" name="AddFields">
         <translation language="nl"><![CDATA[velden toevoegen]]></translation>
         <translation language="en"><![CDATA[add fields]]></translation>
@@ -82,6 +91,21 @@
         <translation language="el"><![CDATA[Πεδίο επιλογής]]></translation>
         <translation language="pl"><![CDATA[powrót do zgłoszeń]]></translation>
       </item>
+      <item type="label" name="Classname">
+        <translation language="nl"><![CDATA[CSS-klasse]]></translation>
+        <translation language="en"><![CDATA[CSS class]]></translation>
+        <translation language="it"><![CDATA[Classe CSS]]></translation>
+        <translation language="ru"><![CDATA[CSS-класс]]></translation>
+        <translation language="zh"><![CDATA[CSS类]]></translation>
+        <translation language="fr"><![CDATA[Classe CSS]]></translation>
+        <translation language="hu"><![CDATA[CSS osztály]]></translation>
+        <translation language="de"><![CDATA[CSS-Klasse]]></translation>
+        <translation language="es"><![CDATA[Clases CSS]]></translation>
+        <translation language="uk"><![CDATA[CSS клас]]></translation>
+        <translation language="sv"><![CDATA[CSS-klass]]></translation>
+        <translation language="el"><![CDATA[CSS Class]]></translation>
+        <translation language="pl"><![CDATA[klasa CSS]]></translation>
+      </item>
       <item type="label" name="DefaultValue">
         <translation language="nl"><![CDATA[standaardwaarde]]></translation>
         <translation language="en"><![CDATA[default value]]></translation>
@@ -144,6 +168,11 @@
         <translation language="el"><![CDATA[πτυσσόμενη λίστα]]></translation>
         <translation language="pl"><![CDATA[lista rozwijana]]></translation>
       </item>
+      <item type="label" name="EditEmail">
+        <translation language="nl"><![CDATA[bewerk email]]></translation>
+        <translation language="en"><![CDATA[edit email]]></translation>
+        <translation language="fr"><![CDATA[éditer l'email]]></translation>
+      </item>
       <item type="label" name="EditForm">
         <translation language="nl"><![CDATA[bewerk formulier "%1$s"]]></translation>
         <translation language="en"><![CDATA[edit form "%1$s"]]></translation>
@@ -158,6 +187,11 @@
         <translation language="sv"><![CDATA[ändra formulär "%1$s"]]></translation>
         <translation language="el"><![CDATA[Μεταβολή της φόρμας "%1$s"]]></translation>
         <translation language="pl"><![CDATA[edytuj od "%1$s"]]></translation>
+      </item>
+      <item type="label" name="EmailFieldsData">
+        <translation language="nl"><![CDATA[voeg de ingegeven velden toe aan de email]]></translation>
+        <translation language="en"><![CDATA[add the entered fields to the email]]></translation>
+        <translation language="fr"><![CDATA[ajouter les champs entrés à l'email]]></translation>
       </item>
       <item type="label" name="ErrorMessage">
         <translation language="nl"><![CDATA[foutmelding]]></translation>
@@ -270,51 +304,6 @@
         <translation language="el"><![CDATA[Αναγνωριστικό]]></translation>
         <translation language="pl"><![CDATA[identyfikator]]></translation>
       </item>
-      <item type="label" name="Method">
-        <translation language="nl"><![CDATA[methode]]></translation>
-        <translation language="en"><![CDATA[method]]></translation>
-        <translation language="it"><![CDATA[metodo]]></translation>
-        <translation language="ru"><![CDATA[Метод]]></translation>
-        <translation language="zh"><![CDATA[方法]]></translation>
-        <translation language="fr"><![CDATA[méthode]]></translation>
-        <translation language="hu"><![CDATA[módszer]]></translation>
-        <translation language="de"><![CDATA[Methode]]></translation>
-        <translation language="es"><![CDATA[método]]></translation>
-        <translation language="uk"><![CDATA[Метод]]></translation>
-        <translation language="sv"><![CDATA[metod]]></translation>
-        <translation language="el"><![CDATA[Μέθοδος]]></translation>
-        <translation language="pl"><![CDATA[metoda]]></translation>
-      </item>
-      <item type="label" name="MethodDatabase">
-        <translation language="nl"><![CDATA[opslaan in de database]]></translation>
-        <translation language="en"><![CDATA[save in the database]]></translation>
-        <translation language="it"><![CDATA[salva nel database]]></translation>
-        <translation language="ru"><![CDATA[Сохранить в БД]]></translation>
-        <translation language="zh"><![CDATA[保存到数据库]]></translation>
-        <translation language="fr"><![CDATA[sauvegarder en base de donnée]]></translation>
-        <translation language="hu"><![CDATA[adatbázisba mentés]]></translation>
-        <translation language="de"><![CDATA[in der Datenbank speichern]]></translation>
-        <translation language="es"><![CDATA[guardar en base de datos]]></translation>
-        <translation language="uk"><![CDATA[Зберегти в БД]]></translation>
-        <translation language="sv"><![CDATA[spara i databas]]></translation>
-        <translation language="el"><![CDATA[Αποθήκευση στη Βάση δεδομένων]]></translation>
-        <translation language="pl"><![CDATA[zapisz w bazie danych]]></translation>
-      </item>
-      <item type="label" name="MethodDatabaseEmail">
-        <translation language="nl"><![CDATA[opslaan in de database en email verzenden]]></translation>
-        <translation language="en"><![CDATA[save in the database and send email]]></translation>
-        <translation language="it"><![CDATA[salva nel database e invia mail]]></translation>
-        <translation language="ru"><![CDATA[Сохранить в БД и отправить по E-Mail]]></translation>
-        <translation language="zh"><![CDATA[保存到数据库并发送邮件]]></translation>
-        <translation language="fr"><![CDATA[sauvegarder en base de données et envoyer par e-mail]]></translation>
-        <translation language="hu"><![CDATA[adatbázisba mentés és email-ben küldés]]></translation>
-        <translation language="de"><![CDATA[in der Datenbank speichern und als E-Mail versenden]]></translation>
-        <translation language="es"><![CDATA[guardar en base de datos y enviar un email]]></translation>
-        <translation language="uk"><![CDATA[Зберегти в БД і нідіслати на e-mail]]></translation>
-        <translation language="sv"><![CDATA[spara i databas och skicka e-post]]></translation>
-        <translation language="el"><![CDATA[Αποθήκευση στη Βάση δεδομένων και αποστολή email]]></translation>
-        <translation language="pl"><![CDATA[zapisz w bazie danych i wyślij email]]></translation>
-      </item>
       <item type="label" name="MailmotorListId">
         <translation language="de"><![CDATA[list id]]></translation>
         <translation language="el"><![CDATA[κατάλογος id]]></translation>
@@ -357,16 +346,15 @@
         <translation language="ru"><![CDATA[Используйте этот адрес электронной почты для подписки на рассылку с помощью mailmotor.]]></translation>
         <translation language="pl"><![CDATA[Użyj tego adresu e-mail, aby zapisać się do programu Mailmotor.]]></translation>
       </item>
-      <item type="label" name="MethodEmail">
-        <translation language="nl"><![CDATA[email verzenden]]></translation>
-        <translation language="en"><![CDATA[send email]]></translation>
-        <translation language="it"><![CDATA[invia mail]]></translation>
-        <translation language="fr"><![CDATA[envoyer par e-mail]]></translation>
-        <translation language="hu"><![CDATA[email-ben küldés]]></translation>
-        <translation language="de"><![CDATA[E-Mail versenden]]></translation>
-        <translation language="es"><![CDATA[enviar un email]]></translation>
-        <translation language="sv"><![CDATA[skicka e-post]]></translation>
-        <translation language="pl"><![CDATA[wyślij email]]></translation>
+      <item type="message" name="HelpSaveInDatabase">
+        <translation language="nl"><![CDATA[Vink aan om de ingezonden formulieren op te slaan in de database.]]></translation>
+        <translation language="fr"><![CDATA[Cochez pour enregistrer les formulaires soumis dans la base de données.]]></translation>
+        <translation language="en"><![CDATA[Check to save the submitted forms in the database.]]></translation>
+      </item>
+      <item type="label" name="Message">
+        <translation language="nl"><![CDATA[bericht]]></translation>
+        <translation language="en"><![CDATA[message]]></translation>
+        <translation language="fr"><![CDATA[message]]></translation>
       </item>
       <item type="label" name="MinutesAgo">
         <translation language="nl"><![CDATA[%1$s minuten geleden]]></translation>
@@ -473,21 +461,6 @@
         <translation language="el"><![CDATA[κράτησης θέσης]]></translation>
         <translation language="pl"><![CDATA[miejsce zarezerwowane]]></translation>
       </item>
-      <item type="label" name="Classname">
-        <translation language="nl"><![CDATA[CSS-klasse]]></translation>
-        <translation language="en"><![CDATA[CSS class]]></translation>
-        <translation language="it"><![CDATA[Classe CSS]]></translation>
-        <translation language="ru"><![CDATA[CSS-класс]]></translation>
-        <translation language="zh"><![CDATA[CSS类]]></translation>
-        <translation language="fr"><![CDATA[Classe CSS]]></translation>
-        <translation language="hu"><![CDATA[CSS osztály]]></translation>
-        <translation language="de"><![CDATA[CSS-Klasse]]></translation>
-        <translation language="es"><![CDATA[Clases CSS]]></translation>
-        <translation language="uk"><![CDATA[CSS клас]]></translation>
-        <translation language="sv"><![CDATA[CSS-klass]]></translation>
-        <translation language="el"><![CDATA[CSS Class]]></translation>
-        <translation language="pl"><![CDATA[klasa CSS]]></translation>
-      </item>
       <item type="label" name="Preview">
         <translation language="nl"><![CDATA[preview]]></translation>
         <translation language="en"><![CDATA[preview]]></translation>
@@ -575,6 +548,21 @@
         <translation language="sv"><![CDATA[obligatoriskt]]></translation>
         <translation language="el"><![CDATA[Απαιτείται]]></translation>
         <translation language="pl"><![CDATA[wymagane]]></translation>
+      </item>
+      <item type="label" name="SaveInDatabase">
+        <translation language="nl"><![CDATA[opslaan in de database]]></translation>
+        <translation language="en"><![CDATA[save in the database]]></translation>
+        <translation language="it"><![CDATA[salva nel database]]></translation>
+        <translation language="ru"><![CDATA[Сохранить в БД]]></translation>
+        <translation language="zh"><![CDATA[保存到数据库]]></translation>
+        <translation language="fr"><![CDATA[sauvegarder en base de donnée]]></translation>
+        <translation language="hu"><![CDATA[adatbázisba mentés]]></translation>
+        <translation language="de"><![CDATA[in der Datenbank speichern]]></translation>
+        <translation language="es"><![CDATA[guardar en base de datos]]></translation>
+        <translation language="uk"><![CDATA[Зберегти в БД]]></translation>
+        <translation language="sv"><![CDATA[spara i databas]]></translation>
+        <translation language="el"><![CDATA[Αποθήκευση στη Βάση δεδομένων]]></translation>
+        <translation language="pl"><![CDATA[zapisz w bazie danych]]></translation>
       </item>
       <item type="label" name="SecondsAgo">
         <translation language="nl"><![CDATA[%1$s seconden geleden]]></translation>
@@ -909,6 +897,11 @@
         <translation language="el"><![CDATA[Σίγουρα θέλετε να διαγράψετε αυτή την υποβολή;]]></translation>
         <translation language="pl"><![CDATA[Jesteś pewien że chcesz usunąć te zgłoszenie?]]></translation>
       </item>
+      <item type="message" name="ConfirmDeleteEmail">
+        <translation language="nl"><![CDATA[Ben je zeker dat je de e-mail wil verwijderen?]]></translation>
+        <translation language="en"><![CDATA[Are you sure you want to delete the e-mail?]]></translation>
+        <translation language="fr"><![CDATA[Êtes-vous sûr de vouloir supprimer l'e-mail?]]></translation>
+      </item>
       <item type="message" name="Deleted">
         <translation language="nl"><![CDATA[Het formulier "%1$s" werd verwijderd.]]></translation>
         <translation language="en"><![CDATA[The form "%1$s" was removed.]]></translation>
@@ -921,6 +914,11 @@
         <translation language="es"><![CDATA[El formulario "%1$s" fue eliminado.]]></translation>
         <translation language="el"><![CDATA[Η φόρμα "%1$s" διεγράφη.]]></translation>
         <translation language="pl"><![CDATA[Formularz "%1$s" został usunięty.]]></translation>
+      </item>
+      <item type="message" name="DeletedEmail">
+        <translation language="nl"><![CDATA[De email werd verwijderd.]]></translation>
+        <translation language="en"><![CDATA[The email was removed.]]></translation>
+        <translation language="fr"><![CDATA[L'email a été effacé.]]></translation>
       </item>
       <item type="message" name="Edited">
         <translation language="nl"><![CDATA[Het formulier "%1$s" werd opgeslagen.]]></translation>
@@ -935,6 +933,29 @@
         <translation language="sv"><![CDATA[formulär "%1$s" sparades.]]></translation>
         <translation language="el"><![CDATA[Η φόρμα "%1$s" αποθηκεύτηκε.]]></translation>
         <translation language="pl"><![CDATA[Formularz "%1$s" został zapisany.]]></translation>
+      </item>
+      <item type="label" name="Emails">
+        <translation language="nl"><![CDATA[emails]]></translation>
+        <translation language="en"><![CDATA[emails]]></translation>
+        <translation language="fr"><![CDATA[courriels]]></translation>
+      </item>
+      <item type="error" name="EmailValidationIsRequired">
+        <translation language="en"><![CDATA[Email validation is required when using this field as 'reply to' emailaddress.]]></translation>
+        <translation language="pl"><![CDATA[Sprawdzanie poprawności adresu e-mail jest wymagane, gdy pole to jest używane jako adres e-mail do odpowiedzi.]]></translation>
+      </item>
+      <item type="error" name="ErrorMessageIsRequired">
+        <translation language="nl"><![CDATA[Gelieve een foutmelding in te geven.]]></translation>
+        <translation language="en"><![CDATA[Please provide an error message.]]></translation>
+        <translation language="it"><![CDATA[Per favore fornisci un messaggio di errore.]]></translation>
+        <translation language="ru"><![CDATA[Введите текст сообщения об ошибке.]]></translation>
+        <translation language="zh"><![CDATA[请输入错误提示信息。]]></translation>
+        <translation language="fr"><![CDATA[Veuillez fournir un message d'erreur.]]></translation>
+        <translation language="hu"><![CDATA[Kérlek add meg a hibaüzenetet.]]></translation>
+        <translation language="de"><![CDATA[Bitte gib eine Fehlermeldung an.]]></translation>
+        <translation language="es"><![CDATA[Por favor introudce un mensaje de error.]]></translation>
+        <translation language="sv"><![CDATA[Vänligen ange ett felmeddelande.]]></translation>
+        <translation language="el"><![CDATA[Παρακαλώ δώστε ένα μήνυμα λάθους.]]></translation>
+        <translation language="pl"><![CDATA[Proszę wprowadzić komunikat o błędzie.]]></translation>
       </item>
       <item type="message" name="HelpIdentifier">
         <translation language="nl"><![CDATA[De identifier wordt in de URL geplaatst na het succesvol opslaan van formulier.]]></translation>
@@ -1013,6 +1034,11 @@
         <translation language="sv"><![CDATA[Det finns inga inskick än.]]></translation>
         <translation language="el"><![CDATA[Δεν υπάρχουν ακόμη υποβολές.]]></translation>
         <translation language="pl"><![CDATA[Brak jeszcze zgłoszeń.]]></translation>
+      </item>
+      <item type="message" name="NoEmails">
+        <translation language="nl"><![CDATA[Er zijn nog geen emails.]]></translation>
+        <translation language="en"><![CDATA[There are no emails yet.]]></translation>
+        <translation language="fr"><![CDATA[Il n'y a pas encore d'emails.]]></translation>
       </item>
       <item type="message" name="NoFields">
         <translation language="nl"><![CDATA[Er zijn nog geen velden.]]></translation>
@@ -1097,20 +1123,6 @@
         <translation language="de"><![CDATA[Zeit und Datum]]></translation>
         <translation language="pl"><![CDATA[czas i data]]></translation>
       </item>
-      <item type="error" name="ErrorMessageIsRequired">
-        <translation language="nl"><![CDATA[Gelieve een foutmelding in te geven.]]></translation>
-        <translation language="en"><![CDATA[Please provide an error message.]]></translation>
-        <translation language="it"><![CDATA[Per favore fornisci un messaggio di errore.]]></translation>
-        <translation language="ru"><![CDATA[Введите текст сообщения об ошибке.]]></translation>
-        <translation language="zh"><![CDATA[请输入错误提示信息。]]></translation>
-        <translation language="fr"><![CDATA[Veuillez fournir un message d'erreur.]]></translation>
-        <translation language="hu"><![CDATA[Kérlek add meg a hibaüzenetet.]]></translation>
-        <translation language="de"><![CDATA[Bitte gib eine Fehlermeldung an.]]></translation>
-        <translation language="es"><![CDATA[Por favor introudce un mensaje de error.]]></translation>
-        <translation language="sv"><![CDATA[Vänligen ange ett felmeddelande.]]></translation>
-        <translation language="el"><![CDATA[Παρακαλώ δώστε ένα μήνυμα λάθους.]]></translation>
-        <translation language="pl"><![CDATA[Proszę wprowadzić komunikat o błędzie.]]></translation>
-      </item>
       <item type="error" name="IdentifierExists">
         <translation language="nl"><![CDATA[This identifier already exists.]]></translation>
         <translation language="it"><![CDATA[Questo identificatore è già esistente.]]></translation>
@@ -1181,6 +1193,11 @@
         <translation language="el"><![CDATA[Το αναγνωριστικό χρησιμοποιείται ήδη.]]></translation>
         <translation language="pl"><![CDATA[Ten identyfikator już jest używany.]]></translation>
       </item>
+      <item type="label" name="ValueOfAField">
+        <translation language="nl"><![CDATA[Waarde van een veld]]></translation>
+        <translation language="en"><![CDATA[Value of a field]]></translation>
+        <translation language="fr"><![CDATA[Valeur d'un champ]]></translation>
+      </item>
       <item type="error" name="ValueIsRequired">
         <translation language="nl"><![CDATA[Gelieve een waarde in te geven.]]></translation>
         <translation language="en"><![CDATA[Please provide a value.]]></translation>
@@ -1196,10 +1213,7 @@
         <translation language="el"><![CDATA[Παρακαλώ δώστε μία τιμή.]]></translation>
         <translation language="pl"><![CDATA[Proszę wprowadzić wartość.]]></translation>
       </item>
-      <item type="error" name="EmailValidationIsRequired">
-        <translation language="en"><![CDATA[Email validation is required when using this field as 'reply to' emailaddress.]]></translation>
-        <translation language="pl"><![CDATA[Sprawdzanie poprawności adresu e-mail jest wymagane, gdy pole to jest używane jako adres e-mail do odpowiedzi.]]></translation>
-      </item>
+
       <item type="error" name="ActivateEmailValidationToUseThisOption">
         <translation language="nl"><![CDATA[Activeer email validatie om deze optie te kunnen gebruiken.]]></translation>
         <translation language="en"><![CDATA[Activate email validation to use this option.]]></translation>

--- a/src/Backend/Modules/FormBuilder/Installer/Installer.php
+++ b/src/Backend/Modules/FormBuilder/Installer/Installer.php
@@ -34,6 +34,9 @@ class Installer extends ModuleInstaller
         $this->setNavigation($navigationModulesId, 'FormBuilder', 'form_builder/index', [
             'form_builder/add',
             'form_builder/edit',
+            'form_builder/emails',
+            'form_builder/edit_email',
+            'form_builder/add_email',
             'form_builder/data',
             'form_builder/data_details',
         ]);
@@ -44,11 +47,15 @@ class Installer extends ModuleInstaller
         $this->setModuleRights(1, $this->getModule());
 
         $this->setActionRights(1, $this->getModule(), 'Add');
+        $this->setActionRights(1, $this->getModule(), 'AddEmail');
         $this->setActionRights(1, $this->getModule(), 'Data');
         $this->setActionRights(1, $this->getModule(), 'DataDetails');
         $this->setActionRights(1, $this->getModule(), 'Delete');
         $this->setActionRights(1, $this->getModule(), 'DeleteField'); // AJAX
+        $this->setActionRights(1, $this->getModule(), 'DeleteEmail');
         $this->setActionRights(1, $this->getModule(), 'Edit');
+        $this->setActionRights(1, $this->getModule(), 'EditEmail');
+        $this->setActionRights(1, $this->getModule(), 'Emails');
         $this->setActionRights(1, $this->getModule(), 'ExportData');
         $this->setActionRights(1, $this->getModule(), 'GetField'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'Index');
@@ -68,8 +75,7 @@ class Installer extends ModuleInstaller
             $form['language'] = $language;
             $form['user_id'] = $this->getDefaultUserID();
             $form['name'] = \SpoonFilter::ucfirst($this->getLocale('Contact', 'Core', $language, 'lbl', 'Frontend'));
-            $form['method'] = 'database_email';
-            $form['email'] = serialize([$this->getVariable('email')]);
+            $form['database'] = 1;
             $form['success_message'] = $this->getLocale('ContactMessageSent', 'Core', $language, 'msg', 'Frontend');
             $form['identifier'] = 'contact-' . $language;
             $form['created_on'] = gmdate('Y-m-d H:i:s');

--- a/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
+++ b/src/Backend/Modules/FormBuilder/Js/FormBuilder.js
@@ -13,6 +13,7 @@ jsBackend.FormBuilder = {
     // variables
     var $selectMethod = $('select#method')
     var $formId = $('#formId')
+    var $recipientOption = $('input[name="recipient"]')
 
     // fields handler
     jsBackend.FormBuilder.Fields.init()
@@ -26,7 +27,14 @@ jsBackend.FormBuilder = {
       $(document).on('change', 'select#method', jsBackend.FormBuilder.handleMethodField)
     }
 
-    $('#email').multipleTextbox({
+    // hide or show the recipient options
+    if ($recipientOption.length > 0) {
+      jsBackend.FormBuilder.handleRecipientOptions()
+      $(document).on('change', 'input[name="recipient"]', jsBackend.FormBuilder.handleRecipientOptions)
+    }
+
+    // format email field
+    $('#emailAddresses').multipleTextbox({
       emptyMessage: jsBackend.locale.msg('NoEmailaddresses'),
       addLabel: utils.string.ucfirst(jsBackend.locale.lbl('Add', 'Core')),
       removeLabel: utils.string.ucfirst(jsBackend.locale.lbl('Delete')),
@@ -52,6 +60,34 @@ jsBackend.FormBuilder = {
 
     // hide email field
     $emailWrapper.slideUp()
+  },
+
+  /**
+   * Toggle recipient options based on the recipient value
+   */
+  handleRecipientOptions: function () {
+    // variables
+    var $recipientOption = $('input[name="recipient"]:checked')
+    var $emailWrapper = $('#recipientGroupEmail')
+    var $fieldsWrapper = $('#recipientGroupFields')
+
+    console.log($recipientOption.val());
+    if ($recipientOption.val() === 'email') {
+      // show email field
+      $emailWrapper.fadeIn()
+      $fieldsWrapper.hide()
+
+      return;
+    }
+
+    if ($recipientOption.val() === 'field') {
+      // show email field
+      $fieldsWrapper.fadeIn()
+      $emailWrapper.hide()
+
+      return;
+    }
+
   }
 }
 

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Add.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Add.html.twig
@@ -34,31 +34,12 @@
                       </label>
                       {% form_field name %} {% form_field_error name %}
                     </div>
-                    <div class="form-group">
-                      <label for="method" class="control-label">
-                        {{ 'lbl.Method'|trans|ucfirst }}
-                        {{ macro.required }}
+                    <div class="form-group last">
+                      <label for="database" class="control-label">
+                        {% form_field database %} {{ 'lbl.SaveInDatabase'|trans|ucfirst }}
                       </label>
-                      {% form_field method %} {% form_field_error method %}
-                    </div>
-                    <div class="form-group">
-                      <label for="EmailSubject" class="control-label">
-                        {{ 'lbl.EmailSubject'|trans|ucfirst }}
-                      </label>
-                      {% form_field email_subject %} {% form_field_error email_subject %}
-                    </div>
-                    {% if ddmTemplate %}
-                      <div class="form-group">
-                        <label for="template" class="control-label">{{ 'lbl.Template'|trans|ucfirst }}</label>
-                        {% form_field template %} {% form_field_error template %}
-                      </div>
-                    {% endif %}
-                    <div class="form-group">
-                      <label for="email" class="control-label">
-                        {{ 'lbl.Recipient'|trans|ucfirst }}
-                        {{ macro.required }}
-                      </label>
-                      {% form_field email %} {% form_field_error email %}
+                      {% form_field_error database %}
+                      <p class="help-block">{{ 'msg.HelpSaveInDatabase'|trans|raw }}</p>
                     </div>
                   </div>
                 </div>

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/AddEmail.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/AddEmail.html.twig
@@ -1,0 +1,124 @@
+{% extends 'Layout/Templates/base.html.twig' %}
+{% import "Layout/Templates/macros.html.twig" as macro %}
+
+{% block actionbar %}
+
+{% endblock %}
+
+{% block content %}
+  {% form add %}
+  <div class="row fork-module-content">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Status'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              <fieldset>
+                <div class="form-group">
+                  <label for="emailSubject" class="control-label">
+                    {{ 'lbl.EmailSubject'|trans|ucfirst }}
+                  </label>
+                  {% form_field email_subject %} {% form_field_error email_subject %}
+                </div>
+              </fieldset>
+              {% if ddmTemplate %}
+                <fieldset>
+                  <div class="form-group">
+                    <label for="template" class="control-label">{{ 'lbl.Template'|trans|ucfirst }}</label>
+                    {% form_field template %} {% form_field_error template %}
+                  </div>
+                </fieldset>
+              {% endif %}
+              <fieldset>
+                <div class="form-group">
+                  <label for="email" class="control-label">
+                    {{ 'lbl.Recipient'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  <ul class="list-unstyled">
+                    {% for option in recipient %}
+                      <li class="radio">
+                        <label for="{{ option.id }}">{{ option.rbtRecipient|raw }} {{ option.label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+                <div class="form-group" id="recipientGroupFields">
+                  {% form_field email_fields %} {% form_field_error email_fields %}
+                </div>
+                <div class="form-group" id="recipientGroupEmail">
+                  {% form_field email_addresses %} {% form_field_error email_addresses %}
+                </div>
+              </fieldset>
+              <fieldset>
+                <legend>
+                  {{ 'lbl.From'|trans|ucfirst }}
+                </legend>
+                <div class="form-group">
+                  <label for="fromName" class="control-label">
+                    {{ 'lbl.Name'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  {% form_field from_name %} {% form_field_error from_name %}
+                </div>
+                <div class="form-group">
+                  <label for="fromEmail" class="control-label">
+                    {{ 'lbl.Email'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  {% form_field from_email %} {% form_field_error from_email %}
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="panel panel-default panel-editor">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Message'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              {% form_field email_body %}
+            </div>
+            {% if txtEmailBodyError %}
+              <div class="panel-footer">
+                {% form_field_error email_body %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Extra'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              <fieldset class="last">
+                <div class="form-group last">
+                  <label for="emailData" class="control-label">
+                    {% form_field email_data %} {{ 'lbl.EmailFieldsData'|trans|ucfirst }}
+                  </label>
+                  {% form_field_error email_data %}
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row fork-module-actions">
+    <div class="col-md-12">
+      <div class="btn-toolbar">
+        <div class="btn-group" role="group">
+          {{ macro.buttonIcon(geturl('Emails', null, '&id='~item.id ), 'times', 'lbl.Cancel'|trans|ucfirst, 'btn-default') }}
+        </div>
+        <div class="btn-group pull-right" role="group">
+          {{ macro.buttonIcon('', 'plus-square', 'lbl.Add'|trans|ucfirst, 'btn-primary', { "id":"addButton", "type":"submit", "name":"add" }) }}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endform %}
+{% endblock %}

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Edit.html.twig
@@ -51,31 +51,12 @@
                       </label>
                       {% form_field name %} {% form_field_error name %}
                     </div>
-                    <div class="form-group">
-                      <label for="method" class="control-label">
-                        {{ 'lbl.Method'|trans|ucfirst }}
-                        {{ macro.required }}
+                    <div class="form-group last">
+                      <label for="database" class="control-label">
+                        {% form_field database %} {{ 'lbl.SaveInDatabase'|trans|ucfirst }}
                       </label>
-                      {% form_field method %} {% form_field_error method %}
-                    </div>
-                    <div class="form-group">
-                      <label for="EmailSubject" class="control-label">
-                        {{ 'lbl.EmailSubject'|trans|ucfirst }}
-                      </label>
-                      {% form_field email_subject %} {% form_field_error email_subject %}
-                    </div>
-                    {% if ddmTemplate %}
-                      <div class="form-group">
-                        <label for="template" class="control-label">{{ 'lbl.Template'|trans|ucfirst }}</label>
-                        {% form_field template %} {% form_field_error template %}
-                      </div>
-                    {% endif %}
-                    <div class="form-group">
-                      <label for="email" class="control-label">
-                        {{ 'lbl.Recipient'|trans|ucfirst }}
-                        {{ macro.required }}
-                      </label>
-                      {% form_field email %} {% form_field_error email %}
+                      {% form_field_error database %}
+                      <p class="help-block">{{ 'msg.HelpSaveInDatabase'|trans|raw }}</p>
                     </div>
                   </div>
                 </div>

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/EditEmail.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/EditEmail.html.twig
@@ -1,0 +1,150 @@
+{% extends 'Layout/Templates/base.html.twig' %}
+{% import "Layout/Templates/macros.html.twig" as macro %}
+
+{% block actionbar %}
+
+{% endblock %}
+
+{% block content %}
+  {% form edit %}
+  <div class="row fork-module-content">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Status'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              <fieldset>
+                <div class="form-group">
+                  <label for="EmailSubject" class="control-label">
+                    {{ 'lbl.EmailSubject'|trans|ucfirst }}
+                  </label>
+                  {% form_field email_subject %} {% form_field_error email_subject %}
+                </div>
+              </fieldset>
+              {% if ddmTemplate %}
+                <fieldset>
+                  <div class="form-group">
+                    <label for="template" class="control-label">{{ 'lbl.Template'|trans|ucfirst }}</label>
+                    {% form_field template %} {% form_field_error template %}
+                  </div>
+                </fieldset>
+              {% endif %}
+              <fieldset>
+                <div class="form-group">
+                  <label for="email" class="control-label">
+                    {{ 'lbl.Recipient'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  <ul class="list-unstyled">
+                    {% for option in recipient %}
+                      <li class="radio">
+                        <label for="{{ option.id }}">{{ option.rbtRecipient|raw }} {{ option.label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+                <div class="form-group" id="recipientGroupFields">
+                  {% form_field email_fields %} {% form_field_error email_fields %}
+                </div>
+                <div class="form-group" id="recipientGroupEmail">
+                  {% form_field email_addresses %} {% form_field_error email_addresses %}
+                </div>
+              </fieldset>
+              <fieldset class="last">
+                <legend>
+                  {{ 'lbl.From'|trans|ucfirst }}
+                </legend>
+                <div class="form-group">
+                  <label for="fromName" class="control-label">
+                    {{ 'lbl.Name'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  {% form_field from_name %} {% form_field_error from_name %}
+                </div>
+                <div class="form-group">
+                  <label for="fromEmail" class="control-label">
+                    {{ 'lbl.Email'|trans|ucfirst }}
+                    {{ macro.required }}
+                  </label>
+                  {% form_field from_email %} {% form_field_error from_email %}
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="panel panel-default panel-editor">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Content'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              {% form_field email_body %}
+            </div>
+            {% if txtEmailBodyError %}
+              <div class="panel-footer">
+                {% form_field_error email_body %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h2 class="panel-title">{{ 'lbl.Extra'|trans|ucfirst }}</h2>
+            </div>
+            <div class="panel-body">
+              <fieldset class="last">
+                <div class="form-group last">
+                  <label for="emailData" class="control-label">
+                    {% form_field email_data %} {{ 'lbl.EmailFieldsData'|trans|ucfirst }}
+                  </label>
+                  {% form_field_error email_data %}
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row fork-module-actions">
+    <div class="col-md-12">
+      <div class="btn-toolbar">
+        <div class="btn-group pull-left" role="group">
+          {% if showFormBuilderDeleteEmail %}
+            {{ macro.buttonIcon('', 'trash-o', 'lbl.Delete'|trans|ucfirst, 'btn-danger', {"type":"button", "data-toggle":"modal", "data-target":"#confirmDelete"}) }}
+          {% endif %}
+          {{ macro.buttonIcon(geturl('Emails', null, '&id='~item.id ), 'times', 'lbl.Cancel'|trans|ucfirst, 'btn-default') }}
+        </div>
+        <div class="btn-group pull-right" role="group">
+          {{ macro.buttonIcon('', 'plus-square', 'lbl.Save'|trans|ucfirst, 'btn-primary', {"type":"submit", "name":"save"}) }}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endform %}
+
+  {% if showFormBuilderDeleteEmail %}
+    {{ form_start(deleteForm) }}
+    {{ form_row(deleteForm._token) }}
+    {{ form_row(deleteForm.id) }}
+    <div class="modal fade" id="confirmDelete" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="confirmDeleteTitle">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title" id="confirmDeleteTitle">{{ 'lbl.Delete'|trans|ucfirst }}</h4>
+          </div>
+          <div class="modal-body">
+            <p>{{ 'msg.ConfirmDeleteEmail'|trans|raw }}</p>
+          </div>
+          <div class="modal-footer">
+            {{ macro.buttonIcon('', 'times', 'lbl.Cancel'|trans|ucfirst, 'btn-default', { "data-dismiss":"modal", "type":"button" } ) }}
+            {{ macro.buttonIcon('', 'trash', 'lbl.Delete'|trans|ucfirst, 'btn-danger', { "type":"submit" } ) }}
+          </div>
+        </div>
+      </div>
+    </div>
+    {{ form_end(deleteForm) }}
+  {% endif %}
+{% endblock %}

--- a/src/Backend/Modules/FormBuilder/Layout/Templates/Emails.html.twig
+++ b/src/Backend/Modules/FormBuilder/Layout/Templates/Emails.html.twig
@@ -1,0 +1,21 @@
+{% extends 'Layout/Templates/base.html.twig' %}
+{% import "Layout/Templates/macros.html.twig" as macro %}
+
+{% block actionbar %}
+  <div class="btn-toolbar pull-right">
+    <div class="btn-group" role="group">
+      {% if showFormBuilderAdd %}
+        {{ macro.buttonIcon( geturl('AddEmail', null, '&id='~item.id), 'plus-square', 'lbl.Add'|trans|ucfirst) }}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}
+
+{% block content %}
+  {% if dataGrid %}
+    {{ macro.dataGrid(dataGrid) }}
+  {% else %}
+    <p>{{ 'msg.NoEmails'|trans|ucfirst }}</p>
+  {% endif %}
+{% endblock %}
+

--- a/src/Frontend/Modules/FormBuilder/Layout/Templates/Mails/Form.html.twig
+++ b/src/Frontend/Modules/FormBuilder/Layout/Templates/Mails/Form.html.twig
@@ -1,24 +1,18 @@
 {% extends 'Core/Layout/Templates/Mails/Default.html.twig' %}
 
-{% block title %}
-  <title>{{ SITE_TITLE }} - {{ 'msg.FormBuilderSubject'|trans|format(name) }}</title>
-{% endblock %}
-
 {% block main %}
-  <h2>{{ SITE_TITLE }}: {{ subject|format(name) }}</h2>
-  <hr />
-  {% if is_confirmation_mail %}
-    <p>{{ 'msg.YouJustSentTheFollowingMessage'|trans }}</p>
-    <hr>
-  {% endif %}
+  <p>
+    {{ message|raw }}
+  </p>
   <h3>{{ 'lbl.SenderInformation'|trans|ucfirst }}</h3>
   <p>
     <strong>{{ 'lbl.SentOn'|trans|ucfirst }}:</strong><br />
     {{ sentOn|spoondate(dateFormatLong, LANGUAGE) }}
   </p>
-
-  <h3>{{ 'lbl.Content'|trans|ucfirst }}</h3>
-  {% for field in fields %}
-    <p><strong>{{ field.label }}:</strong><br /> {{ field.value|raw }}</p>
-  {% endfor %}
+  {% if email_data %}
+    <h3>{{ 'lbl.Content'|trans|ucfirst }}</h3>
+    {% for field in fields %}
+      <p><strong>{{ field.label }}:</strong><br /> {{ field.value|raw }}</p>
+    {% endfor %}
+  {% endif %}
 {% endblock %}

--- a/src/Frontend/Modules/FormBuilder/Widgets/Form.php
+++ b/src/Frontend/Modules/FormBuilder/Widgets/Form.php
@@ -504,7 +504,7 @@ class Form extends FrontendBaseWidget
 
                 $dataId = null;
                 // insert data
-                if ($this->item['method'] !== 'email') {
+                if ($this->item['database']) {
                     $dataId = FrontendFormBuilderModel::insertData($data);
                 }
 
@@ -549,7 +549,7 @@ class Form extends FrontendBaseWidget
                     $fields[$field['id']] = $fieldData;
 
                     // insert
-                    if ($this->item['method'] !== 'email') {
+                    if ($this->item['database']) {
                         FrontendFormBuilderModel::insertDataField($fieldData);
                     }
                 }


### PR DESCRIPTION
## Type
- Feature

## Pull request description
In the current formbuilder module you can send 1 e-mail to the value of a certain field, in addition to the confirmation e-mail to the site owner.
With this extension it is possible to set multiple e-mails per form, choose destinations (multiple addresses or value of a field), choose to add the form data and also specify the message itself.
Tested but errors are possible, as well as possible improvements to code.

![Schermafbeelding 2019-10-26 om 21 50 24](https://user-images.githubusercontent.com/4540274/67625170-ae71dc80-f83a-11e9-8860-bdf0b9c48b9a.png)
