### PR TITLE
Bugfix move blocks between positions

### DIFF
--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1588,8 +1588,8 @@
       var searchFor = fromBlockName
       var replaceWith = toBlockName
       if (fromBlockName !== toBlockName) {
-        searchFor += prefix + currentIndex
-        replaceWith += prefix + newIndex
+        searchFor += prefix + currentIndex + suffix
+        replaceWith += prefix + newIndex + suffix
       }
 
       return oldString.replace(searchFor, replaceWith)

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1585,23 +1585,32 @@
       })
     },
 
+    buildNewString: function(oldString, fromBlockName, toBlockName, currentIndex, newIndex, prefix = '', suffix = '') {
+      var searchFor = fromBlockName
+      var replaceWith = toBlockName
+      if (fromBlockName !== toBlockName) {
+        searchFor += prefix + currentIndex
+        replaceWith += prefix + newIndex
+      }
+
+      return oldString.replace(searchFor, replaceWith)
+    },
+
     saveNewGroup: function (event) {
+      var $this = this;
       var fromBlockName = $(event.from).data('position')
       var toBlockName = $(event.to).data('position')
+      var currentFieldIndex = null
+      var newFieldIndex = event.newIndex
+      var $sequenceField = $(event.item).find(sequenceField)
+      var currentId = $sequenceField.attr('id')
 
-      var positionHasChanged = (fromBlockName != toBlockName)
-      if(positionHasChanged) {
-        var $sequenceField = $(event.item).find(sequenceField)
-        var currentId = $sequenceField.attr('id')
-
-        var currentFieldIndex = this.getFieldIndexFromString(currentId)
-        if(currentFieldIndex === -1) {
+      if (fromBlockName !== toBlockName) {
+        currentFieldIndex = this.getFieldIndexFromString(currentId)
+        if (currentFieldIndex === -1) {
           console.error('Could not find the index.')
         }
-
-        var newFieldIndex = event.newIndex
         var regexp = new RegExp(fromBlockName + '_' + currentFieldIndex, 'g')
-
         while ($('#' + currentId.replace(regexp, toBlockName + '_' + newFieldIndex)).length > 0) {
           newFieldIndex++
         }
@@ -1609,47 +1618,27 @@
 
       $(event.item).find('[id*="' + fromBlockName + '"]').each(function (index, item) {
         var oldId = $(item).attr('id')
-        var searchFor = fromBlockName
-        var replaceWith = toBlockName
-        if(positionHasChanged) {
-          searchFor += '_' + currentFieldIndex
-          replaceWith += '_' + newFieldIndex
-        }
-        var newId = oldId.replace(searchFor, replaceWith)
+        var newId = $this.buildNewString(oldId, fromBlockName, toBlockName, currentFieldIndex, newFieldIndex, '_')
 
         $(item).attr('id', newId)
       })
 
       $(event.item).find('[aria-labelledby*="' + fromBlockName + '"]').each(function (index, item) {
-        var searchFor = fromBlockName
-        var replaceWith = toBlockName
-        if(positionHasChanged) {
-          searchFor += '_' + currentFieldIndex
-          replaceWith += '_' + newFieldIndex
-        }
-
         var oldLabel = $(item).attr('aria-labelledby')
-        var newLabel = oldLabel.replace(searchFor, replaceWith)
+        var newLabel = $this.buildNewString(oldLabel, fromBlockName, toBlockName, currentFieldIndex, newFieldIndex, '_')
 
         $(item).attr('aria-labelledby', newLabel)
       })
 
       $(event.item).find('[name*="' + fromBlockName + '"]').each(function (index, item) {
-        var searchFor = fromBlockName
-        var replaceWith = toBlockName
-        if(positionHasChanged) {
-          searchFor += '][' + currentFieldIndex + ']'
-          replaceWith += '][' + newFieldIndex + ']'
-        }
-
         var oldName = $(item).attr('name')
-        var newName = oldName.replace(searchFor, replaceWith)
+        var newName = $this.buildNewString(oldName, fromBlockName, toBlockName, currentFieldIndex, newFieldIndex, '][', ']')
 
         $(item).attr('name', newName)
       })
 
       $('[data-position="' + toBlockName + '"] li.list-group-item').each(function (index, item) {
-        $(item).find('[data-role="sequence"]').val(index)
+        $(item).find(sequenceField).val(index)
       })
     }
   }

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1568,7 +1568,6 @@
       var chunks = name.split('_')
 
       for(var chunk of chunks) {
-        // if the
         if(!isNaN(+chunk)) {
           return (+chunk)
         }

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1589,29 +1589,66 @@
       var fromBlockName = $(event.from).data('position')
       var toBlockName = $(event.to).data('position')
 
+      var positionHasChanged = (fromBlockName != toBlockName)
+      if(positionHasChanged) {
+        var $sequenceField = $(event.item).find(sequenceField)
+        var currentId = $sequenceField.attr('id')
+
+        var currentFieldIndex = this.getFieldIndexFromString(currentId)
+        if(currentFieldIndex === -1) {
+          console.error('Could not find the index.')
+        }
+
+        var newFieldIndex = event.newIndex
+        var regexp = new RegExp(fromBlockName + '_' + currentFieldIndex, 'g')
+
+        while ($('#' + currentId.replace(regexp, toBlockName + '_' + newFieldIndex)).length > 0) {
+          newFieldIndex++
+        }
+      }
+
       $(event.item).find('[id*="' + fromBlockName + '"]').each(function (index, item) {
         var oldId = $(item).attr('id')
-        var newId = oldId.replace(fromBlockName, toBlockName)
+        var searchFor = fromBlockName
+        var replaceWith = toBlockName
+        if(positionHasChanged) {
+          searchFor += '_' + currentFieldIndex
+          replaceWith += '_' + newFieldIndex
+        }
+        var newId = oldId.replace(searchFor, replaceWith)
 
         $(item).attr('id', newId)
       })
 
       $(event.item).find('[aria-labelledby*="' + fromBlockName + '"]').each(function (index, item) {
+        var searchFor = fromBlockName
+        var replaceWith = toBlockName
+        if(positionHasChanged) {
+          searchFor += '_' + currentFieldIndex
+          replaceWith += '_' + newFieldIndex
+        }
+
         var oldLabel = $(item).attr('aria-labelledby')
-        var newLabel = oldLabel.replace(fromBlockName, toBlockName)
+        var newLabel = oldLabel.replace(searchFor, replaceWith)
 
         $(item).attr('aria-labelledby', newLabel)
       })
 
       $(event.item).find('[name*="' + fromBlockName + '"]').each(function (index, item) {
+        var searchFor = fromBlockName
+        var replaceWith = toBlockName
+        if(positionHasChanged) {
+          searchFor += '][' + currentFieldIndex + ']'
+          replaceWith += '][' + newFieldIndex + ']'
+        }
+
         var oldName = $(item).attr('name')
-        var newName = oldName.replace(fromBlockName, toBlockName)
+        var newName = oldName.replace(searchFor, replaceWith)
 
         $(item).attr('name', newName)
       })
 
       $('[data-position="' + toBlockName + '"] li.list-group-item').each(function (index, item) {
-        console.log($(item).find('[data-role="sequence"]'))
         $(item).find('[data-role="sequence"]').val(index)
       })
     }

--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -1564,6 +1564,18 @@
       })
     },
 
+    getFieldIndexFromString: function(name) {
+      var chunks = name.split('_')
+
+      for(var chunk of chunks) {
+        // if the
+        if(!isNaN(+chunk)) {
+          return (+chunk)
+        }
+      }
+      return -1
+    },
+
     // TODO This might be deleted now we have saveNewGroup
     saveNewSequence: function ($sequenceBody) {
       var counter = 0


### PR DESCRIPTION
## Type

- Critical bugfix

## Pull request description

In the [use-new-sortable-js](https://github.com/forkcms/forkcms/tree/use-new-sortable-js-plugin)-branch there was an issue when you moved blocks from one position to another. In some cases the block would disappear when saving the page. 

In each position the blocks are stored with some hidden fields, but while the "position" was updated, the "index" of the field was not, so it could happen that the same "index" was multiple times in the same "position".

This PR fixes this.
