### PR TITLE
Filter on empty levels

### DIFF
--- a/src/ForkCMS/Privacy/ConsentDialog.php
+++ b/src/ForkCMS/Privacy/ConsentDialog.php
@@ -51,10 +51,10 @@ class ConsentDialog
             $levels = ['functional'];
         }
 
-        $levels = array_merge(
+        $levels = array_filter(array_merge(
             $levels,
             $this->settings->get('Core', 'privacy_consent_levels', [])
-        );
+        ));
 
         return $levels;
     }


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When you have no extra levels (fe, there is no tracking of social media, Google analytics,...) in the privacy dialog box, there is still an empty checkbox.

## Pull request description

Filter the array of levels on empty strings.