### PR TITLE
Fix xss in profiles display name

### DIFF
--- a/src/Backend/Modules/Profiles/Actions/Index.php
+++ b/src/Backend/Modules/Profiles/Actions/Index.php
@@ -128,6 +128,7 @@ class Index extends BackendBaseActionIndex
             'registered_on',
             true
         );
+        $this->dgProfiles->setColumnFunction('htmlspecialchars', ['[display_name]'], 'display_name');
 
         // add the mass action controls
         $this->dgProfiles->setMassActionCheckboxes('check', '[id]');


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Security

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

it was possible to do an xss attack using the profiles module with the display name because the datagrid doesn't run on twig yet