### PR TITLE
Api: MediaLibrary: GET /api/medialibrary/asset/:uuid

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -25,6 +25,8 @@ frontend_ajax:
 # Api routing files
 content_blocks_api:
     resource: '../src/Backend/Modules/ContentBlocks/Resources/config/routing.yml'
+media_library_api:
+    resource: '../src/Backend/Modules/MediaLibrary/Resources/config/routing.yml'
 
 # Frontend controller (this is as good as the default when no other route gets matched)
 frontend:

--- a/src/Backend/Modules/MediaLibrary/Api/AssetController.php
+++ b/src/Backend/Modules/MediaLibrary/Api/AssetController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Backend\Modules\MediaLibrary\Api;
+
+use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItemRepository;
+use FOS\RestBundle\Controller\Annotations as Rest;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\SerializerInterface;
+
+final class AssetController
+{
+    /** @var MediaItemRepository */
+    private $mediaItemRepository;
+
+    /** @var SerializerInterface */
+    private $serializer;
+
+    public function __construct(MediaItemRepository $mediaItemRepository, SerializerInterface $serializer)
+    {
+        $this->mediaItemRepository = $mediaItemRepository;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * @Rest\Get("/medialibrary/asset/{uuid}")
+     */
+    public function getAssetAction(string $uuid): JsonResponse
+    {
+        return JsonResponse::fromJsonString(
+            $this->serializer->serialize($this->mediaItemRepository->find($uuid), 'json')
+        );
+    }
+}

--- a/src/Backend/Modules/MediaLibrary/Resources/config/routing.yml
+++ b/src/Backend/Modules/MediaLibrary/Resources/config/routing.yml
@@ -1,0 +1,4 @@
+media_library_api:
+    type:     rest
+    prefix:   /api
+    resource: Backend\Modules\MediaLibrary\Api\AssetController

--- a/src/Backend/Modules/MediaLibrary/Resources/config/services.yml
+++ b/src/Backend/Modules/MediaLibrary/Resources/config/services.yml
@@ -23,6 +23,11 @@ imports:
   - { resource: form.yml }
 
 services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
     media_library.twig_extension:
         class: Frontend\Modules\MediaLibrary\Twig\Extensions\FrontendHelperExtensions
         public: false
@@ -30,3 +35,6 @@ services:
             - "@media_library.helper.frontend"
         tags:
             - { name: twig.extension }
+
+    Backend\Modules\MediaLibrary\Api\:
+        resource: '../../Api/*'


### PR DESCRIPTION
## Type

- Feature

## Pull request description

This PR adds an API endpoint to be able to retrieve a media item (asset) in JSON format.

`GET /api/medialibrary/asset/{uuid}`

Example JSON output:

```
{
    "id": "b62bd5e4-055d-11ea-82c8-0242ac170002",
    "folder": {
        "id": 1,
        "parent": null,
        "userId": 1,
        "name": "default",
        "createdOn": 1573551884,
        "editedOn": 1573551884,
        "numberOfItems": 1
    },
    "userId": 1,
    "type": "image",
    "storageType": "local",
    "mime": "image/png",
    "shardingFolderName": "01",
    "url": "face.png",
    "fullUrl": "01/face.png",
    "title": "face",
    "size": 122948,
    "width": 989,
    "height": 1024,
    "createdOn": 1573571063,
    "editedOn": 1573571063,
    "source": "/src/Frontend/Files/MediaLibrary/01/face.png",
    "preview_source": "https://127.0.0.1:8000/src/Frontend/Files/Cache/media_library_backend_thumbnail/src/Frontend/Files/MediaLibrary/01/face.png",
    "direct_url": "/src/Frontend/Files/MediaLibrary/01/face.png",
    "image": true
}
```