### PR TITLE
Add some missing permissions to the admin group during installation

### DIFF
--- a/src/Backend/Modules/Extensions/Installer/Installer.php
+++ b/src/Backend/Modules/Extensions/Installer/Installer.php
@@ -34,6 +34,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'AddThemeTemplate');
         $this->setActionRights(1, $this->getModule(), 'DeleteThemeTemplate');
         $this->setActionRights(1, $this->getModule(), 'EditThemeTemplate');
+        $this->setActionRights(1, $this->getModule(), 'ExportThemeTemplates');
         $this->setActionRights(1, $this->getModule(), 'ThemeTemplates');
     }
 

--- a/src/Backend/Modules/Location/Installer/Installer.php
+++ b/src/Backend/Modules/Location/Installer/Installer.php
@@ -41,6 +41,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'Delete');
         $this->setActionRights(1, $this->getModule(), 'Edit');
         $this->setActionRights(1, $this->getModule(), 'Index');
+        $this->setActionRights(1, $this->getModule(), 'Settings');
         $this->setActionRights(1, $this->getModule(), 'SaveLiveLocation'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'UpdateMarker'); // AJAX
     }

--- a/src/Backend/Modules/Mailmotor/Installer/Installer.php
+++ b/src/Backend/Modules/Mailmotor/Installer/Installer.php
@@ -41,6 +41,7 @@ class Installer extends ModuleInstaller
 
         $this->setActionRights(1, $this->getModule(), 'Ping');
         $this->setActionRights(1, $this->getModule(), 'Settings');
+        $this->setActionRights(1, $this->getModule(), 'Index');
     }
 
     private function configureFrontendExtras(): void

--- a/src/Backend/Modules/Pages/Installer/Installer.php
+++ b/src/Backend/Modules/Pages/Installer/Installer.php
@@ -45,6 +45,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'Add');
         $this->setActionRights(1, $this->getModule(), 'Delete');
         $this->setActionRights(1, $this->getModule(), 'Edit');
+        $this->setActionRights(1, $this->getModule(), 'Copy');
         $this->setActionRights(1, $this->getModule(), 'GetInfo'); // AJAX
         $this->setActionRights(1, $this->getModule(), 'Index');
         $this->setActionRights(1, $this->getModule(), 'Move'); // AJAX

--- a/src/Backend/Modules/Profiles/Installer/Installer.php
+++ b/src/Backend/Modules/Profiles/Installer/Installer.php
@@ -48,6 +48,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'Import');
         $this->setActionRights(1, $this->getModule(), 'Index');
         $this->setActionRights(1, $this->getModule(), 'MassAction');
+        $this->setActionRights(1, $this->getModule(), 'Settings');
     }
 
     private function configureBackendActionRightsForProfileGroup(): void

--- a/src/Backend/Modules/Tags/Installer/Installer.php
+++ b/src/Backend/Modules/Tags/Installer/Installer.php
@@ -39,6 +39,7 @@ class Installer extends ModuleInstaller
         $this->setActionRights(1, $this->getModule(), 'Edit');
         $this->setActionRights(1, $this->getModule(), 'Index');
         $this->setActionRights(1, $this->getModule(), 'MassAction');
+        $this->setActionRights(1, $this->getModule(), 'GetAllTags');
     }
 
     private function configureFrontendExtras(): void


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
Some modules had actions that didn't have their permission set during the installation for the admin group

I didn't add the Settings:tools and Settings:ClearCache because it seemed like a good default not to give everybody access to that
<img width="197" alt="Screenshot 2020-10-26 at 08 06 14" src="https://user-images.githubusercontent.com/3634654/97143011-2599c380-1762-11eb-8178-ba508ee01485.png">
