### PR TITLE
Fix cropping for images with height lower than requested folder height

### DIFF
--- a/src/ForkCMS/Utility/Thumbnails.php
+++ b/src/ForkCMS/Utility/Thumbnails.php
@@ -86,6 +86,9 @@ class Thumbnails
                 if ($box->getWidth() < $width) {
                     $height = ($box->getHeight() / $box->getWidth()) * $width;
                     $image = $image->resize(new Box($width, $height));
+                } elseif ($box->getHeight() < $height) {
+                    $width *= ($box->getWidth() / $box->getHeight());
+                    $image = $image->resize(new Box($width, $height));
                 } else {
                     $image = $image->thumbnail(new Box($width, $height), ImageInterface::THUMBNAIL_OUTBOUND);
                 }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

This commit fixes thumbnail generation for images that have a base height lower than what is requested for that folder.

Before:
![oeps](https://user-images.githubusercontent.com/24303072/70131054-f11ca500-1681-11ea-8a77-adf93510ba07.jpg)

After:
![beter](https://user-images.githubusercontent.com/24303072/70131066-f679ef80-1681-11ea-8f55-51220c5f1ade.jpg)

