### PR TITLE
Bugfix : remove last slash in url after hreflang

### DIFF
--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -414,6 +414,9 @@ class Page extends KernelLoader
             $url = Navigation::getUrl($this->pageId, $language);
         }
 
+        // remove last /
+        $url = rtrim($url, '/\\');
+
         // Ignore 404 links
         if ($this->pageId !== Response::HTTP_NOT_FOUND
             && $url === Navigation::getUrl(Response::HTTP_NOT_FOUND, $language)) {


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
On the homepage the hreflang tag url is being displayed with the / on the end.
Example:
NL homepage of https://www.test.be/nl will generate a hreflang tag url as follow to the FR homepage
https://www.test.be/fr/

## Pull request description
By trimming the last / of the url the problem is solved and the href lang tag is correct.