### PR TITLE
Codecov should wait for 3 reports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /docs export-ignore
 /.github export-ignore
 .gitattributes export-ignore
-.travis.yml export-ignore
+.scrutinizer.yml export-ignore
+codecov.yml export-ignore

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+    notify:
+        after_n_builds: 3 # Let codecov wait for unit-tests, integration tests and installer tests
+        wait_for_ci: yes


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
We recently added Codecov for improved coverage calculation. But it already posts a message after 1 or 2 reports received. It should wait until all reports have been sent

See all options possible: https://docs.codecov.io/docs/codecovyml-reference#codecovnotify