### PR TITLE
Allow html in user template textareas

### DIFF
--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -901,7 +901,7 @@ jsBackend.pages.extras = {
     }
 
     if ($element.is('[data-ft-type="textarea"]')) {
-      $placeholder.append(jsBackend.pages.extras.getTextAreaFieldHtml($element.text(), $element.data('ft-label'), key))
+      $placeholder.append(jsBackend.pages.extras.getTextAreaFieldHtml($element.html(), $element.data('ft-label'), key))
 
       return
     }
@@ -1063,7 +1063,7 @@ jsBackend.pages.extras = {
     if ($element.is('[data-ft-type="textarea"]')) {
       $textarea = $placeholder.find('#user-template-textarea-' + key + ' textarea[data-ft-label]')
 
-      $element.text($textarea.val())
+      $element.html($textarea.val())
 
       return
     }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix


## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
At the moment you can't add html when using a textarea in a usertemplate, for instance to paste an embed code.
I fixed this by enabling the html.
Another solution would be to create a new type: html. Feedback and opinions welcome