### PR TITLE
Fix redirects are cached

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -17,6 +17,7 @@ use Backend\Modules\Profiles\Engine\Model as BackendProfilesModel;
 use ForkCMS\Utility\Thumbnails;
 use SpoonFormHidden;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This is the add-action, it will display a form to create a new item
@@ -510,7 +511,7 @@ class Add extends BackendBaseActionAdd
                 if ($redirectValue === 'internal') {
                     $data['internal_redirect'] = [
                         'page_id' => $this->form->getField('internal_redirect')->getValue(),
-                        'code' => '301',
+                        'code' => Response::HTTP_TEMPORARY_REDIRECT,
                     ];
                 }
                 if ($redirectValue === 'external') {
@@ -518,7 +519,7 @@ class Add extends BackendBaseActionAdd
                         'url' => BackendPagesModel::getEncodedRedirectUrl(
                             $this->form->getField('external_redirect')->getValue()
                         ),
-                        'code' => '301',
+                        'code' => Response::HTTP_TEMPORARY_REDIRECT,
                     ];
                 }
                 if (array_key_exists('image', $this->templates[$templateId]['data'])) {

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -19,6 +19,7 @@ use Backend\Modules\Tags\Engine\Model as BackendTagsModel;
 use Backend\Modules\Profiles\Engine\Model as BackendProfilesModel;
 use ForkCMS\Utility\Thumbnails;
 use SpoonFormHidden;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This is the edit-action, it will display a form to update an item
@@ -195,6 +196,7 @@ class Edit extends BackendBaseActionEdit
             ['[edited_on]'],
             'edited_on'
         );
+        $this->dgDrafts->setColumnFunction('htmlspecialchars', ['[title]'], 'title');
 
         // our JS needs to know an id, so we can highlight it
         $this->dgDrafts->setRowAttributes(['id' => 'row-[revision_id]']);
@@ -600,6 +602,7 @@ class Edit extends BackendBaseActionEdit
             ['[edited_on]'],
             'edited_on'
         );
+        $this->dgRevisions->setColumnFunction('htmlspecialchars', ['[title]'], 'title');
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('Edit')) {
@@ -857,7 +860,7 @@ class Edit extends BackendBaseActionEdit
         if ($redirectValue === 'internal') {
             $data['internal_redirect'] = [
                 'page_id' => $this->form->getField('internal_redirect')->getValue(),
-                'code' => '301',
+                'code' => Response::HTTP_TEMPORARY_REDIRECT,
             ];
         }
         if ($redirectValue === 'external') {
@@ -865,7 +868,7 @@ class Edit extends BackendBaseActionEdit
                 'url' => BackendPagesModel::getEncodedRedirectUrl(
                     $this->form->getField('external_redirect')->getValue()
                 ),
-                'code' => '301',
+                'code' => Response::HTTP_TEMPORARY_REDIRECT,
             ];
         }
         if (array_key_exists('image', $this->templates[$templateId]['data'])) {

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -310,7 +310,7 @@ class Model
             // loop elements
             foreach ($navigation[$navigationType][$depth][$parentId] as $key => $aValue) {
                 $html .= "\t<li>" . "\n";
-                $html .= "\t\t" . '<a href="#">' . $aValue['navigation_title'] . '</a>' . "\n";
+                $html .= "\t\t" . '<a href="#">' . htmlspecialchars($aValue['navigation_title']) . '</a>' . "\n";
 
                 // insert recursive here!
                 if (isset($navigation[$navigationType][$depth + 1][$key])) {
@@ -844,7 +844,7 @@ class Model
                     null,
                     null,
                     ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . $page['navigation_title'] . '</a>' . "\n";
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // get childs
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -971,7 +971,7 @@ class Model
                         null,
                         null,
                         ['id' => $page['page_id']]
-                    ) . '"><ins>&#160;</ins>' . $page['navigation_title'] . '</a>' . "\n";
+                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                     // insert subtree
                     $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1006,7 +1006,7 @@ class Model
                     null,
                     null,
                     ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . $page['navigation_title'] . '</a>' . "\n";
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1040,7 +1040,7 @@ class Model
                     null,
                     null,
                     ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . $page['navigation_title'] . '</a>' . "\n";
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);

--- a/src/Frontend/Core/Engine/Url.php
+++ b/src/Frontend/Core/Engine/Url.php
@@ -7,6 +7,7 @@ use ForkCMS\App\KernelLoader;
 use Frontend\Core\Language\Language;
 use SpoonFilter;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -43,7 +44,7 @@ class Url extends KernelLoader
                 'Redirect',
                 new RedirectResponse(
                     mb_substr(Model::getRequest()->getRequestUri(), 0, -1),
-                    301
+                    Response::HTTP_FOUND
                 )
             );
         }
@@ -268,7 +269,7 @@ class Url extends KernelLoader
         $url = rtrim('/' . $language . '/' . trim($this->getQueryString(), '/'), '/');
         // when we are just adding the language to the domain, it's a temporary redirect because
         // Safari keeps the 301 in cache, so the cookie to switch language doesn't work any more
-        $redirectCode = ($url === '/' . $language ? 302 : 301);
+        $redirectCode = ($url === '/' . $language) ? Response::HTTP_FOUND : Response::HTTP_MOVED_PERMANENTLY;
 
         // set header & redirect
         throw new RedirectException(


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
You cqn configure redirects in the backend and we also redirect to a child page if the parent is empty but those were permanent redirects. This made it hard to change it afterwards 
