### PR TITLE
Add edit button to media item within a form

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemEditTitle.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemEditTitle.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Backend\Modules\MediaLibrary\Ajax;
+
+use Backend\Core\Engine\Base\AjaxAction as BackendBaseAJAXAction;
+use Backend\Core\Language\Language;
+use Backend\Modules\MediaLibrary\Domain\MediaItem\Command\UpdateMediaItem;
+use Backend\Modules\MediaLibrary\Domain\MediaItem\Exception\MediaItemNotFound;
+use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItem;
+use Common\Exception\AjaxExitException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This AJAX-action is being used to edit the title for an existing MediaItem item and save them into to the database.
+ */
+class MediaItemEditTitle extends BackendBaseAJAXAction
+{
+    public function execute(): void
+    {
+        parent::execute();
+
+        /** @var UpdateMediaItem $updateMediaItem */
+        $updateMediaItem = $this->updateMediaItem();
+
+        // Output
+        $this->output(
+            Response::HTTP_OK,
+            $updateMediaItem->getMediaItemEntity(),
+            sprintf(
+                Language::msg('MediaItemEdited'),
+                $updateMediaItem->getMediaItemEntity()->getTitle()
+            )
+        );
+    }
+
+    protected function getMediaItem(): MediaItem
+    {
+        $id = $this->getRequest()->request->get('media_id');
+
+        // validate values
+        if ($id === null) {
+            throw new AjaxExitException(Language::err('MediaItemIdIsRequired'));
+        }
+
+        try {
+            /** @var MediaItem $mediaItem */
+            return $this->get('media_library.repository.item')->findOneById($id);
+        } catch (MediaItemNotFound $mediaItemNotFound) {
+            throw new AjaxExitException(Language::err('MediaItemDoesNotExists'));
+        }
+    }
+
+    protected function getItemTitle(): ?string
+    {
+        return $this->getRequest()->request->get('title');
+    }
+
+    private function updateMediaItem(): UpdateMediaItem
+    {
+        /** @var MediaItem $mediaItem */
+        $mediaItem = $this->getMediaItem();
+
+        /** @var string $title */
+        $title = $this->getItemTitle();
+
+        /** @var UpdateMediaItem $updateMediaItem */
+        $updateMediaItem = new UpdateMediaItem($mediaItem);
+        $updateMediaItem->title = $title;
+
+        // Handle the MediaItem update
+        $this->get('command_bus')->handle($updateMediaItem);
+
+        return $updateMediaItem;
+    }
+}

--- a/src/Backend/Modules/MediaLibrary/Installer/Installer.php
+++ b/src/Backend/Modules/MediaLibrary/Installer/Installer.php
@@ -42,6 +42,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'MediaItemAddMovie'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'MediaItemDelete');
         $this->setActionRights(1, $this->getModule(), 'MediaItemEdit');
+        $this->setActionRights(1, $this->getModule(), 'MediaItemEditTitle'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'MediaItemFindAll'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'MediaItemGetAllById'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'MediaItemIndex');

--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -196,13 +196,13 @@ jsBackend.mediaLibraryHelper.group = {
   /**
    * Edit media in a dialog
    */
-  editMediaDialog: function(){
+  editMediaDialog: function () {
     var $editMediaDialog = $('[data-role=media-library-edit-dialog]')
     var $editMediaSubmit = $('#editMediaSubmit')
-    var $mediaItemTitleInput = $('#editMediaItemTile');
-    var $mediaItem;
+    var $mediaItemTitleInput = $('#editMediaItemTile')
+    var $mediaItem
 
-    $('[data-fork=connectedItems]').on('click', '[data-fork=edit]', function(){
+    $('[data-fork=connectedItems]').on('click', '[data-fork=edit]', function () {
       $mediaItem = $(this).closest('[data-fork=mediaItem]')
 
       $mediaItemTitleInput.val($mediaItem.data('mediaTitle'))
@@ -210,22 +210,22 @@ jsBackend.mediaLibraryHelper.group = {
       $editMediaDialog.modal('show')
     })
 
-    $mediaItemTitleInput.keyup(function(e){
+    $mediaItemTitleInput.keyup(function (e) {
       if (e.keyCode === 13) {
         $editMediaSubmit.click()
       }
     })
 
-    $editMediaSubmit.click(function(){
+    $editMediaSubmit.click(function () {
       if (!$mediaItem || !$mediaItem.data('mediaId')) {
-        return;
+        return
       }
 
       $editMediaDialog.find('.is-invalid').removeClass('is-invalid')
       $editMediaDialog.find('.help-block').remove()
 
-      if ($mediaItemTitleInput.val() === "") {
-        $mediaItemTitleInput.addClass('is-invalid');
+      if ($mediaItemTitleInput.val() === '') {
+        $mediaItemTitleInput.addClass('is-invalid')
 
         $('<span>').addClass('help-block')
           .append(
@@ -240,7 +240,7 @@ jsBackend.mediaLibraryHelper.group = {
           )
           .insertAfter($mediaItemTitleInput)
 
-        return;
+        return
       }
 
       $.ajax({
@@ -274,7 +274,7 @@ jsBackend.mediaLibraryHelper.group = {
       })
     })
 
-    $editMediaDialog.on('hide.bs.modal', function(e){
+    $editMediaDialog.on('hide.bs.modal', function (e) {
       $mediaItem = null
       $mediaItemTitleInput.val('')
     })

--- a/src/Backend/Modules/MediaLibrary/Layout/Css/MediaLibrary.css
+++ b/src/Backend/Modules/MediaLibrary/Layout/Css/MediaLibrary.css
@@ -177,6 +177,35 @@
     display: block;
     font-weight: normal;
   }
+  .mediaConnectedItems .editMediaItem::before {
+    content: "\f044";
+    color: #2f77cf;
+    font: normal normal normal 2rem/1.7rem FontAwesome;
+    position: absolute;
+    top: 7px;
+    right: 26px;
+    background: #ffffff;
+  }
+  .mediaConnectedItems .mediaHolder .editMediaItem:hover,
+  .mediaConnectedItems .mediaHolder .editMediaItem:focus {
+    font-size: 14px;
+  }
+  .mediaConnectedItems .mediaHolder .editMediaItem:hover::before,
+  .mediaConnectedItems .mediaHolder .editMediaItem:focus::before {
+    color: #01417b;
+    padding: 0;
+    font-weight: normal;
+  }
+  .mediaConnectedItems .editMediaItem {
+    color: #2f77cf;
+    line-height: 2em;
+    font-size: 0;
+    width: 100%;
+    background: none;
+    border: none;
+    display: block;
+    font-weight: normal;
+  }
 /**
  * Media Dialog
  */

--- a/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaGroupsHelper.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/BackendMediaGroupsHelper.html.twig
@@ -85,4 +85,27 @@
     </div>
     {% include "MediaLibrary/Resources/views/CropperDialog.html.twig" %}
   </div>
+  {# Edit media dialog #}
+  <div class="modal fade" id="editMediaDialog" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="editMediaDialogTitle" data-role="media-library-edit-dialog">
+    <div class="modal-dialog modal-lg" data-role="media-library-select-modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title" id="editMediaDialogTitle">{{ 'lbl.Edit'|trans|ucfirst }}</h4>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label for="editMediaItemTitle">{{ 'lbl.Title'|trans|ucfirst }}{{ macro.required() }}</label>
+            <input type="text" class="form-control" name="mediaItemTitle" id="editMediaItemTile" value="" />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            {{ macro.icon('times') }}<span class="btn-text">{{ 'lbl.Cancel'|trans|ucfirst }}</span>
+          </button>
+          <button id="editMediaSubmit" type="button" class="btn btn-primary">
+            {{ macro.icon('check') }}<span class="btn-text">{{ 'lbl.Save'|trans|ucfirst }}</span></button>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endif %}

--- a/src/Backend/Modules/MediaLibrary/Resources/views/FormLayout.html.twig
+++ b/src/Backend/Modules/MediaLibrary/Resources/views/FormLayout.html.twig
@@ -66,7 +66,7 @@
 {% endblock %}
 
 {% macro mediaItem(mediaItem) %}
-  <div class="mediaHolder mediaHolder{{ mediaItem.item.type|ucfirst }}" data-fork="mediaItem" data-folder-id="{{ mediaItem.item.folder.id }}" data-media-id="{{ mediaItem.item.id }}">
+  <div class="mediaHolder mediaHolder{{ mediaItem.item.type|ucfirst }}" data-fork="mediaItem" data-folder-id="{{ mediaItem.item.folder.id }}" data-media-id="{{ mediaItem.item.id }}" data-media-title="{{ mediaItem.item.title }}">
     {% if mediaItem.item.type.isAudio %}
       {# Audio #}
       <div class="icon"></div>
@@ -84,6 +84,9 @@
         <div class="icon"></div>
       </div>
     {% endif %}
+    <button type="button" class="editMediaItem" data-fork="edit" title="{{ 'lbl.Edit'|trans }}">
+      {{ 'lbl.Edit'|trans|ucfirst }}
+    </button>
     <button type="button" class="disconnectMediaItem" data-fork="disconnect" title="{{ 'lbl.MediaDisconnect'|trans }}">
       {{ 'lbl.MediaDisconnect'|trans|ucfirst }}
     </button>


### PR DESCRIPTION
It is nice to edit the title of a media item within a from. When
there are a large amount of files it is hard to find the right file.
With this addition it is possible to click the edit pencil and change
the title.

## Type

- Enhancement

## Resolves the following issues

## Pull request description

With this function it would be able to change the title of a media item within a form. This means that the user doesn't have to search the whole library to find one item.
