### PR TITLE
Allow switching in the backend to a language that is disabled in the frontend

### DIFF
--- a/src/Backend/Core/Engine/TemplateModifiers.php
+++ b/src/Backend/Core/Engine/TemplateModifiers.php
@@ -149,7 +149,7 @@ class TemplateModifiers extends BaseTwigModifiers
         string $suffix = null,
         string $language = null
     ): string {
-        if (!in_array($language, BackendLanguage::getActiveLanguages())) {
+        if (!array_key_exists($language, BackendLanguage::getWorkingLanguages())) {
             $language = BackendLanguage::getWorkingLanguage();
         }
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
It was impossible to get a backend url for a language that was disabled in the frontend. This made it hard to prepare a language before enabling it in the frontend