### PR TITLE
Add composer v2 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  tools: composer:v1 # Use composer v1 until Fork CMS v6 is out with support for PHP 7.4
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, bcmath, intl, gd, exif, iconv, imagick
                   coverage: xdebug # Switch to PCOV for a speed gain when we can use PHP 7.2 & PHPUnit 8.0.
 
@@ -84,7 +83,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.1
-                  tools: composer:v1 # Use composer v1 until Fork CMS v6 is out with support for PHP 7.4
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, bcmath, intl, gd, exif, iconv, imagick
                   coverage: none
 
@@ -119,7 +117,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.1
-                  tools: composer:v1 # Use composer v1 until Fork CMS v6 is out with support for PHP 7.4
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, bcmath, intl, gd, exif, iconv, imagick
                   coverage: none
 
@@ -159,7 +156,6 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.1
-                  tools: composer:v1 # Use composer v1 until Fork CMS v6 is out with support for PHP 7.4
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, bcmath, intl, gd, exif, iconv, imagick
                   coverage: none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,8 @@ RUN pecl install xdebug && \
     rm -rf /tmp/pear
 
 # Install composer
-# Use composer v1 until Fork CMS v6 is out with support for PHP 7.4
 RUN curl -sS https://getcomposer.org/installer | \
-    php -- --install-dir=/usr/bin/ --filename=composer --version=1.10.16
+    php -- --install-dir=/usr/bin/ --filename=composer
 
 # Set the work directory to /var/www/html so all subsequent commands in this file start from that directory.
 # Also set this work directory so that it uses this directory everytime we use docker exec.

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "symfony/symfony": "^3.3",
         "tijsverkoyen/akismet": "1.1.*",
         "tijsverkoyen/css-to-inline-styles": "1.5.*",
-        "phpoffice/phpspreadsheet": "^1.12"
+        "phpoffice/phpspreadsheet": "^1.12",
+        "composer/package-versions-deprecated": "^1.11"
     },
     "require-dev": {
         "jdorn/sql-formatter": "1.2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64ddde09d27a7b526dc8b160a3b2c008",
+    "content-hash": "818c6630f51110e293cbae33e01c0b27",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -248,6 +248,79 @@
                 "monitor"
             ],
             "time": "2018-04-20T23:24:11+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-25T05:50:16+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -3175,56 +3248,6 @@
                 }
             ],
             "time": "2020-08-04T19:12:46+00:00"
-        },
-        {
-            "name": "ocramius/package-versions",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
-                "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.5.17"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-11-15T16:17:10+00:00"
         },
         {
             "name": "pacely/mailchimp-apiv3",
@@ -6663,5 +6686,5 @@
         "ext-intl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/ForkCMS/Tests/Utility/ThumbnailsTest.php
+++ b/src/ForkCMS/Tests/Utility/ThumbnailsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ForkCMS\Tests\Utility\Thumbnails;
+namespace ForkCMS\Tests\Utility;
 
 use ForkCMS\Utility\Thumbnails;
 use PHPUnit\Framework\TestCase;

--- a/tests/Utility/ThumbnailsTest.php
+++ b/tests/Utility/ThumbnailsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ForkCMS\Tests\Utility;
+namespace ForkCMS\Tests\Utility\Thumbnails;
 
 use ForkCMS\Utility\Thumbnails;
 use PHPUnit\Framework\TestCase;

--- a/tests/Utility/ThumbnailsTest.php
+++ b/tests/Utility/ThumbnailsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ForkCMS\Tests\Utility\Thumbnails;
+namespace ForkCMS\Tests\Utility;
 
 use ForkCMS\Utility\Thumbnails;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
https://twitter.com/packagist/status/1319945203797708800
https://php.watch/articles/composer-2
https://blog.packagist.com/composer-2-0-is-now-available/

Composer v2 is out 🎉 
However, doctrine contains `ocramius/package-versions` which forces composer v1 support. Unless you are on PHP 7.4. But we keep PHP 7.1 as min. version in Fork CMS 5.x. 

![image](https://user-images.githubusercontent.com/1352979/97219381-39791000-17ca-11eb-9910-c6693c3b5df7.png)


Luckily, @carakas found a fork by Composer itself: https://github.com/composer/package-versions-deprecated
Adding this, uninstalls `ocramius/package-versions` 🥇  and allows for Composer v2 support on PHP 7.1 in fork cms. 

I executed: 

```bash
composer self-update --2

composer require composer/package-versions-deprecated --with-all-dependencies
```

Now we enjoy faster install times and many other benefits 🥳 

![Screenshot 2020-10-26 at 20 34 26](https://user-images.githubusercontent.com/1352979/97219837-e18ed900-17ca-11eb-861f-be57aec45500.gif)
