### PR TITLE
Make max amount of display name changes dynamic

### DIFF
--- a/src/Backend/Modules/Profiles/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Profiles/Installer/Data/locale.xml
@@ -366,6 +366,14 @@
         <translation language="el"><![CDATA[Πλήθος μελών]]></translation>
         <translation language="pl"><![CDATA[liczba członków]]></translation>
       </item>
+      <item type="label" name="LimitDisplayNameChanges">
+        <translation language="nl"><![CDATA[Wijzigingen in weergavenaam beperken]]></translation>
+        <translation language="en"><![CDATA[Limit display name changes]]></translation>
+      </item>
+      <item type="label" name="DisplayNameChanges">
+        <translation language="nl"><![CDATA[Wijzigingen in weergavenaam]]></translation>
+        <translation language="en"><![CDATA[Display name changes]]></translation>
+      </item>
       <item type="label" name="NotificationNewProfileToAdmin">
         <translation language="nl"><![CDATA[Nieuw profiel voor %1$s is toegevoegd.]]></translation>
         <translation language="en"><![CDATA[New profile for %1$s has been created.]]></translation>
@@ -950,6 +958,10 @@
         <translation language="es"><![CDATA[Acción desconocida.]]></translation>
         <translation language="el"><![CDATA[Άγνωστη ενέργεια.]]></translation>
         <translation language="pl"><![CDATA[Nieznane działanie.]]></translation>
+      </item>
+      <item type="error" name="InvalidNumberOfChanges">
+        <translation language="nl"><![CDATA[The number of display name changes should be greater or equal to O]]></translation>
+        <translation language="en"><![CDATA[Het aantal wijzigingen in de weergavenaam moet groter of gelijk zijn aan 0]]></translation>
       </item>
     </Profiles>
     <Core>

--- a/src/Backend/Modules/Profiles/Installer/Installer.php
+++ b/src/Backend/Modules/Profiles/Installer/Installer.php
@@ -4,6 +4,7 @@ namespace Backend\Modules\Profiles\Installer;
 
 use Backend\Core\Installer\ModuleInstaller;
 use Common\ModuleExtraType;
+use Frontend\Modules\Profiles\Engine\Model;
 use SpoonFilter;
 use Symfony\Component\Filesystem\Filesystem;
 use Backend\Core\Language\Language;
@@ -360,6 +361,8 @@ class Installer extends ModuleInstaller
         $this->setSetting($this->getModule(), 'profile_notification_email', null);
         $this->setSetting($this->getModule(), 'send_mail_for_new_profile_to_admin', false);
         $this->setSetting($this->getModule(), 'send_mail_for_new_profile_to_profile', false);
+        $this->setSetting($this->getModule(), 'limit_display_name_changes', true);
+        $this->setSetting($this->getModule(), 'max_display_name_changes', Model::MAX_DISPLAY_NAME_CHANGES);
     }
 
     private function getExtraId(string $key): int

--- a/src/Backend/Modules/Profiles/Js/Profiles.js
+++ b/src/Backend/Modules/Profiles/Js/Profiles.js
@@ -74,11 +74,16 @@ jsBackend.Profiles = {
         jsBackend.Profiles.settings.toggleAdminMail()
       })
 
+      $('#limitDisplayNameChanges').on('change', function () {
+        jsBackend.Profiles.settings.toggleDisplayNameChanges()
+      })
+
       $('#overwriteProfileNotificationEmail').on('change', function () {
         jsBackend.Profiles.settings.toggleProfileNotificationEmail()
       })
 
       jsBackend.Profiles.settings.toggleAdminMail()
+      jsBackend.Profiles.settings.toggleDisplayNameChanges()
       jsBackend.Profiles.settings.toggleProfileNotificationEmail()
     },
 
@@ -87,6 +92,13 @@ jsBackend.Profiles = {
       var checked = ($item.attr('checked') === 'checked')
 
       $('#overwriteProfileNotificationEmailBox').toggle(checked)
+    },
+
+    toggleDisplayNameChanges: function () {
+      var $item = $('#limitDisplayNameChanges')
+      var checked = ($item.attr('checked') === 'checked')
+
+      $('#maxDisplayNameChangesBox').toggle(checked)
     },
 
     toggleProfileNotificationEmail: function () {

--- a/src/Backend/Modules/Profiles/Layout/Templates/Settings.html.twig
+++ b/src/Backend/Modules/Profiles/Layout/Templates/Settings.html.twig
@@ -13,6 +13,26 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h2 class="panel-title">
+            {{ 'lbl.DisplayNameChanges'|trans|ucfirst }}
+          </h2>
+        </div>
+        <div class="panel-body">
+          <div class="form-group">
+            <ul class="list-unstyled">
+              <li class="checkbox">
+                <label for="limitDisplayNameChanges" class="control-label">{% form_field limit_display_name_changes %} {{ 'lbl.LimitDisplayNameChanges'|trans|ucfirst }}</label>
+                <span id="maxDisplayNameChangesBox">
+                  {{ macro.required }} {% form_field max_display_name_changes %}
+                  {% form_field_error max_display_name_changes %}
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h2 class="panel-title">
             {{ 'lbl.Notifications'|trans|ucfirst }}
           </h2>
         </div>
@@ -24,9 +44,9 @@
               </li>
               <li class="checkbox" id="overwriteProfileNotificationEmailBox">
                 <label for="overwriteProfileNotificationEmail" class="control-label">{% form_field overwrite_profile_notification_email %} {{ 'lbl.OverwriteProfileNotificationEmail'|trans|ucfirst }}</label><br />
-                    <span id="profileNotificationEmailBox">
+                <span id="profileNotificationEmailBox">
                       {{ macro.required }} {% form_field profile_notification_email %}
-                      {% form_field_error profile_notification_email %}
+                  {% form_field_error profile_notification_email %}
                     </span>
               </li>
             </ul>

--- a/src/Frontend/Modules/Profiles/Actions/Settings.php
+++ b/src/Frontend/Modules/Profiles/Actions/Settings.php
@@ -125,7 +125,7 @@ class Settings extends FrontendBaseBlock
 
     private function displayNameCanStillBeChanged(): bool
     {
-        return $this->getAmountOfDisplayNameChanges() < FrontendProfilesModel::MAX_DISPLAY_NAME_CHANGES;
+        return FrontendProfilesModel::displayNameCanStillBeChanged($this->profile);
     }
 
     private function validateForm(): bool

--- a/src/Frontend/Modules/Profiles/Engine/Model.php
+++ b/src/Frontend/Modules/Profiles/Engine/Model.php
@@ -6,6 +6,7 @@ use Common\Uri as CommonUri;
 use Frontend\Core\Engine\Model as FrontendModel;
 use Frontend\Core\Engine\Navigation as FrontendNavigation;
 use Frontend\Modules\Profiles\Engine\Authentication as FrontendProfilesAuthentication;
+use Frontend\Modules\Profiles\Engine\Model as FrontendProfilesModel;
 use Frontend\Modules\Profiles\Engine\Profile as FrontendProfilesProfile;
 
 /**
@@ -21,6 +22,21 @@ class Model
      * @var array
      */
     private static $avatars = [];
+
+    public static function maxDisplayNameChanges(): int
+    {
+        return FrontendModel::getModuleSetting('Profiles', 'max_display_name_changes', self::MAX_DISPLAY_NAME_CHANGES);
+    }
+
+    public static function displayNameCanStillBeChanged(Profile $profile): bool
+    {
+        if (!FrontendModel::getModuleSetting('Profiles', 'limit_display_name_changes', false)) {
+            return true;
+        }
+
+        return (int) FrontendProfilesModel::getSetting($profile->getId(), 'display_name_changes') <
+            self::maxDisplayNameChanges();
+    }
 
     public static function deleteSetting(int $profileId, string $name): int
     {


### PR DESCRIPTION
## Type
- Enhancement

## Pull request description
Not every user needs a limitation on display name changes. This change allow the admin to set the number of changes or make it unlimited
