### PR TITLE
Cast the data value to string

### DIFF
--- a/src/Backend/Core/Engine/Model.php
+++ b/src/Backend/Core/Engine/Model.php
@@ -363,7 +363,7 @@ class Model extends \Common\Core\Model
                 function (?string $serializedData) use ($key, $value) {
                     $data = $serializedData === null ? [] : unserialize($serializedData);
 
-                    return isset($data[$key]) && $data[$key] === $value;
+                    return isset($data[$key]) && (string) $data[$key] === $value;
                 }
             )
         );


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The value to check on is always a string as dictated by the signature of
getExtrasForData. So to check, we should make sure the data's value is
also always a string.
