### PR TITLE
Added a search box to the media library

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Actions/MediaItemIndex.php
+++ b/src/Backend/Modules/MediaLibrary/Actions/MediaItemIndex.php
@@ -90,9 +90,12 @@ class MediaItemIndex extends BackendBaseActionIndex
     private function getSearchForm(): Form
     {
         $request = $this->getRequest();
-        $data = [
-            'query' => $request->get('query')
-        ];
+        $data = [];
+
+        if (!empty((string) $request->get('query'))) {
+            $data['query'] = (string) $request->get('query');
+        }
+
         $form = $this->createForm(MediaItemSearchType::class, $data);
 
         $form->handleRequest($request);

--- a/src/Backend/Modules/MediaLibrary/Actions/MediaItemIndex.php
+++ b/src/Backend/Modules/MediaLibrary/Actions/MediaItemIndex.php
@@ -4,12 +4,15 @@ namespace Backend\Modules\MediaLibrary\Actions;
 
 use Backend\Core\Engine\Base\ActionIndex as BackendBaseActionIndex;
 use Backend\Core\Engine\DataGridDatabase;
+use Backend\Core\Engine\Model;
 use Backend\Core\Language\Language;
 use Backend\Modules\MediaLibrary\Builder\MediaFolder\MediaFolderCacheItem;
 use Backend\Modules\MediaLibrary\Domain\MediaFolder\Exception\MediaFolderNotFound;
 use Backend\Modules\MediaLibrary\Domain\MediaFolder\MediaFolder;
+use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItemSearchType;
 use Backend\Modules\MediaLibrary\Domain\MediaItem\Type;
 use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItemDataGrid;
+use Symfony\Component\Form\Form;
 
 class MediaItemIndex extends BackendBaseActionIndex
 {
@@ -21,14 +24,15 @@ class MediaItemIndex extends BackendBaseActionIndex
         $this->display();
     }
 
-    private function getDataGrids(MediaFolder $mediaFolder = null): array
+    private function getDataGrids(MediaFolder $mediaFolder = null, string $searchQuery = null): array
     {
         return array_map(
-            function ($type) use ($mediaFolder) {
+            function ($type) use ($mediaFolder, $searchQuery) {
                 /** @var DataGridDatabase $dataGrid */
                 $dataGrid = MediaItemDataGrid::getDataGrid(
                     Type::fromString($type),
-                    ($mediaFolder !== null) ? $mediaFolder->getId() : null
+                    ($mediaFolder !== null) ? $mediaFolder->getId() : null,
+                    $searchQuery
                 );
 
                 return [
@@ -83,6 +87,19 @@ class MediaItemIndex extends BackendBaseActionIndex
         return $dropdownItems;
     }
 
+    private function getSearchForm(): Form
+    {
+        $request = $this->getRequest();
+        $data = [
+            'query' => $request->get('query')
+        ];
+        $form = $this->createForm(MediaItemSearchType::class, $data);
+
+        $form->handleRequest($request);
+
+        return $form;
+    }
+
     private function hasResults(array $dataGrids): bool
     {
         $totalResultCount = array_sum(
@@ -103,6 +120,24 @@ class MediaItemIndex extends BackendBaseActionIndex
 
         /** @var MediaFolder|null $mediaFolder */
         $mediaFolder = $this->getMediaFolder();
+        $searchQuery = $this->getRequest()->get('query');
+        $searchForm = $this->getSearchForm();
+
+        if ($searchForm->isSubmitted() && $searchForm->isValid()) {
+            $parameters = [
+                'query' => $searchForm->getData()['query'],
+            ];
+
+            $this->redirect(
+                Model::createUrlForAction(
+                    'MediaItemIndex',
+                    null,
+                    null,
+                    $parameters
+                )
+            );
+            return;
+        }
 
         $this->template->assign(
             'folderHasNoChildren',
@@ -113,15 +148,16 @@ class MediaItemIndex extends BackendBaseActionIndex
 
         // Assign variables
         $this->template->assign('tree', $this->get('media_library.manager.tree')->getHTML());
+        $this->template->assign('searchForm', $searchForm->createView());
 
-        $this->parseDataGrids($mediaFolder);
+        $this->parseDataGrids($mediaFolder, $searchQuery);
         $this->parseMediaFolders($mediaFolder);
     }
 
-    private function parseDataGrids(MediaFolder $mediaFolder = null): void
+    private function parseDataGrids(MediaFolder $mediaFolder = null, string $searchQuery = null): void
     {
         /** @var array $dataGrids */
-        $dataGrids = $this->getDataGrids($mediaFolder);
+        $dataGrids = $this->getDataGrids($mediaFolder, $searchQuery);
 
         $this->template->assign('dataGrids', $dataGrids);
         $this->template->assign('hasResults', $this->hasResults($dataGrids));

--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemFindAll.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemFindAll.php
@@ -27,12 +27,13 @@ class MediaItemFindAll extends BackendBaseAJAXAction
 
         $mediaFolder = $this->getMediaFolderBasedOnMediaGroup();
         $aspectRatio = $this->getAspectRatio();
+        $searchQuery = $this->getSearchQuery();
 
         // Output success message with variables
         $this->output(
             Response::HTTP_OK,
             [
-                'media' => $this->loadMediaItems($mediaFolder, $aspectRatio),
+                'media' => $this->loadMediaItems($mediaFolder, $aspectRatio, $searchQuery),
                 'folder' => $mediaFolder !== null ? $mediaFolder->getId() : null,
                 'tab' => $this->selectedTab,
             ]
@@ -48,6 +49,17 @@ class MediaItemFindAll extends BackendBaseAJAXAction
         }
 
         return new AspectRatio($aspectRatio);
+    }
+
+    private function getSearchQuery(): ?string
+    {
+        $query = $this->getRequest()->request->get('query');
+
+        if (empty($query)) {
+            return null;
+        }
+
+        return $query;
     }
 
     private function getMediaFolder(): ?MediaFolder
@@ -113,10 +125,18 @@ class MediaItemFindAll extends BackendBaseAJAXAction
         }
     }
 
-    private function loadMediaItems(?MediaFolder $mediaFolder, ?AspectRatio $aspectRatio): array
+    private function loadMediaItems(?MediaFolder $mediaFolder, ?AspectRatio $aspectRatio, ?string $searchQuery): array
     {
         if ($mediaFolder === null) {
             return [];
+        }
+
+        if ($searchQuery) {
+            return $this->get('media_library.repository.item')->findByFolderAndAspectRatioAndSearchQuery(
+                $mediaFolder,
+                $aspectRatio,
+                $searchQuery
+            );
         }
 
         return $this->get('media_library.repository.item')->findByFolderAndAspectRatio($mediaFolder, $aspectRatio);

--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemFindAll.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemFindAll.php
@@ -53,7 +53,7 @@ class MediaItemFindAll extends BackendBaseAJAXAction
 
     private function getSearchQuery(): ?string
     {
-        $query = $this->getRequest()->request->get('query');
+        $query = (string) $this->getRequest()->request->get('query');
 
         if (empty($query)) {
             return null;

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemRepository.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemRepository.php
@@ -59,4 +59,30 @@ final class MediaItemRepository extends EntityRepository
             ['title' => 'ASC']
         );
     }
+
+    public function findByFolderAndAspectRatioAndSearchQuery(
+        MediaFolder $mediaFolder,
+        ?AspectRatio $aspectRatio,
+        ?string $searchQuery
+    ): array {
+        $queryBuilder = $this->createQueryBuilder('i')
+            ->select('i');
+
+        $queryBuilder = $queryBuilder->where('i.folder = :folder')
+            ->orderBy('i.title', 'ASC')
+            ->setParameter('folder', $mediaFolder);
+
+        if ($aspectRatio instanceof AspectRatio) {
+            $queryBuilder = $queryBuilder->andWhere('i.aspectRatio = :aspectRatio')
+                ->setParameter('aspectRatio', $aspectRatio);
+        }
+
+        if ($searchQuery) {
+            $queryBuilder = $queryBuilder->andWhere('i.title LIKE :searchQuery')
+                ->setParameter('searchQuery', '%'. $searchQuery .'%');
+        }
+
+        return $queryBuilder->getQuery()
+            ->execute();
+    }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemSearchType.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemSearchType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Backend\Modules\MediaLibrary\Domain\MediaItem;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class MediaItemSearchType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add(
+            'query',
+            TextType::class,
+            [
+                'label' => 'lbl.Search',
+                'required' => false,
+            ]
+        );
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'media_item_search';
+    }
+}

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -39,6 +39,7 @@ var mediaFolders = false
 var mediaGroups = {}
 var currentMediaGroupId = 0
 var mediaFolderId
+var searchQuery
 var currentAspectRatio = false
 var minimumMediaItemsCount = false
 var maximumMediaItemsCount = false
@@ -188,6 +189,30 @@ jsBackend.mediaLibraryHelper.group = {
       // get media for this folder
       jsBackend.mediaLibraryHelper.group.getMedia()
     })
+
+    $('#searchMedia').on('click', function(e){
+      e.preventDefault();
+      e.stopPropagation();
+
+      mediaFolderId = $('#mediaFolders').val();
+      searchQuery = $('[name=query]').val();
+
+      jsBackend.mediaLibraryHelper.group.clearMediaCache(mediaFolderId);
+      jsBackend.mediaLibraryHelper.group.getMedia()
+    })
+
+    $('[name=query]').on('keyup', function(e){
+      if (e.keyCode == 13) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        mediaFolderId = $('#mediaFolders').val();
+        searchQuery = $(this).val();
+
+        jsBackend.mediaLibraryHelper.group.clearMediaCache(mediaFolderId);
+        jsBackend.mediaLibraryHelper.group.getMedia()
+      }
+    })
   },
 
   /**
@@ -195,6 +220,13 @@ jsBackend.mediaLibraryHelper.group = {
    */
   clearFoldersCache: function () {
     mediaFolders = false
+  },
+
+  /**
+   * Clear the media cache when necessary
+   */
+  clearMediaCache: function(mediaFolderId) {
+    media[mediaFolderId] = false;
   },
 
   /**
@@ -435,6 +467,7 @@ jsBackend.mediaLibraryHelper.group = {
         },
         group_id: (mediaGroups[currentMediaGroupId]) ? mediaGroups[currentMediaGroupId].id : null,
         folder_id: mediaFolderId,
+        query: searchQuery,
         aspect_ratio: currentAspectRatio
       },
       success: function (json, textStatus) {

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -201,18 +201,13 @@ jsBackend.mediaLibraryHelper.group = {
       jsBackend.mediaLibraryHelper.group.getMedia()
     })
 
-    $('[name=query]').on('keyup', function(e){
-      if (e.keyCode == 13) {
-        e.preventDefault();
-        e.stopPropagation();
+    $('[name=query]').bind('keyup input', utils.events.debounce(function(e){
+      mediaFolderId = $('#mediaFolders').val();
+      searchQuery = $(this).val();
 
-        mediaFolderId = $('#mediaFolders').val();
-        searchQuery = $(this).val();
-
-        jsBackend.mediaLibraryHelper.group.clearMediaCache(mediaFolderId);
-        jsBackend.mediaLibraryHelper.group.getMedia()
-      }
-    })
+      jsBackend.mediaLibraryHelper.group.clearMediaCache(mediaFolderId);
+      jsBackend.mediaLibraryHelper.group.getMedia()
+    }, 400))
   },
 
   /**

--- a/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Layout/Templates/MediaItemIndex.html.twig
@@ -45,6 +45,16 @@
             <a href="#{{ dataGrid.tabName }}" aria-controls="tabImage" role="tab" data-toggle="tab">{{ dataGrid.label|capitalize }} ({{ dataGrid.numberOfResults }})</a>
           </li>
           {% endfor %}
+          <li class="pull-right">
+            {{ form_start(searchForm, { 'attr' : { 'class': 'form-inline' } }) }}
+            <div class="input-group">
+              {{ form_widget(searchForm.query) }}
+              <span class="input-group-btn">
+                {{ macro.buttonIcon('', 'search', 'lbl.Search'|trans|capitalize, 'submitSearchForm', {'type':'submit'}) }}
+              </span>
+            </div>
+            {{ form_end(searchForm) }}
+          </li>
         </ul>
         <div class="tab-content">
           {% for dataGrid in dataGrids %}

--- a/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaGroupsHelper.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaGroupsHelper.html.twig
@@ -24,9 +24,23 @@
               {% include "MediaLibrary/Resources/views/BackendMediaLibraryUpload.html.twig" %}
             </div>
             <div role="tabpanel" class="tab-pane" id="tabLibrary">
-              <div class="options">
-                <label for="folders">{{ 'msg.MediaYouAreHere'|trans }}</label>
-                <select id="mediaFolders"></select>
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="options">
+                    <label for="folders">{{ 'msg.MediaYouAreHere'|trans }}</label>
+                    <select id="mediaFolders"></select>
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="option">
+                    <div class="input-group">
+                      <input type="search" value="" name="query" class="form-control" />
+                      <span class="input-group-btn">
+                        {{ macro.buttonIcon('', 'search', 'lbl.Search'|trans|capitalize, 'btn-secondary', {'id': 'searchMedia', 'type' : 'button'}) }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
               </div>
               <div class="options">
                 <div class="alert alert-warning hidden" data-role="fork-media-count-error"></div>


### PR DESCRIPTION
When you have a large amount of files it would be nice to search through
those files. This commit enables you to search through your media
library, even in the media library dialog.

## Type

- Enhancement

## Resolves the following issues

fixes #3187 

## Pull request description

Adds a search box to the media library but also adds a search box to the media library dialog. The results are filtered on the title only, not the file name or any other value.
