### PR TITLE
Fix fade of slickslider clashing with bootstrap 4

### DIFF
--- a/src/Frontend/Modules/MediaLibrary/Js/Slider.js
+++ b/src/Frontend/Modules/MediaLibrary/Js/Slider.js
@@ -30,7 +30,7 @@
         autoplay: multipleItems,
         adaptiveHeight: true,
         dots: showPager,
-        fade: true,
+        // fade: true, // this has side effects in bootstrap 4 because of the .fade class, if you enable this don't forget to add extra styling for this
         lazyLoad: 'ondemand',
         mobileFirst: true
       })


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix


## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
The fade option of slick slider is clashing with bootstrap 4.
I disabled it and added a comment for people that want to enable it