### PR TITLE
Always require a media item to have a title

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemDataTransferObject.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemDataTransferObject.php
@@ -3,6 +3,7 @@
 namespace Backend\Modules\MediaLibrary\Domain\MediaItem;
 
 use Backend\Modules\MediaLibrary\Domain\MediaFolder\MediaFolder;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class MediaItemDataTransferObject
 {
@@ -12,7 +13,11 @@ class MediaItemDataTransferObject
     /** @var MediaFolder|null */
     public $folder;
 
-    /** @var string */
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank(message="err.FieldIsRequired")
+     */
     public $title;
 
     /** @var string */


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

When adding or editing a MediaItem a title is clearly required but if you circumvent the HTML5 validation it is possible to have a blank title. This PR fixes that by adding extra validation on the PHP level.
