### PR TITLE
Replace SpoonFileCSV

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -235,6 +235,9 @@ services:
         arguments:
             - "%kernel.charset%"
 
+    ForkCMS\Utility\Csv\Reader:
+        public: true
+
     templating:
         class: Frontend\Core\Engine\TwigTemplate
         public: true

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -230,6 +230,11 @@ services:
         arguments:
             - "%site.path_www%"
 
+    ForkCMS\Utility\Csv\Writer:
+        public: true
+        arguments:
+            - "%kernel.charset%"
+
     templating:
         class: Frontend\Core\Engine\TwigTemplate
         public: true

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "symfony/swiftmailer-bundle": "^3.0",
         "symfony/symfony": "^3.3",
         "tijsverkoyen/akismet": "1.1.*",
-        "tijsverkoyen/css-to-inline-styles": "1.5.*"
+        "tijsverkoyen/css-to-inline-styles": "1.5.*",
+        "phpoffice/phpspreadsheet": "^1.14"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2e3406bdfabb19c63955407925d6e30",
+    "content-hash": "8afcb68fca7ea8fc485f66a76b1fe832",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -128,13 +128,13 @@
             "authors": [
                 {
                     "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de",
-                    "role": "Lead Developer"
+                    "role": "Lead Developer",
+                    "email": "kontakt@beberlei.de"
                 },
                 {
                     "name": "Richard Quadling",
-                    "email": "rquadling@gmail.com",
-                    "role": "Collaborator"
+                    "role": "Collaborator",
+                    "email": "rquadling@gmail.com"
                 }
             ],
             "description": "Thin assertion library for input validation in business models.",
@@ -235,8 +235,8 @@
             "authors": [
                 {
                     "name": "Toby Brain",
-                    "email": "tobio85@gmail.com",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "tobio85@gmail.com"
                 }
             ],
             "description": "A php library which implements the complete functionality of the Campaign Monitor API.",
@@ -1326,20 +1326,6 @@
                 "orm",
                 "persistence"
             ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-21T15:13:52+00:00"
         },
         {
@@ -2061,9 +2047,9 @@
             "authors": [
                 {
                     "name": "Jeroen Desloovere",
+                    "role": "Developer",
                     "email": "info@jeroendesloovere.be",
-                    "homepage": "http://jeroendesloovere.be",
-                    "role": "Developer"
+                    "homepage": "http://jeroendesloovere.be"
                 }
             ],
             "description": "This Geolocation PHP class connects to Google Maps API to find latitude/longitude or address.",
@@ -2440,6 +2426,73 @@
             "time": "2017-09-09T03:53:30+00:00"
         },
         {
+            "name": "maennchen/zipstream-php",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "shasum": ""
+            },
+            "require": {
+                "myclabs/php-enum": "^1.5",
+                "php": ">= 7.1",
+                "psr/http-message": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": ">= 6.3",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": ">= 7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "funding": [
+                {
+                    "url": "https://opencollective.com/zipstream",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2020-05-30T13:11:16+00:00"
+        },
+        {
             "name": "mailmotor/campaignmonitor-bundle",
             "version": "2.0.0",
             "source": {
@@ -2566,9 +2619,9 @@
             "authors": [
                 {
                     "name": "Jeroen Desloovere",
+                    "role": "Developer",
                     "email": "info@jeroendesloovere.be",
-                    "homepage": "http://jeroendesloovere.be",
-                    "role": "Developer"
+                    "homepage": "http://jeroendesloovere.be"
                 }
             ],
             "description": "This Symfony bundle loads in MailMotor as a service. So you can subscribe/unsubscribe members to any mailinglist managing API. F.e.: MailChimp, CampaignMonitor, ...",
@@ -2579,6 +2632,170 @@
                 "symfony"
             ],
             "time": "2018-06-11T09:33:45+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "8eaa40cceec7bf0518187530b2e63871be661b72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/8eaa40cceec7bf0518187530b2e63871be661b72",
+                "reference": "8eaa40cceec7bf0518187530b2e63871be661b72",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6.0|^7.0.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "2.*",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^4.8.35|^5.4.0",
+                "sebastian/phpcpd": "2.*",
+                "squizlabs/php_codesniffer": "^3.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                },
+                "files": [
+                    "classes/src/functions/abs.php",
+                    "classes/src/functions/acos.php",
+                    "classes/src/functions/acosh.php",
+                    "classes/src/functions/acot.php",
+                    "classes/src/functions/acoth.php",
+                    "classes/src/functions/acsc.php",
+                    "classes/src/functions/acsch.php",
+                    "classes/src/functions/argument.php",
+                    "classes/src/functions/asec.php",
+                    "classes/src/functions/asech.php",
+                    "classes/src/functions/asin.php",
+                    "classes/src/functions/asinh.php",
+                    "classes/src/functions/atan.php",
+                    "classes/src/functions/atanh.php",
+                    "classes/src/functions/conjugate.php",
+                    "classes/src/functions/cos.php",
+                    "classes/src/functions/cosh.php",
+                    "classes/src/functions/cot.php",
+                    "classes/src/functions/coth.php",
+                    "classes/src/functions/csc.php",
+                    "classes/src/functions/csch.php",
+                    "classes/src/functions/exp.php",
+                    "classes/src/functions/inverse.php",
+                    "classes/src/functions/ln.php",
+                    "classes/src/functions/log2.php",
+                    "classes/src/functions/log10.php",
+                    "classes/src/functions/negative.php",
+                    "classes/src/functions/pow.php",
+                    "classes/src/functions/rho.php",
+                    "classes/src/functions/sec.php",
+                    "classes/src/functions/sech.php",
+                    "classes/src/functions/sin.php",
+                    "classes/src/functions/sinh.php",
+                    "classes/src/functions/sqrt.php",
+                    "classes/src/functions/tan.php",
+                    "classes/src/functions/tanh.php",
+                    "classes/src/functions/theta.php",
+                    "classes/src/operations/add.php",
+                    "classes/src/operations/subtract.php",
+                    "classes/src/operations/multiply.php",
+                    "classes/src/operations/divideby.php",
+                    "classes/src/operations/divideinto.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "time": "2020-03-11T20:15:49+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "5348c5a67e3b75cd209d70103f916a93b1f1ed21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/5348c5a67e3b75cd209d70103f916a93b1f1ed21",
+                "reference": "5348c5a67e3b75cd209d70103f916a93b1f1ed21",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6.0|^7.0.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "dev-master",
+                "phploc/phploc": "^4",
+                "phpmd/phpmd": "dev-master",
+                "phpunit/phpunit": "^5.7",
+                "sebastian/phpcpd": "^3.0",
+                "squizlabs/php_codesniffer": "^3.0@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                },
+                "files": [
+                    "classes/src/functions/adjoint.php",
+                    "classes/src/functions/antidiagonal.php",
+                    "classes/src/functions/cofactors.php",
+                    "classes/src/functions/determinant.php",
+                    "classes/src/functions/diagonal.php",
+                    "classes/src/functions/identity.php",
+                    "classes/src/functions/inverse.php",
+                    "classes/src/functions/minors.php",
+                    "classes/src/functions/trace.php",
+                    "classes/src/functions/transpose.php",
+                    "classes/src/operations/add.php",
+                    "classes/src/operations/directsum.php",
+                    "classes/src/operations/subtract.php",
+                    "classes/src/operations/multiply.php",
+                    "classes/src/operations/divideby.php",
+                    "classes/src/operations/divideinto.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "time": "2019-10-06T11:29:25+00:00"
         },
         {
             "name": "matthiasmullie/minify",
@@ -2912,6 +3129,52 @@
             "time": "2019-12-30T18:03:34+00:00"
         },
         {
+            "name": "myclabs/php-enum",
+            "version": "1.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2020-02-14T08:15:52+00:00"
+        },
+        {
             "name": "nesbot/carbon",
             "version": "2.30.0",
             "source": {
@@ -3129,6 +3392,102 @@
             "time": "2018-07-02T15:55:56+00:00"
         },
         {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "2383aad5689778470491581442aab38cec41bf1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/2383aad5689778470491581442aab38cec41bf1d",
+                "reference": "2383aad5689778470491581442aab38cec41bf1d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "maennchen/zipstream-php": "^2.1",
+                "markbaker/complex": "^1.4",
+                "markbaker/matrix": "^1.2",
+                "php": "^7.2",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^0.8.5",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "jpgraph/jpgraph": "^4.0",
+                "mpdf/mpdf": "^8.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^8.5",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "^6.3"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "jpgraph/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "time": "2020-07-19T09:51:35+00:00"
+        },
+        {
             "name": "pimple/pimple",
             "version": "v3.2.3",
             "source": {
@@ -3272,6 +3631,107 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -5035,8 +5495,8 @@
             "authors": [
                 {
                     "name": "Tijs Verkoyen",
-                    "email": "akismet@verkoyen.eu",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "akismet@verkoyen.eu"
                 }
             ],
             "description": "Akismet is a wrapper-class to communicate with the Akismet API.",
@@ -5082,8 +5542,8 @@
             "authors": [
                 {
                     "name": "Tijs Verkoyen",
-                    "email": "css_to_inline_styles@verkoyen.eu",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "css_to_inline_styles@verkoyen.eu"
                 }
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
@@ -5198,12 +5658,6 @@
             "keywords": [
                 "Xdebug",
                 "performance"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                }
             ],
             "time": "2020-03-01T12:26:26+00:00"
         },

--- a/src/Backend/Core/Engine/Csv.php
+++ b/src/Backend/Core/Engine/Csv.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @deprecated remove this in Fork 6, just use ForkCMS\Utility\Csv\Writer
  */
-class Csv
+class Csv extends \SpoonFileCSV
 {
     /**
      * Output a CSV-file as a download

--- a/src/Backend/Core/Engine/Csv.php
+++ b/src/Backend/Core/Engine/Csv.php
@@ -8,10 +8,15 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
+/**
+ * @deprecated remove this in Fork 6, just use ForkCMS\Utility\Csv\Writer
+ */
 class Csv
 {
     /**
      * Output a CSV-file as a download
+     *
+     * @deprecated remove this in Fork 6, just use ForkCMS\Utility\Csv\Writer->output()
      *
      * @param string $filename       The name of the file.
      * @param array  $array          The array to convert.
@@ -80,6 +85,9 @@ class Csv
         );
     }
 
+    /**
+     * @deprecated remove this in Fork 6, you should not rely on this.
+     */
     private static function getLineEnding(): string
     {
         $lineEnding = Authentication::getUser()->getSetting('csv_line_ending');

--- a/src/Backend/Core/Engine/Csv.php
+++ b/src/Backend/Core/Engine/Csv.php
@@ -4,20 +4,19 @@ namespace Backend\Core\Engine;
 
 use Backend\Core\Engine\Model as BackendModel;
 use Common\Exception\RedirectException;
-use Symfony\Component\HttpFoundation\Response;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
-/**
- * This is our extended version of SpoonFileCSV
- */
-class Csv extends \SpoonFileCSV
+class Csv
 {
     /**
      * Output a CSV-file as a download
      *
-     * @param string $filename The name of the file.
-     * @param array $array The array to convert.
-     * @param array $columns The column names you want to use.
-     * @param array $excludeColumns The columns you want to exclude.
+     * @param string $filename       The name of the file.
+     * @param array  $array          The array to convert.
+     * @param array  $columns        The column names you want to use.
+     * @param array  $excludeColumns The columns you want to exclude.
      *
      * @throws RedirectException
      */
@@ -27,30 +26,57 @@ class Csv extends \SpoonFileCSV
         array $columns = null,
         array $excludeColumns = null
     ) {
-        // convert into CSV
-        $csv = \SpoonFileCSV::arrayToString(
-            $array,
-            $columns,
-            $excludeColumns,
-            Authentication::getUser()->getSetting('csv_split_character'),
-            '"',
-            self::getLineEnding()
+        $headers = $columns;
+        $data = $array;
+
+        // remove data that should be excluded
+        if (!empty($excludeColumns)) {
+            $headers = array_filter(
+                $columns,
+                function ($column) use ($excludeColumns) {
+                    return !in_array($column, $excludeColumns);
+                }
+            );
+
+            foreach ($array as $rowNumber => $row) {
+                $data[$rowNumber] = array_filter(
+                    $row,
+                    function ($key) use ($excludeColumns) {
+                        return !in_array($key, $excludeColumns);
+                    },
+                    ARRAY_FILTER_USE_KEY
+                );
+            }
+        }
+
+        $spreadSheet = new Spreadsheet();
+        $sheet = $spreadSheet->getActiveSheet();
+
+        // add data
+        $sheet->fromArray($headers, null, 'A1');
+        $sheet->fromArray($data, null, 'A2');
+
+        $writer = new CsvWriter($spreadSheet);
+        $writer->setDelimiter(Authentication::getUser()->getSetting('csv_split_character'));
+        $writer->setEnclosure('"');
+        $writer->setLineEnding(self::getLineEnding());
+
+        $response = new StreamedResponse(
+            function () use ($writer) {
+                $writer->save('php://output');
+            }
         );
 
-        // set headers for download
+        // set headers
         $charset = BackendModel::getContainer()->getParameter('kernel.charset');
+        $response->headers->set('Content-type', 'application/csv; charset=' . $charset);
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
+        $response->headers->set('Cache-Control', 'max-age=0');
+        $response->headers->set('Pragma', 'no-cache');
+
         throw new RedirectException(
             'Return the csv data',
-            new Response(
-                $csv,
-                Response::HTTP_OK,
-                [
-                    'Content-type' => 'application/csv; charset=' . $charset,
-                    'Content-Disposition' => 'attachment; filename="' . $filename . '"',
-                    'Content-Length' => mb_strlen($csv),
-                    'Pragma' => 'no-cache',
-                ]
-            )
+            $response
         );
     }
 

--- a/src/Backend/Modules/FormBuilder/Actions/ExportData.php
+++ b/src/Backend/Modules/FormBuilder/Actions/ExportData.php
@@ -2,11 +2,14 @@
 
 namespace Backend\Modules\FormBuilder\Actions;
 
+use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Base\Action as BackendBaseAction;
 use Backend\Core\Language\Language as BL;
 use Backend\Core\Engine\Model as BackendModel;
-use Backend\Core\Engine\Csv as BackendCSV;
 use Backend\Modules\FormBuilder\Engine\Model as BackendFormBuilderModel;
+use Common\Exception\RedirectException;
+use ForkCMS\Utility\Csv\Writer;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 /**
  * This action is used to export submissions of a form.
@@ -94,7 +97,18 @@ class ExportData extends BackendBaseAction
             parent::execute();
             $this->setFilter();
             $this->setItems();
-            BackendCSV::outputCSV(date('Ymd_His') . '.csv', $this->rows, $this->columnHeaders);
+
+            $spreadSheet = new Spreadsheet();
+            $sheet = $spreadSheet->getActiveSheet();
+            $sheet->fromArray($this->columnHeaders, null, 'A1');
+            $sheet->fromArray($this->rows, null, 'A2');
+
+            throw new RedirectException(
+                'Return the csv data',
+                $this->get(Writer::class)
+                    ->forBackendUser(Authentication::getUser())
+                    ->output($spreadSheet, date('Ymd_His') . '.csv')
+            );
         } else {
             // no item found, redirect to index, because somebody is fucking with our url
             $this->redirect(BackendModel::createUrlForAction('Index') . '&error=non-existing');

--- a/src/Backend/Modules/FormBuilder/Actions/ExportData.php
+++ b/src/Backend/Modules/FormBuilder/Actions/ExportData.php
@@ -106,8 +106,11 @@ class ExportData extends BackendBaseAction
             throw new RedirectException(
                 'Return the csv data',
                 $this->get(Writer::class)
-                    ->forBackendUser(Authentication::getUser())
-                    ->getResponse($spreadSheet, date('Ymd_His') . '.csv')
+                    ->getResponseForUser(
+                        $spreadSheet,
+                        date('Ymd_His') . '.csv',
+                        Authentication::getUser()
+                    )
             );
         } else {
             // no item found, redirect to index, because somebody is fucking with our url

--- a/src/Backend/Modules/FormBuilder/Actions/ExportData.php
+++ b/src/Backend/Modules/FormBuilder/Actions/ExportData.php
@@ -107,7 +107,7 @@ class ExportData extends BackendBaseAction
                 'Return the csv data',
                 $this->get(Writer::class)
                     ->forBackendUser(Authentication::getUser())
-                    ->output($spreadSheet, date('Ymd_His') . '.csv')
+                    ->getResponse($spreadSheet, date('Ymd_His') . '.csv')
             );
         } else {
             // no item found, redirect to index, because somebody is fucking with our url

--- a/src/Backend/Modules/Profiles/Actions/ExportTemplate.php
+++ b/src/Backend/Modules/Profiles/Actions/ExportTemplate.php
@@ -2,7 +2,11 @@
 
 namespace Backend\Modules\Profiles\Actions;
 
+use Backend\Core\Engine\Authentication;
 use Backend\Core\Engine\Base\ActionAdd as BackendBaseActionAdd;
+use Common\Exception\RedirectException;
+use ForkCMS\Utility\Csv\Writer;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 /**
  * This is the add-action, it will display a form to add a new profile.
@@ -13,20 +17,23 @@ class ExportTemplate extends BackendBaseActionAdd
     {
         $this->checkToken();
 
-        // define path
-        $path = BACKEND_CACHE_PATH . '/Profiles/import_template.csv';
+        $spreadSheet = new Spreadsheet();
+        $sheet = $spreadSheet->getActiveSheet();
+        $sheet->fromArray(
+            [
+                'email',
+                'display_name',
+                'password',
+            ],
+            null,
+            'A1'
+        );
 
-        // define required fields
-        $fields = [
-            'email',
-            'display_name',
-            'password',
-        ];
-
-        // define file
-        $file = new \SpoonFileCSV();
-
-        // download the file
-        $file->arrayToFile($path, [], $fields, null, ',', '"', true);
+        throw new RedirectException(
+            'Return the csv data',
+            $this->get(Writer::class)
+                ->forBackendUser(Authentication::getUser())
+                ->output($spreadSheet, 'import_template.csv')
+        );
     }
 }

--- a/src/Backend/Modules/Profiles/Actions/ExportTemplate.php
+++ b/src/Backend/Modules/Profiles/Actions/ExportTemplate.php
@@ -32,8 +32,11 @@ class ExportTemplate extends BackendBaseActionAdd
         throw new RedirectException(
             'Return the csv data',
             $this->get(Writer::class)
-                ->forBackendUser(Authentication::getUser())
-                ->output($spreadSheet, 'import_template.csv')
+                ->getResponseForUser(
+                    $spreadSheet,
+                    'import_template.csv',
+                    Authentication::getUser()
+                )
         );
     }
 }

--- a/src/Backend/Modules/Profiles/Actions/Import.php
+++ b/src/Backend/Modules/Profiles/Actions/Import.php
@@ -7,7 +7,9 @@ use Backend\Core\Engine\Form as BackendForm;
 use Backend\Core\Language\Language as BL;
 use Backend\Core\Engine\Model as BackendModel;
 use Backend\Modules\Profiles\Engine\Model as BackendProfilesModel;
-use Backend\Core\Engine\Csv;
+use ForkCMS\Utility\Csv\Reader;
+use ForkCMS\Utility\PhpSpreadsheet\Reader\Filter\ColumnsFilter;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 /**
  * This is the add-action, it will display a form to add a new profile.
@@ -45,14 +47,16 @@ class Import extends BackendBaseActionAdd
         // get fields
         $ddmGroup = $this->form->getField('group');
         $fileFile = $this->form->getField('file');
-        $csv = [];
 
         // validate input
         $ddmGroup->isFilled(BL::getError('FieldIsRequired'));
         if ($fileFile->isFilled(BL::err('FieldIsRequired'))) {
             if ($fileFile->isAllowedExtension(['csv'], sprintf(BL::getError('ExtensionNotAllowed'), 'csv'))) {
-                $csv = Csv::fileToArray($fileFile->getTempFileName());
-                if ($csv === false) {
+                $indexes = $this->get(Reader::class)->findColumnIndexes(
+                    $fileFile->getTempFileName(),
+                    ['email', 'display_name', 'password']
+                );
+                if (in_array(null, $indexes)) {
                     $fileFile->addError(BL::getError('InvalidCSV'));
                 }
             }
@@ -64,8 +68,11 @@ class Import extends BackendBaseActionAdd
 
         // import the profiles
         $overwrite = $this->form->getField('overwrite_existing')->isChecked();
-        $statistics = BackendProfilesModel::importCsv(
-            $csv,
+
+        $csvData = $this->convertFileToArray($fileFile->getTempFileName(), array_flip($indexes));
+
+        $statistics = BackendProfilesModel::importFromArray(
+            $csvData,
             $ddmGroup->getValue(),
             $overwrite
         );
@@ -80,5 +87,29 @@ class Import extends BackendBaseActionAdd
 
         // everything is saved, so redirect to the overview
         $this->redirect($redirectUrl);
+    }
+
+    private function convertFileToArray(string $path, array $mapping): array
+    {
+        $dataToImport = [];
+
+        $reader = IOFactory::createReader('Csv');
+        $reader->setReadDataOnly(true);
+        $reader->setReadFilter(new ColumnsFilter(array_keys($mapping)));
+        $spreadSheet = $reader->load($path);
+
+        foreach ($spreadSheet->getActiveSheet()->getRowIterator() as $row) {
+            // skip the first row as it contains the headers
+            if ($row->getRowIndex() === 1) {
+                continue;
+            }
+
+            $dataToImport[] = $this->get(Reader::class)->convertRowIntoMappedArray(
+                $row,
+                $mapping
+            );
+        }
+
+        return $dataToImport;
     }
 }

--- a/src/Backend/Modules/Profiles/Engine/Model.php
+++ b/src/Backend/Modules/Profiles/Engine/Model.php
@@ -544,6 +544,8 @@ class Model
     /**
      * Import CSV data
      *
+     * @deprecated remove this in Fork 6, use Backend\Modules\Profiles\Engine::importFromArray
+     *
      * @param array $data The array from the .csv file
      * @param int|null $groupId $groupId Adding these profiles to a group
      * @param bool $overwriteExisting $overwriteExisting
@@ -624,6 +626,71 @@ class Model
                 $values['starts_on'] = BackendModel::getUTCDate();
 
                 // insert values
+                self::insertProfileGroup($values);
+            }
+        }
+
+        return $statistics;
+    }
+
+    /**
+     * Import multiple profiles based on a given array
+     * Each row in the array should contain the fields:
+     *  * email
+     *  * display_name
+     *  * password
+     *
+     * @return array array('count' => array('exists' => 0, 'inserted' => 0));
+     */
+    public static function importFromArray(array $data, int $groupId = null, bool $overwriteExisting = false): array
+    {
+        $statistics = ['count' => ['exists' => 0, 'inserted' => 0]];
+
+        foreach ($data as $item) {
+            if (!isset($item['email']) || !isset($item['display_name']) || !isset($item['password'])) {
+                throw new BackendException(
+                    'The array should have the following fields; "email", "password" and "display_name".'
+                );
+            }
+
+            $exists = self::existsByEmail($item['email']);
+
+            // do not overwrite existing profiles
+            if ($exists && !$overwriteExisting) {
+                $statistics['count']['exists'] += 1;
+                continue;
+            }
+
+            $values = [
+                'email' => $item['email'],
+                'registered_on' => BackendModel::getUTCDate(),
+                'display_name' => $item['display_name'],
+                'url' => self::getUrl($item['display_name']),
+                'password' => self::encryptPassword(time()), // @remark this is a temporary password, but it can't be null
+                'last_login' => date('Y-m-d H:i:s', 0), // @remark, this should be fixed! but at this point the column last_login can't be null
+            ];
+
+            if (!$exists) {
+                $id = self::insert($values);
+                $statistics['count']['inserted'] += 1;
+            } else {
+                $profile = self::getByEmail($item['email']);
+                $id = $profile['id'];
+                $statistics['count']['exists'] += 1;
+            }
+
+            if ($item['password']) {
+                $values['password'] = self::encryptPassword($item['password']);
+                self::update($id, $values);
+            }
+
+            if ($groupId !== null) {
+                $values = [];
+
+                $values['profile_id'] = $id;
+                $values['group_id'] = $groupId;
+                $values['starts_on'] = BackendModel::getUTCDate();
+
                 self::insertProfileGroup($values);
             }
         }

--- a/src/ForkCMS/Utility/Csv/Reader.php
+++ b/src/ForkCMS/Utility/Csv/Reader.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace ForkCMS\Utility\Csv;
+
+use ForkCMS\Utility\PhpSpreadsheet\Reader\Filter\ChunkReadFilter;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Row;
+
+class Reader
+{
+    public function findColumnIndexes(string $path, array $columns): array
+    {
+        $reader = IOFactory::createReader('Csv');
+        $reader->setReadDataOnly(true);
+        $reader->setReadFilter(new ChunkReadFilter(1, 1));
+        $spreadSheet = $reader->load($path);
+
+        $indexes = array_fill_keys(array_values($columns), null);
+
+        foreach ($spreadSheet->getSheet(0)->getRowIterator() as $row) {
+            foreach ($row->getCellIterator() as $cell) {
+                if (in_array($cell->getValue(), $columns)) {
+                    $indexes[$cell->getValue()] = $cell->getColumn();
+                }
+            }
+        }
+
+        return $indexes;
+    }
+
+    public function convertRowIntoMappedArray(Row $row, array $mapping): array
+    {
+        $data = array_fill_keys(
+            array_values($mapping),
+            null
+        );
+
+        $cellIterator = $row->getCellIterator();
+        foreach ($cellIterator as $cell) {
+            if (in_array($cell->getColumn(), array_keys($mapping))) {
+                $key = $mapping[$cell->getColumn()];
+                $data[$key] = $cell->getValue();
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/ForkCMS/Utility/Csv/Writer.php
+++ b/src/ForkCMS/Utility/Csv/Writer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ForkCMS\Utility\Csv;
+
+use Backend\Core\Engine\Authentication;
+use Backend\Core\Engine\User;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class Writer
+{
+    private $charset;
+
+    private $options = [];
+
+    public function __construct(string $charset)
+    {
+        $this->charset = $charset;
+        $this->setDefaultOptions();
+    }
+
+    private function setDefaultOptions()
+    {
+        $this->options['Enclosure'] = '"';
+        $this->options['Delimiter'] = ',';
+        $this->options['LineEnding'] = "\n";
+        $this->options['UseBOM'] = true;
+    }
+
+    private function getWriter(Spreadsheet $spreadsheet): Csv
+    {
+        $writer = IOFactory::createWriter($spreadsheet, 'Csv');
+
+        if (!empty($this->options)) {
+            foreach ($this->options as $option => $value) {
+                $methodName = 'set' . $option;
+                if (method_exists($writer, $methodName)) {
+                    call_user_func([$writer, $methodName], $value);
+                }
+            }
+        }
+
+        return $writer;
+    }
+
+    public function forBackendUser(User $user): self
+    {
+        $this->options['Delimiter'] = $user->getSetting('csv_split_character');
+
+        $lineEnding = Authentication::getUser()->getSetting('csv_line_ending');
+        if ($lineEnding === '\n') {
+            $this->options['LineEnding'] = "\n";
+        }
+        if ($lineEnding === '\r\n') {
+            $this->options['LineEnding'] = "\r\n";
+        }
+
+        return $this;
+    }
+
+    public function output(Spreadsheet $spreadsheet, string $filename): StreamedResponse
+    {
+        $writer = $this->getWriter($spreadsheet);
+
+        $response = new StreamedResponse(
+            function () use ($writer) {
+                $writer->save('php://output');
+            }
+        );
+
+        // set headers
+        $response->headers->set('Content-type', 'application/csv; charset=' . $this->charset);
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
+        $response->headers->set('Cache-Control', 'max-age=0');
+        $response->headers->set('Pragma', 'no-cache');
+
+        return $response;
+    }
+}

--- a/src/ForkCMS/Utility/Csv/Writer.php
+++ b/src/ForkCMS/Utility/Csv/Writer.php
@@ -60,7 +60,7 @@ class Writer
         return $this;
     }
 
-    public function output(Spreadsheet $spreadsheet, string $filename): StreamedResponse
+    public function getResponse(Spreadsheet $spreadsheet, string $filename): StreamedResponse
     {
         $writer = $this->getWriter($spreadsheet);
 

--- a/src/ForkCMS/Utility/PhpSpreadsheet/Reader/Filter/ChunkReadFilter.php
+++ b/src/ForkCMS/Utility/PhpSpreadsheet/Reader/Filter/ChunkReadFilter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace ForkCMS\Utility\PhpSpreadsheet\Reader\Filter;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+class ChunkReadFilter implements IReadFilter
+{
+    /**
+     * @var int
+     */
+    private $start = 0;
+
+    /**
+     * @var int
+     */
+    private $end = 0;
+
+    public function __construct(int $start, int $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function setStart(int $start): self
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function setEnd(int $end): self
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function setChunk(int $start, int $numberOfRows): self
+    {
+        $this->start = $start;
+        $this->end = $start + $numberOfRows;
+
+        return $this;
+    }
+
+    public function readCell($column, $row, $worksheetName = ''): bool
+    {
+        if ($row >= $this->start && $row <= $this->end) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ForkCMS/Utility/PhpSpreadsheet/Reader/Filter/ColumnsFilter.php
+++ b/src/ForkCMS/Utility/PhpSpreadsheet/Reader/Filter/ColumnsFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ForkCMS\Utility\PhpSpreadsheet\Reader\Filter;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+class ColumnsFilter implements IReadFilter
+{
+    /**
+     * @var array
+     */
+    private $columns;
+
+    public function __construct(array $columns)
+    {
+        $this->columns = $columns;
+    }
+
+    public function readCell($column, $row, $worksheetName = ''): bool
+    {
+        if (in_array($column, $this->columns)) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

* Replaces https://github.com/forkcms/forkcms/pull/2687
* Resolved https://github.com/forkcms/forkcms/issues/2099

## Pull request description

SpoonFileCSV is deprecated so it should be replaced with something that is more maintained. 

With this PR we introduce the usage of [PhpSpreadsheet](https://phpspreadsheet.readthedocs.io). I choose this one over `league/csv`, as the later one does not really have a lot of features, and does not really integrate in the Symfony responses, per example: outputting a CSV file won't return a string, but just outputs the CSV and stop the code.

### Writing CSV files

So instead of working with arrays you should create a SpreadSheet instance first,
check the [official documentation](https://phpspreadsheet.readthedocs.io/en/latest/topics/creating-spreadsheet/).

The easiest way to convert existing code is:

```php
$spreadSheet = new Spreadsheet();
$sheet = $spreadSheet->getActiveSheet();
$sheet->fromArray($headers, null, 'A1');
$sheet->fromArray($rows, null, 'A2');
```

A service called `ForkCMS\Utility\Csv\Writer` is added, which allows you to force the download of a spreadsheet in CSV-format thru a Symfony StreamedResponse. If you want to force a download you can use the code below in the backend:

```php
    throw new RedirectException(
        'Return the csv data',
        $this->get(Writer::class)
            ->forBackendUser(Authentication::getUser())
            ->output($spreadSheet, date('Ymd_His') . '.csv')
    );
```

