### PR TITLE
Add select-all checkbox to MediaGallery connect datagrid

### DIFF
--- a/src/Backend/Core/Js/backend.js
+++ b/src/Backend/Core/Js/backend.js
@@ -874,7 +874,7 @@ jsBackend.controls = {
       var $this = $(this)
 
       // check or uncheck all the checkboxes in this datagrid
-      $this.closest('table').find('td input:checkbox').prop('checked', $this.is(':checked'))
+      $this.closest('table').find('td input:checkbox').prop('checked', $this.is(':checked')).change()
 
       // set selected class
       if ($this.is(':checked')) {

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -613,8 +613,11 @@ jsBackend.mediaLibraryHelper.group = {
     })
 
     $(mediaItemTypes).each(function (index, type) {
-      var mediaTableHtml = '<thead><tr><th class="check"><span><input type="checkbox" name="toggleChecks" value="toggleChecks"></span></th>' +
-        '<th>&nbsp;</th><th>&nbsp;</th><th>&nbsp;</th></tr></thead>' +
+      var mediaTableHtml = '<thead><tr><th class="check"><span><input type="checkbox" name="toggleChecks" value="toggleChecks" title="Select all"></span></th>' +
+        (type === 'image' ? '<th>' + utils.string.ucfirst(jsBackend.locale.lbl('Image')) + '</th>' : '') +
+        '<th>' + utils.string.ucfirst(jsBackend.locale.lbl('Filename')) + '</th>' +
+        '<th>' + utils.string.ucfirst(jsBackend.locale.lbl('Title')) + '</th>' +
+        '</tr></thead>' +
         '<tbody>' + html[type] + '</tbody>'
       $('#mediaTable' + utils.string.ucfirst(type)).html((html[type]) ? $(mediaTableHtml) : rowNoItems)
       $('#mediaCount' + utils.string.ucfirst(type)).text('(' + counts[type] + ')')

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -613,9 +613,15 @@ jsBackend.mediaLibraryHelper.group = {
     })
 
     $(mediaItemTypes).each(function (index, type) {
-      $('#mediaTable' + utils.string.ucfirst(type)).html((html[type]) ? $('<tbody>' + html[type] + '</tbody>') : rowNoItems)
+      var mediaTableHtml = '<thead><tr><th class="check"><span><input type="checkbox" name="toggleChecks" value="toggleChecks"></span></th>' +
+        '<th>&nbsp;</th><th>&nbsp;</th><th>&nbsp;</th></tr></thead>' +
+        '<tbody>' + html[type] + '</tbody>'
+      $('#mediaTable' + utils.string.ucfirst(type)).html((html[type]) ? $(mediaTableHtml) : rowNoItems)
       $('#mediaCount' + utils.string.ucfirst(type)).text('(' + counts[type] + ')')
     })
+
+    // Init toggle for mass-action checkbox
+    jsBackend.controls.bindMassCheckbox()
 
     // init $tabs
     var $tabs = $('#tabLibrary').find('.nav-tabs')
@@ -661,22 +667,25 @@ jsBackend.mediaLibraryHelper.group = {
     var $tables = $('.mediaTable')
 
     // bind change when connecting/disconnecting media
-    $tables.find('.toggleConnectedCheckbox').on('click', function () {
+    $tables.find('.toggleConnectedCheckbox').on('change', function () {
       // mediaId
       var mediaId = $(this).parent().parent().attr('id').replace('media-', '')
+
+      // Is the checkbox checked or unchecked?
+      var isChecked = $(this).is(':checked')
 
       // was already connected?
       var connected = utils.array.inArray(mediaId, currentMediaItemIds)
 
       // delete from array
-      if (connected) {
+      if (connected && !isChecked) {
         // loop all to find value and to delete it
         currentMediaItemIds.splice(currentMediaItemIds.indexOf(mediaId), 1)
 
         // update folder count
         jsBackend.mediaLibraryHelper.group.updateFolderCount(mediaFolderId, '-', 1)
         // add to array
-      } else {
+      } else if (!connected && isChecked) {
         currentMediaItemIds.push(mediaId)
 
         // update folder count


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

In the current MediaGallery module you need to browse through your media and "connect" images. This looks like this:
![Screen Shot 2019-11-02 at 17 39 12](https://user-images.githubusercontent.com/1352979/68075417-ea132600-fda7-11e9-8f91-f9972a00106d.png)

However, if you have 100+ images to add to a gallery, it's quite annoying to select them all manually, as there is no select-all checkbox. 

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
This PR adds a check-all checkbox to the datagrid of the MediaGallery modal to connect media to a gallery. It looks just like any other datagrid used in Fork CMS

![image](https://user-images.githubusercontent.com/1352979/68075443-4118fb00-fda8-11e9-886f-b435ac06617a.png)

### Changes done

* Added `.change()` to the bindMassCheckbox event handler in `backend.js` because programmatically checking checkboxes does not trigger any events (change event). Without triggering events, the medialibrary modal would not actually add any images even though they're selected. It needs the event to add them to the `currentMediaItemIds` array
* Added a `<thead>` in `MediaLibraryHelper.js` with the checkbox to select all checkboxes. 
* Changed the event handler on checkboxes from `click` to `change` which makes more sense for checkboxes. Added an `isChecked` check to the conditionals that populate the `currentMediaItemIds`