### PR TITLE
Setup overview with pages for each language

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -840,11 +840,11 @@ class Model
 
                 // insert link
                 $html .= '    <a href="' . BackendModel::createUrlForAction(
-                    'Edit',
-                    null,
-                    null,
-                    ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                        'Edit',
+                        null,
+                        null,
+                        ['id' => $page['page_id']]
+                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // get childs
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -937,11 +937,11 @@ class Model
         // create homepage anchor from title
         $homePage = self::get(BackendModel::HOME_PAGE_ID);
         $html .= '            <a href="' . BackendModel::createUrlForAction(
-            'Edit',
-            null,
-            null,
-            ['id' => BackendModel::HOME_PAGE_ID]
-        ) . '"><ins>&#160;</ins>' . $homePage['title'] . '</a>' . "\n";
+                'Edit',
+                null,
+                null,
+                ['id' => BackendModel::HOME_PAGE_ID]
+            ) . '"><ins>&#160;</ins>' . $homePage['title'] . '</a>' . "\n";
 
         // add subpages
         $html .= self::getSubtree($navigation, BackendModel::HOME_PAGE_ID);
@@ -967,11 +967,11 @@ class Model
 
                     // insert link
                     $html .= '            <a href="' . BackendModel::createUrlForAction(
-                        'Edit',
-                        null,
-                        null,
-                        ['id' => $page['page_id']]
-                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                            'Edit',
+                            null,
+                            null,
+                            ['id' => $page['page_id']]
+                        ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                     // insert subtree
                     $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1002,11 +1002,11 @@ class Model
 
                 // insert link
                 $html .= '            <a href="' . BackendModel::createUrlForAction(
-                    'Edit',
-                    null,
-                    null,
-                    ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                        'Edit',
+                        null,
+                        null,
+                        ['id' => $page['page_id']]
+                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1036,11 +1036,11 @@ class Model
 
                 // insert link
                 $html .= '            <a href="' . BackendModel::createUrlForAction(
-                    'Edit',
-                    null,
-                    null,
-                    ['id' => $page['page_id']]
-                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                        'Edit',
+                        null,
+                        null,
+                        ['id' => $page['page_id']]
+                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1415,19 +1415,22 @@ class Model
     /**
      * @param array $page
      */
-    public static function updateByIdAndRevisionId(array $page): void
+    public static function updateRevisionData(int $pageId, int $revisionId, array $data): void
     {
         // get database
         $database = BackendModel::getContainer()->get('database');
 
+        // serialize the data
+        $data['data'] = serialize($data['data']);
+
         $database->update(
             'pages',
-            $page,
+            $data,
             'id = ? AND revision_id = ?',
-            [(int) $page['id'], (int) $page['revision_id']]
+            [$pageId, $revisionId]
         );
     }
-    
+
     /**
      * Switch templates for all existing pages
      *
@@ -1583,11 +1586,11 @@ class Model
         // calculate new sequence for items that should be moved inside
         if ($typeOfDrop === self::TYPE_OF_DROP_INSIDE) {
             $newSequence = (int) $database->getVar(
-                'SELECT MAX(i.sequence)
+                    'SELECT MAX(i.sequence)
                  FROM pages AS i
                  WHERE i.id = ? AND i.language = ? AND i.status = ?',
-                [$newParent, $language, 'active']
-            ) + 1;
+                    [$newParent, $language, 'active']
+                ) + 1;
 
             $database->update(
                 'pages',

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1413,6 +1413,22 @@ class Model
     }
 
     /**
+     * @param array $page
+     */
+    public static function updateByIdAndRevisionId(array $page): void
+    {
+        // get database
+        $database = BackendModel::getContainer()->get('database');
+
+        $database->update(
+            'pages',
+            $page,
+            'id = ? AND revision_id = ?',
+            [(int) $page['id'], (int) $page['revision_id']]
+        );
+    }
+    
+    /**
      * Switch templates for all existing pages
      *
      * @param int $oldTemplateId The id of the new template to replace.

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -840,11 +840,11 @@ class Model
 
                 // insert link
                 $html .= '    <a href="' . BackendModel::createUrlForAction(
-                        'Edit',
-                        null,
-                        null,
-                        ['id' => $page['page_id']]
-                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                    'Edit',
+                    null,
+                    null,
+                    ['id' => $page['page_id']]
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // get childs
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -937,11 +937,11 @@ class Model
         // create homepage anchor from title
         $homePage = self::get(BackendModel::HOME_PAGE_ID);
         $html .= '            <a href="' . BackendModel::createUrlForAction(
-                'Edit',
-                null,
-                null,
-                ['id' => BackendModel::HOME_PAGE_ID]
-            ) . '"><ins>&#160;</ins>' . $homePage['title'] . '</a>' . "\n";
+            'Edit',
+            null,
+            null,
+            ['id' => BackendModel::HOME_PAGE_ID]
+        ) . '"><ins>&#160;</ins>' . $homePage['title'] . '</a>' . "\n";
 
         // add subpages
         $html .= self::getSubtree($navigation, BackendModel::HOME_PAGE_ID);
@@ -967,11 +967,11 @@ class Model
 
                     // insert link
                     $html .= '            <a href="' . BackendModel::createUrlForAction(
-                            'Edit',
-                            null,
-                            null,
-                            ['id' => $page['page_id']]
-                        ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                        'Edit',
+                        null,
+                        null,
+                        ['id' => $page['page_id']]
+                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                     // insert subtree
                     $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1002,11 +1002,11 @@ class Model
 
                 // insert link
                 $html .= '            <a href="' . BackendModel::createUrlForAction(
-                        'Edit',
-                        null,
-                        null,
-                        ['id' => $page['page_id']]
-                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                    'Edit',
+                    null,
+                    null,
+                    ['id' => $page['page_id']]
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1036,11 +1036,11 @@ class Model
 
                 // insert link
                 $html .= '            <a href="' . BackendModel::createUrlForAction(
-                        'Edit',
-                        null,
-                        null,
-                        ['id' => $page['page_id']]
-                    ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
+                    'Edit',
+                    null,
+                    null,
+                    ['id' => $page['page_id']]
+                ) . '"><ins>&#160;</ins>' . htmlspecialchars($page['navigation_title']) . '</a>' . "\n";
 
                 // insert subtree
                 $html .= self::getSubtree($navigation, $page['page_id']);
@@ -1430,7 +1430,7 @@ class Model
             [$pageId, $revisionId]
         );
     }
-    
+
     /**
      * Switch templates for all existing pages
      *
@@ -1586,11 +1586,11 @@ class Model
         // calculate new sequence for items that should be moved inside
         if ($typeOfDrop === self::TYPE_OF_DROP_INSIDE) {
             $newSequence = (int) $database->getVar(
-                    'SELECT MAX(i.sequence)
+                'SELECT MAX(i.sequence)
                  FROM pages AS i
                  WHERE i.id = ? AND i.language = ? AND i.status = ?',
-                    [$newParent, $language, 'active']
-                ) + 1;
+                [$newParent, $language, 'active']
+            ) + 1;
 
             $database->update(
                 'pages',

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -1430,7 +1430,7 @@ class Model
             [$pageId, $revisionId]
         );
     }
-
+    
     /**
      * Switch templates for all existing pages
      *

--- a/src/Backend/Modules/Settings/Actions/Seo.php
+++ b/src/Backend/Modules/Settings/Actions/Seo.php
@@ -4,7 +4,9 @@ namespace Backend\Modules\Settings\Actions;
 
 use Backend\Core\Engine\Base\ActionIndex as BackendBaseActionIndex;
 use Backend\Core\Engine\Form as BackendForm;
+use Backend\Core\Engine\Model as BackendModel;
 use Backend\Core\Language\Language as BL;
+use Backend\Modules\Pages\Engine\Model as BackendPagesModel;
 
 /**
  * This is the SEO-action, it will display a form to set SEO settings
@@ -18,9 +20,38 @@ class Seo extends BackendBaseActionIndex
      */
     private $form;
 
+    /**
+     * @var bool
+     */
+    private $isMultiLangual;
+
+    /**
+     * The array of active languages
+     *
+     * @var array
+     */
+    private $languages = [];
+
+    /**
+     * Array of pages in the current working language
+     * @var array
+     */
+    private $workingLanguagePages = [];
+
+    /**
+     * Fields for linking the pages through the languages
+     *
+     * @var array
+     */
+    private $langFields = [];
+
+
     public function execute(): void
     {
         parent::execute();
+
+        $this->isMultiLangual = BackendModel::getContainer()->getParameter('site.multilanguage');
+
         $this->loadForm();
         $this->validateForm();
         $this->parse();
@@ -36,11 +67,37 @@ class Seo extends BackendBaseActionIndex
             'seo_nofollow_in_comments',
             $this->get('fork.settings')->get('Core', 'seo_nofollow_in_comments', false)
         );
+
+        if ($this->isMultiLangual) {
+            $this->workingLanguagePages = BackendPagesModel::getPagesForDropdown(
+                BL::getWorkingLanguage()
+            );
+            $this->languages = BL::getWorkingLanguages();
+
+            // loop through pages and build dropdown for each language
+            foreach ($this->workingLanguagePages as $pageId => $pageTitle) {
+                $pageData = BackendPagesModel::get($pageId);
+                foreach ($this->languages as $lang => $language) {
+                    if ($lang == BL::getWorkingLanguage()) {
+                        $this->langFields[$pageId][$lang]['title'] = $pageTitle;
+                    } else {
+                        $langPages = BackendPagesModel::getPagesForDropdown($lang);
+                        $ddn = $this->form->addDropdown('page_' . $lang . '_' . $pageId, $langPages, isset($pageData['data']['hreflang_' . $lang]) ? $pageData['data']['hreflang_' . $lang] : null)->setDefaultElement('');
+                        $this->langFields[$pageId][$lang]['field'] = $ddn->parse();
+                    }
+                }
+            }
+        }
     }
 
     protected function parse(): void
     {
         parent::parse();
+
+        if ($this->isMultiLangual) {
+            $this->template->assign('langFields', $this->langFields);
+            $this->template->assign('languages', $this->languages);
+        }
 
         $this->form->parse($this->template);
     }
@@ -59,6 +116,25 @@ class Seo extends BackendBaseActionIndex
                     'seo_nofollow_in_comments',
                     $this->form->getField('seo_nofollow_in_comments')->getValue()
                 );
+
+                if ($this->isMultiLangual) {
+                    // save the linked pages for each language
+                    foreach ($this->workingLanguagePages as $pageId => $pageTitle) {
+                        $pageData = BackendPagesModel::get($pageId);
+                        $update['id'] = (int)$pageData['id'];
+                        $update['revision_id'] = (int)$pageData['revision_id'];
+                        $update['data'] = $pageData['data'];
+
+                        foreach ($this->languages as $lang => $language) {
+                            if ($lang != BL::getWorkingLanguage()) {
+                                $update['data']['hreflang_' . $lang] = $this->form->getField('page_' . $lang . '_' . $pageId)->getValue();
+                            }
+                        }
+
+                        $update['data'] = serialize($update['data']);
+                        BackendPagesModel::updateByIdAndRevisionId($update);
+                    }
+                }
 
                 // assign report
                 $this->template->assign('report', true);

--- a/src/Backend/Modules/Settings/Actions/Seo.php
+++ b/src/Backend/Modules/Settings/Actions/Seo.php
@@ -121,18 +121,15 @@ class Seo extends BackendBaseActionIndex
                     // save the linked pages for each language
                     foreach ($this->workingLanguagePages as $pageId => $pageTitle) {
                         $pageData = BackendPagesModel::get($pageId);
-                        $update['id'] = (int)$pageData['id'];
-                        $update['revision_id'] = (int)$pageData['revision_id'];
-                        $update['data'] = $pageData['data'];
+                        $data['data'] = $pageData['data'];
 
                         foreach ($this->languages as $lang => $language) {
                             if ($lang != BL::getWorkingLanguage()) {
-                                $update['data']['hreflang_' . $lang] = $this->form->getField('page_' . $lang . '_' . $pageId)->getValue();
+                                $data['data']['hreflang_' . $lang] = $this->form->getField('page_' . $lang . '_' . $pageId)->getValue();
                             }
                         }
 
-                        $update['data'] = serialize($update['data']);
-                        BackendPagesModel::updateByIdAndRevisionId($update);
+                        BackendPagesModel::updateRevisionData($pageData['id'], $pageData['revision_id'], $data);
                     }
                 }
 

--- a/src/Backend/Modules/Settings/Installer/Data/locale.xml
+++ b/src/Backend/Modules/Settings/Installer/Data/locale.xml
@@ -499,6 +499,10 @@
         <translation language="en"><![CDATA[The cache has been successfully cleared.]]></translation>
         <translation language="pl"><![CDATA[Pamięć podręczna została pomyślnie wyczyszczona.]]></translation>
       </item>
+      <item type="label" name="LinkedPagesPerLanguage">
+        <translation language="nl"><![CDATA[gelinkte pagina's per taal]]></translation>
+        <translation language="en"><![CDATA[linked pages per language]]></translation>
+      </item>
       <item type="message" name="NoAdminIds">
         <translation language="nl"><![CDATA[Nog geen admin-ids]]></translation>
         <translation language="en"><![CDATA[No admin ids yet.]]></translation>

--- a/src/Backend/Modules/Settings/Layout/Templates/Seo.html.twig
+++ b/src/Backend/Modules/Settings/Layout/Templates/Seo.html.twig
@@ -33,6 +33,43 @@
           </div>
         </div>
       </div>
+      {% if langFields %}
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h2 class="panel-title">
+              {{ 'lbl.LinkedPagesPerLanguage'|trans|ucfirst }}
+            </h2>
+          </div>
+          <div class="panel-body">
+            <div class="form-group last">
+              <table class="table table-hover table-striped fork-data-grid jsDataGrid">
+                <thead>
+                  <tr>
+                    {% for lang in languages %}
+                      <th>{{ lang }}</th>
+                    {% endfor %}
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for pageId, item in langFields %}
+                    <tr class="{% if loop.index%2 == 0 %}odd{% else %}even{% endif %}">
+                      {% for lang, data in item %}
+                        <td>
+                          {% if data.field %}
+                            {{ data.field|raw }}
+                          {% else %}
+                            {{ data.title }}
+                          {% endif%}
+                        </td>
+                      {% endfor %}
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
   <div class="row fork-module-actions">


### PR DESCRIPTION
## Type
- Feature

## Pull request description

When you have multiple languages and add pages (after install) the hreflang link between the languages is no longer insured. As these meta info is pretty important for Google, I think it's useful to have a global overview where it's possible to quickly change linked pages. This is much faster than manually edit the page...
I came along (after a quick setup) with the following:
<img width="1612" alt="Schermafbeelding 2020-05-24 om 22 37 27" src="https://user-images.githubusercontent.com/4540274/82789291-55b70080-9e6a-11ea-9498-5a29e5d40093.png">

- at the right column you see the Working Language (still has to be ordered at the left)
- the other 2 columns are the other 2 installed languages (FR and ENG in the example)
- the dropdowns are the values you can set for each page individually in the SEO tab

To do:
- put the working language as the first column in the datagrid
- maybe we can show warnings if there are "empty values" in the dropdowns, so these links are correct?
- code optimizations
