### PR TITLE
Return a 404 when a page isn't found instead of a server error

### DIFF
--- a/src/Backend/Modules/Pages/Api/PageController.php
+++ b/src/Backend/Modules/Pages/Api/PageController.php
@@ -27,7 +27,7 @@ final class PageController
         $latest = $this->pageRepository->getLatestForApi($id, Locale::fromString($locale));
 
         if ($latest === null) {
-            throw new NotFoundHttpException();
+            return JsonResponse::create(null, JsonResponse::HTTP_NOT_FOUND);
         }
 
         return JsonResponse::create($latest);


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix


## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

When you requested a page that didn't exist you got a 500 error because it was returning the symfony 404 exception. This returns an empty json with the satus code 404
