### PR TITLE
Fix page update error for an array offset on boolean value

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1184,7 +1184,7 @@ class Model
         $parentPageInfo = self::get($parentId, null, BL::getWorkingLanguage());
 
         // does the parent have extras?
-        if (!$isAction && $parentPageInfo['has_extra']) {
+        if (!$isAction && isset($parentPageInfo['has_extra']) && $parentPageInfo['has_extra']) {
             // set locale
             FrontendLanguage::setLocale(BL::getWorkingLanguage(), true);
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if their are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
![image](https://user-images.githubusercontent.com/1352979/73894780-cb786b80-487d-11ea-8ebf-80ebc496edfe.png)



## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
Stumbled upon this error in a personal project. It happens when I edit a page in the root ($parentId is `0`) and click the Save button. 

Adding some hardening in case the `self::get` method above returns a `false` boolean value. 