### PR TITLE
Use sinle quotes for background images

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -1088,7 +1088,7 @@ jsBackend.pages.extras = {
       $img = $placeholder.find('#user-template-image-background-' + key + ' img')
 
       $element.attr('data-src', $img.attr('src'))
-      $element.css('background-image', 'url("' + $img.attr('src') + '")')
+      $element.css('background-imag\'' + $img.attr('src') + '\')')
 
       return
     }

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -1088,7 +1088,7 @@ jsBackend.pages.extras = {
       $img = $placeholder.find('#user-template-image-background-' + key + ' img')
 
       $element.attr('data-src', $img.attr('src'))
-      $element.css('background-imag\'' + $img.attr('src') + '\')')
+      $element.css('background-image\'' + $img.attr('src') + '\')')
 
       return
     }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When using user templates the generated background image uses double quotes. Because of this the background url doesn't work. When using single quotes this problem is avoided
