### PR TITLE
Use fork translations for the text used in select2

### DIFF
--- a/src/Backend/Core/Installer/Data/locale.xml
+++ b/src/Backend/Core/Installer/Data/locale.xml
@@ -12683,6 +12683,30 @@
         <translation language="de"><![CDATA[eine Kategorie hinzufügen]]></translation>
         <translation language="fr"><![CDATA[ajouter une catégorie]]></translation>
       </item>
+      <item type="label" name="NoResultsFound">
+        <translation language="nl"><![CDATA[geen resultaten gevonden]]></translation>
+        <translation language="en"><![CDATA[no results found]]></translation>
+        <translation language="de"><![CDATA[keine Ergebnisse gefunden]]></translation>
+        <translation language="fr"><![CDATA[aucun résultat trouvé]]></translation>
+      </item>
+      <item type="label" name="TheResultsCouldNotBeLoaded">
+        <translation language="nl"><![CDATA[de resultaten kunnen niet geladen worden]]></translation>
+        <translation language="en"><![CDATA[the results could not be loaded]]></translation>
+        <translation language="de"><![CDATA[die Ergebnisse konnten nicht geladen werden]]></translation>
+        <translation language="fr"><![CDATA[les résultats n'ont pas pu être chargés]]></translation>
+      </item>
+      <item type="label" name="LoadingMoreResults">
+        <translation language="nl"><![CDATA[meer resultaten laden…]]></translation>
+        <translation language="en"><![CDATA[loading more results…]]></translation>
+        <translation language="de"><![CDATA[Weitere Ergebnisse laden…]]></translation>
+        <translation language="fr"><![CDATA[chargement d'autres résultats…]]></translation>
+      </item>
+      <item type="label" name="Searching">
+        <translation language="nl"><![CDATA[zoeken…]]></translation>
+        <translation language="en"><![CDATA[searching…]]></translation>
+        <translation language="de"><![CDATA[Suche…]]></translation>
+        <translation language="fr"><![CDATA[recherche…]]></translation>
+      </item>
     </Core>
   </Backend>
 </locale>

--- a/src/Backend/Core/Js/Components/Forms.js
+++ b/src/Backend/Core/Js/Components/Forms.js
@@ -32,7 +32,21 @@ export class Forms {
   select2 () {
     $.fn.select2.defaults.set('theme', 'bootstrap')
 
-    // todo webpack: add label for empty text
+    $.fn.select2.defaults.set('language', {
+      noResults: () => {
+        return window.backend.locale.lbl('NoResultsFound')
+      },
+      errorLoading: () => {
+        return window.backend.local.lbl('TheResultsCouldNotBeLoaded')
+      },
+      loadingMore: () => {
+        return window.backend.locale.lbl('LoadingMoreResults')
+      },
+      searching: () => {
+        return window.backend.locale.lbl('Searching')
+      }
+    })
+
     $('[data-fork="select2"]').select2()
   }
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Enhancement

## Pull request description

In the past we were using the translation files from select2. We are talking about one file per language. Al these files were in git. I changed it so we can use the translations in fork. No more extra files and we can also easily changes the values.
