### PR TITLE
Allow get parameters to be set when creating an action for the DeleteType

### DIFF
--- a/src/Backend/Form/Type/DeleteType.php
+++ b/src/Backend/Form/Type/DeleteType.php
@@ -12,7 +12,14 @@ class DeleteType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->setAction(Model::createUrlForAction($options['action'], $options['module']));
+        $builder->setAction(
+            Model::createUrlForAction(
+                $options['action'],
+                $options['module'],
+                null,
+                $options['get_parameters']
+            )
+        );
 
         $builder->add($options['id_field_name'], HiddenType::class);
     }
@@ -28,6 +35,7 @@ class DeleteType extends AbstractType
         $resolver->setDefaults([
             'action' => 'Delete',
             'id_field_name' => 'id',
+            'get_parameters' => [],
         ]);
     }
 }

--- a/src/Backend/Form/Type/DeleteType.php
+++ b/src/Backend/Form/Type/DeleteType.php
@@ -35,7 +35,7 @@ class DeleteType extends AbstractType
         $resolver->setDefaults([
             'action' => 'Delete',
             'id_field_name' => 'id',
-            'get_parameters' => [],
+            'get_parameters' => [], // Get parameters to be added to the generated action url
         ]);
     }
 }


### PR DESCRIPTION
## Type

- Feature

## Pull request description

While I was working on a feature in a project, the delete action my DeleteType was POSTing to didn't know what to redirect to after performing the delete but the action where I created the DeleteType did! By allowing the GET parameters of the action in the DeleteType to be set I was able to send a `queryString` parameter along to the Delete action. This allowed me to have the Edit action tell the Delete action where to redirect to, useful stuff!

This could be used for a multitude of other things as well.
