### PR TITLE
Fix timestamps for caching incorrect

### DIFF
--- a/src/Backend/Core/Engine/Form.php
+++ b/src/Backend/Core/Engine/Form.php
@@ -82,16 +82,12 @@ class Form extends \Common\Core\Form
 
         // add the internal link lists-file
         if (is_file(FRONTEND_CACHE_PATH . '/Navigation/editor_link_list_' . BackendLanguage::getWorkingLanguage() . '.js')) {
-            $timestamp = @filemtime(
-                FRONTEND_CACHE_PATH . '/Navigation/editor_link_list_' . BackendLanguage::getWorkingLanguage() . '.js'
-            );
             $this->header->addJS(
-                '/src/Frontend/Cache/Navigation/editor_link_list_' . BackendLanguage::getWorkingLanguage(
-                ) . '.js?m=' . $timestamp,
+                '/src/Frontend/Cache/Navigation/editor_link_list_' . BackendLanguage::getWorkingLanguage() . '.js',
                 null,
                 false,
                 true,
-                false
+                true
             );
         }
 

--- a/src/Backend/Core/Layout/Templates/head.html.twig
+++ b/src/Backend/Core/Layout/Templates/head.html.twig
@@ -10,11 +10,11 @@
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro%7COpen+Sans:400,600' rel='stylesheet' type='text/css'>
 
   {% for cssFile in cssFiles %}
-    <link rel="stylesheet" href="{{ cssFile.file }}" />{{ CRLF }}{{ TAB }}
+    <link rel="stylesheet" href="{{ cssFile }}" />{{ CRLF }}{{ TAB }}
   {% endfor %}
 
   {% for jsFile in jsFiles %}
-    <script src="{{ jsFile.file }}"></script>{{ CRLF }}{{ TAB }}
+    <script src="{{ jsFile }}"></script>{{ CRLF }}{{ TAB }}
   {% endfor %}
 
   {{ jsData|raw }}

--- a/src/Backend/Form/Type/EditorType.php
+++ b/src/Backend/Form/Type/EditorType.php
@@ -29,16 +29,12 @@ class EditorType extends TextareaType
 
         // add the internal link lists-file
         if (is_file(FRONTEND_CACHE_PATH . '/Navigation/editor_link_list_' . Language::getWorkingLanguage() . '.js')) {
-            $timestamp = @filemtime(
-                FRONTEND_CACHE_PATH . '/Navigation/editor_link_list_' . Language::getWorkingLanguage() . '.js'
-            );
             $header->addJS(
-                '/src/Frontend/Cache/Navigation/editor_link_list_' . Language::getWorkingLanguage(
-                ) . '.js?m=' . $timestamp,
+                '/src/Frontend/Cache/Navigation/editor_link_list_' . Language::getWorkingLanguage() . '.js',
                 null,
                 false,
                 true,
-                false
+                true
             );
         }
     }

--- a/src/Common/Core/Header/Asset.php
+++ b/src/Common/Core/Header/Asset.php
@@ -64,6 +64,6 @@ final class Asset
         // check if we need to use a ? or &
         $separator = mb_strpos($this->file, '?') === false ? '?' : '&';
 
-        return $this->file . $separator . 'm=' . filemtime(__DIR__ . '/../../../../' . $this->file);
+        return $this->file . $separator . 'm=' . @filemtime(__DIR__ . '/../../../../' . $this->file);
     }
 }

--- a/src/Common/Core/Header/Asset.php
+++ b/src/Common/Core/Header/Asset.php
@@ -26,7 +26,7 @@ final class Asset
         $this->createdOn = new DateTimeImmutable();
     }
 
-    public function compare(Asset $asset)
+    public function compare(Asset $asset): int
     {
         $comparison = $this->priority->compare($asset->priority);
 
@@ -62,6 +62,8 @@ final class Asset
         }
 
         // check if we need to use a ? or &
-        return $this->file . (mb_strpos($this->file, '?') === false ? '?' : '&') . 'm=' . LAST_MODIFIED_TIME;
+        $separator = mb_strpos($this->file, '?') === false ? '?' : '&';
+
+        return $this->file . $separator . 'm=' . filemtime(__DIR__ . '/../../../../' . $this->file);
     }
 }

--- a/src/Common/Core/Init.php
+++ b/src/Common/Core/Init.php
@@ -50,7 +50,7 @@ abstract class Init extends KernelLoader
             $lastModifiedTime = time();
         }
 
-        // define as a constant
+        /** @DEPRECATED */
         defined('LAST_MODIFIED_TIME') || define('LAST_MODIFIED_TIME', $lastModifiedTime);
     }
 }

--- a/src/Console/Core/CacheClearCommand.php
+++ b/src/Console/Core/CacheClearCommand.php
@@ -37,6 +37,9 @@ class CacheClearCommand extends Command
         $symfonyCacheClearCommand = $this->getApplication()->find('cache:clear');
         $symfonyCacheClearCommand->run(new ArrayInput(['--no-warmup' => true]), $output);
 
+        // clear file info cache
+        clearstatcache();
+
         $io->success('Cache is cleared');
     }
 

--- a/src/Frontend/Core/Layout/Templates/Base.html.twig
+++ b/src/Frontend/Core/Layout/Templates/Base.html.twig
@@ -55,7 +55,7 @@
 
 {# General Javascript #}
 {% for js in jsFiles %}
-  <script src="{{ js.file }}"></script>
+  <script src="{{ js }}"></script>
 {% endfor %}
 <script src="/js/vendors/bootstrap.min.js"></script>
 <script src="/js/vendors/bootstrap-accessibility.min.js"></script>

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/Head.html.twig
@@ -21,7 +21,7 @@
 
   {# Stylesheets #}
   {% for cssFiles in cssFiles %}
-    <link rel="stylesheet" href="{{ cssFiles.file }}" />
+    <link rel="stylesheet" href="{{ cssFiles }}" />
   {% endfor %}
 
   {# Site wide HTML #}


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement
- Deprecation

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

Use the filetime of the actual file instead of that of the parameters.yml file for caching assets
That way you don't need to touch the parameters.yml file to make sure your assets get a new url
