### PR TITLE
Fix scrutinizer & coverage upload

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,17 +50,17 @@ jobs:
               run: composer install -o
 
             - name: Execute tests
-              run: bin/simple-phpunit --testsuite=${{ matrix.testsuite}} --coverage-clover=coverage.clover
+              run: bin/simple-phpunit --testsuite=${{ matrix.testsuite}} --coverage-clover=${{ matrix.testsuite}}.clover
 
             - name: Display error logs on failure
               if: ${{ failure() }}
               run: cat var/logs/test.log
 
             - name: Upload Coverage report
-              if: ${{ github.repository == 'forkcms/forkcms' }}
-              run: |
-                  curl -L https://scrutinizer-ci.com/ocular.phar > ./ocular.phar
-                  php ocular.phar code-coverage:upload -vvv --format=php-clover coverage.clover
+              uses: codecov/codecov-action@v1
+              with:
+                file: ${{ matrix.testsuite}}.clover
+                flags: ${{ matrix.testsuite}}
 
     phpstan:
         name: PHPStan - Static Code Analysis

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
               run: composer install -o
 
             - name: Execute tests
-              run: bin/simple-phpunit --testsuite=${{ matrix.testsuite}} --coverage-clover=${{ matrix.testsuite}}.clover
+              run: bin/simple-phpunit --testsuite=${{ matrix.testsuite}} --coverage-clover=coverage.clover
 
             - name: Display error logs on failure
               if: ${{ failure() }}
@@ -60,9 +60,7 @@ jobs:
               if: ${{ github.repository == 'forkcms/forkcms' }}
               run: |
                   curl -L https://scrutinizer-ci.com/ocular.phar > ./ocular.phar
-                  php ocular.phar code-coverage:upload --access-token="${SCRUTINIZER_ACCESS_TOKEN}" --format=php-clover ./${{ matrix.testsuite}}.clover
-              env:
-                  SCRUTINIZER_ACCESS_TOKEN: ${{ secrets.SCRUTINIZER_ACCESS_TOKEN }}
+                  php ocular.phar code-coverage:upload -vvv --format=php-clover coverage.clover
 
     phpstan:
         name: PHPStan - Static Code Analysis

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,59 @@
+build:
+    nodes:
+        analysis:
+            environment:
+                php:
+                    version: 7.1
+            cache:
+                disabled: false
+                directories:
+                    - ~/.composer/cache
+            project_setup:
+                override: true
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+filter:
+    excluded_paths:
+        - app/*
+        - bin/*
+        - docs/*
+        - src/Backend/Core/Js/ckfinder/*
+        - src/Backend/Core/Js/ckeditor/*
+        - var/*
+        - vendor/*
+
+tools:
+    external_code_coverage:
+        timeout: 3600
+        runs: 3 # Scrutinizer will wait for 3 code coverage submissions
+    php_mess_detector: true
+    sensiolabs_security_checker: true
+    php_code_coverage: true
+    php_cpd: false
+    php_sim: true
+    php_pdepend:
+        excluded_dirs:
+            - vendor
+
+application:
+    symfony2:
+        autoload_file: autoload.php
+    dependencies:
+        before:
+            - 'composer install --prefer-dist'
+
+checks:
+    php:
+        unused_variables: true
+        unused_properties: true
+        unused_parameters: true
+        variable_existence: true
+        unused_methods: true
+        symfony_request_injection: true
+        sql_injection_vulnerabilities: true
+        simplify_boolean_return: true
+        excluded_dependencies:
+            - simple-bus/doctrine-orm-bridge
+            - symfony/security-acl

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -25,12 +25,8 @@ filter:
         - vendor/*
 
 tools:
-    external_code_coverage:
-        timeout: 3600
-        runs: 3 # Scrutinizer will wait for 3 code coverage submissions
     php_mess_detector: true
     sensiolabs_security_checker: true
-    php_code_coverage: true
     php_cpd: false
     php_sim: true
     php_pdepend:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/forkcms/forkcms.svg?branch=testsuite)](https://travis-ci.org/forkcms/forkcms)
 [![Latest Stable Version](https://poser.pugx.org/forkcms/forkcms/v/stable)](https://packagist.org/packages/forkcms/forkcms)
 [![License](https://poser.pugx.org/forkcms/forkcms/license)](https://packagist.org/packages/forkcms/forkcms)
-[![Code Coverage](https://scrutinizer-ci.com/g/forkcms/forkcms/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/forkcms/forkcms/?branch=master)
+[![Code Coverage](https://codecov.io/gh/forkcms/forkcms/branch/master/graph/badge.svg?token=ahj70hVO29)](http://codecov.io/github/forkcms/forkcms?branch=master)
 [![Slack Status](https://fork-cms.herokuapp.com/badge.svg)](https://fork-cms.herokuapp.com/)
 [![Documentation Status](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://docs.fork-cms.com/)
 

--- a/src/Frontend/Modules/Blog/Actions/Index.php
+++ b/src/Frontend/Modules/Blog/Actions/Index.php
@@ -50,6 +50,11 @@ class Index extends FrontendBaseBlock
 
     private function getData(): void
     {
+        $test = true;
+        if ($test) {
+            $hello = "world";
+        }
+
         $this->pagination = $this->buildPaginationConfig();
         $this->articles = FrontendBlogModel::getAll($this->pagination['limit'], $this->pagination['offset']);
     }

--- a/src/Frontend/Modules/Blog/Actions/Index.php
+++ b/src/Frontend/Modules/Blog/Actions/Index.php
@@ -50,11 +50,6 @@ class Index extends FrontendBaseBlock
 
     private function getData(): void
     {
-        $test = true;
-        if ($test) {
-            $hello = "world";
-        }
-
         $this->pagination = $this->buildPaginationConfig();
         $this->articles = FrontendBlogModel::getAll($this->pagination['limit'], $this->pagination['offset']);
     }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

### On the topic of static code analysis
* Scrutinizer seems to rely on a global config we hardcoded in the settings of the scrutinized admin panel. It seemed a bit outdated... I added the `.scrutinizer.yml` in this repo, and cleaned it up a bit. Having it in the repo itself might help to keep it more up to date? Are we still sure we benefit from scrutinizer? I actually never looked at it in the past years, but I can't speak for others 🤔  I'd be more in favour of improving our **PHPStan** integration, which seems to be the more modern approach of static code analysis for PHP? But want to hear opinions to keep or remove it?
* I removed phpcs from scrutinizer's config since we already have that in our Github Actions.
* Adding phpstan github annotations: https://twitter.com/OndrejMirtes/status/1278262546819100684

### On the topic of code coverage
Scrutinizer is being a **pain**. It never seems to receive the coverage report we sent, even though it waits a long time for it, and the `--verbose` logs say that we successfully uploaded the file. Did numerous attempts. I have previous experience with the widely known coverage tool https://codecov.io and that seemed to work out of the box. I got it working in just a few minutes, by using their nice [Github workflow action](https://github.com/codecov/codecov-action) ready for use. I think there's a lot of benefits to codecov. It allows us to set a `.codecov.yml` with rules, like any PR cannot decrease coverage with more than 1%. And it allows us to browse the code on github with the [codecov browser extension](https://docs.codecov.io/docs/browser-extension) and see the source code of fork cms colored with red or green to easily spot code with no tests. 