### PR TITLE
Fix images always being put in a source directory even when disabled

### DIFF
--- a/src/Common/Doctrine/ValueObject/AbstractImage.php
+++ b/src/Common/Doctrine/ValueObject/AbstractImage.php
@@ -37,7 +37,7 @@ abstract class AbstractImage extends AbstractFile
 
     public function getAbsolutePath(string $subDirectory = null): ?string
     {
-        if (self::GENERATE_THUMBNAILS && $subDirectory === null) {
+        if (static::GENERATE_THUMBNAILS && $subDirectory === null) {
             $subDirectory = 'source';
         }
 
@@ -46,7 +46,7 @@ abstract class AbstractImage extends AbstractFile
 
     public function getWebPath(string $subDirectory = null): string
     {
-        if (self::GENERATE_THUMBNAILS && $subDirectory === null) {
+        if (static::GENERATE_THUMBNAILS && $subDirectory === null) {
             $subDirectory = 'source';
         }
 
@@ -129,6 +129,6 @@ abstract class AbstractImage extends AbstractFile
 
     protected function writeFileToDisk(): void
     {
-        $this->getFile()->move($this->getUploadRootDir(self::GENERATE_THUMBNAILS ? 'source' : null), $this->fileName);
+        $this->getFile()->move($this->getUploadRootDir(static::GENERATE_THUMBNAILS ? 'source' : null), $this->fileName);
     }
 }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

By overwriting the constant `GENERATE_THUMBNAILS` you can prevent that a source directory is used while uploading, but it didn't check in all places correctly if it was overwritten by the parent
