### PR TITLE
Prevent floating elements from covering the recaptcha badge

### DIFF
--- a/src/Frontend/Themes/Fork/Core/Layout/Sass/components/_forms.scss
+++ b/src/Frontend/Themes/Fork/Core/Layout/Sass/components/_forms.scss
@@ -10,3 +10,7 @@
 .alert-danger {
   color: $white !important;
 }
+
+.grecaptcha-badge {
+  z-index: 9000;
+}


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->
fixes #3002 
## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
Sticky footers or floating things sometimes covered the recaptcha badge. By adding a z-index to it we make sure the recaptcha badge is always on top
