### PR TITLE
Only copy the text and not the html when editing a value in a datagrid

### DIFF
--- a/src/Backend/Core/Js/jquery/jquery.backend.js
+++ b/src/Backend/Core/Js/jquery/jquery.backend.js
@@ -302,7 +302,7 @@
       var $this = $(this)
 
       // add wrapper and tooltip
-      $this.html('<span>' + $this.html() + '</span><span style="display: none;" class="inlineEditTooltip label label-primary">' + options.tooltip + '</span>')
+      $this.html('<span>' + $this.text() + '</span><span style="display: none;" class="inlineEditTooltip label label-primary">' + options.tooltip + '</span>')
 
       // grab element
       var $span = $this.find('span')


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #3147 
## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
html should be ignored when editing inline values in a datagrid