### PR TITLE
Bugfix: Skip default photo cropping if unchecked

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -1038,10 +1038,16 @@ jsBackend.mediaLibraryHelper.upload = {
       --jsBackend.mediaLibraryHelper.upload.uploadedCount
       jsBackend.mediaLibraryHelper.group.validateMinimumMaximumCount()
     })
+
+    // bind change to "Enable cropper" checkbox
+    $('[data-role="enable-cropper-checkbox"]').on('change', function () {
+      // Reset the fineuploader upload box so we can skip or use a scaling config for the cropper
+      $('#fine-uploader-gallery').unbind().empty()
+      jsBackend.mediaLibraryHelper.upload.init()
+    })
   },
 
   toggleCropper: function () {
-    // the cropper is mandatory
     var $formGroup = $('[data-role="cropper-is-mandatory-form-group"]')
     var $warning = $('[data-role="cropper-is-mandatory-message"]')
     var $checkbox = $('[data-role="enable-cropper-checkbox"]')
@@ -1154,6 +1160,14 @@ jsBackend.mediaLibraryHelper.upload = {
    * Configure the uploader to trigger the cropper
    */
   getScalingConfig: function () {
+    // Skip scaling config for cropping if we don't have cropping enabled
+    if (!$('[data-role="enable-cropper-checkbox"]').is(':checked')) {
+      return {
+        includeExif: false,
+      }
+    }
+
+    // Add a scaling config with custom resizer for our cropper feature
     return {
       includeExif: false, // needs to be false to prevent issues during the cropping process, it also is good for privacy reasons
       sendOriginal: false,


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
Fixes #2877

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
When we upload an image, it gets passed to the cropper by default, even if the cropper checkbox is unchecked before uploading. As Stijn mentions in #2877 when you upload his image of 392KB you end up with an image of 455KB. 
By adding an early return in the scaling config, we bypass the cropper logic and end up with an uploaded image of 392KB still ✅ 

However, the Fine Uploader gets initialized when the page loads. Therefore, when we toggle the checkbox we have to destroy the uploader dropzone and re-init fineuploader with no scaling config (if cropper is disabled) or with custom scaling config (if cropper is enabled). 

This fix will also allow for a fix for #3150 as the EXIF data is only removed when using the cropper 🙌 This means LiipImagineBundle can rotate images and strip the exif data properly. 

![Screenshot 2020-07-19 at 14 21 17](https://user-images.githubusercontent.com/1352979/87874568-2d133900-c9cb-11ea-864a-d1cb108df792.png)
