### PR TITLE
Bugfix: Fix rotation of images based on exif and strip metadata

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -86,6 +86,10 @@ liip_imagine:
             quality: 95
             # list of transformations to apply (the "filters")
             filters:
+                # auto rotate the image using EXIF metadata and then strip the metadata (privacy)
+                auto_rotate: ~
+                strip: ~
+
                 ## Using the "thumbnail + background" combination will crop the
                 ## the centered image to create your required width/height.
                 # Use the "outbound" mode to crop the image when the size ratio of the input differs
@@ -93,15 +97,31 @@ liip_imagine:
                 background: { size : [140, 90], position : center }
         media_library_lightbox_small:
             filters:
+                # auto rotate the image using EXIF metadata and then strip the metadata (privacy)
+                auto_rotate: ~
+                strip: ~
+
                 scale: { dim : [800, 600] }
         media_library_lightbox_large:
             filters:
+                # auto rotate the image using EXIF metadata and then strip the metadata (privacy)
+                auto_rotate: ~
+                strip: ~
+
                 scale: { dim : [1600, 800] }
         media_library_slider_pano:
             filters:
+                # auto rotate the image using EXIF metadata and then strip the metadata (privacy)
+                auto_rotate: ~
+                strip: ~
+
                 scale: { dim : [1600, 600] }
         media_library_one_image_large:
             filters:
+                # auto rotate the image using EXIF metadata and then strip the metadata (privacy)
+                auto_rotate: ~
+                strip: ~
+
                 thumbnail: { size : [1600, 500], mode : inbound }
 
 services:

--- a/docs/07. media library/04. image management.md
+++ b/docs/07. media library/04. image management.md
@@ -6,7 +6,9 @@ The media library module uses the [Liip Imagine Bundle](http://symfony.com/doc/1
 
 **Default image filters**
 
-* The media library in fork comes with 5 predefined filters. The 5 predefined filters can be found in `app/config/config.yml`, [view config.yml here](../../app/config/config.yml).
+* The media library in fork comes with 5 predefined filters. The 5 predefined filters can be found in `app/config/config.yml`, [view config.yml here](../../app/config/config.yml). 
+Each filter starts with an [`auto_rotate`](https://symfony.com/doc/2.0/bundles/LiipImagineBundle/filters/orientation.html#auto-rotate) and [`strip`](https://symfony.com/doc/2.0/bundles/LiipImagineBundle/filters/general.html#strip) 
+filter to ensure that uploaded images are rotated correctly (based on EXIF metadata) and stripped from that EXIF metadata as that data can contain sensitive information. 
 
 **Custom image filters**
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
Fixes #3150

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
As described in #3150 there's an issue with images getting incorrectly rotated if they contain EXIF rotation data. 

There is a dependency on the fix of https://github.com/forkcms/forkcms/pull/3151, where the cropper gets bypassed by default. This means that php still receives a source image with EXIF data. Before this fix, the source image would contain no EXIF data anymore. 

Using the `auto_rotate` and `strip` filter from LiipImagineBundle we can rotate the image based on EXIF data and then we still strip the exif metadata from the thumbnails as this contains privacy info (location, camera type, ...). The order of the filters is important here according to the LiipImagineBundle docs. 

https://symfony.com/doc/2.0/bundles/LiipImagineBundle/filters/orientation.html#auto-rotate
https://symfony.com/doc/2.0/bundles/LiipImagineBundle/filters/general.html#strip



End result: images are no longer rotated incorrectly
![image](https://user-images.githubusercontent.com/1352979/87876274-5f2a9800-c9d7-11ea-8480-237edb304270.png)
