### PR TITLE
Use w-100 task instead of deprecated img-responsive

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Resources/views/CropperDialog.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/CropperDialog.html.twig
@@ -5,7 +5,7 @@
       <h4 class="modal-title" id="mediaLibraryCropperModalTitle">{{ 'lbl.CropImage'|trans|ucfirst }}</h4>
     </div>
     <div class="modal-body" data-role="media-library-cropper-dialog-body">
-      <div class="img-responsive" data-role="media-library-cropper-dialog-canvas-wrapper"></div>
+      <div class="w-100" data-role="media-library-cropper-dialog-canvas-wrapper"></div>
     </div>
     <div class="modal-footer d-flex justify-content-center">
       <div class="btn-toolbar" role="toolbar">


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

The container of the cropper was too large for images that where larger than the cropper.
The issues was caused by a css class for images that does not exist anymore in Bootstrap 4. It was ignored by the conversion because it was an image class on a a div.