### PR TITLE
Remove editor js import in php

### DIFF
--- a/src/Backend/Form/Type/EditorType.php
+++ b/src/Backend/Form/Type/EditorType.php
@@ -184,13 +184,6 @@ class EditorType extends TextareaType
     {
         parent::buildView($view, $form, $options);
 
-        $javaScriptUrls = $options['editorBlocks']->getJavaScriptUrls();
-        $javaScriptUrls['/js/vendors/editor.js'] = '/js/vendors/editor.js';
-
-        foreach ($javaScriptUrls as $url) {
-            $header->addJS($url, null, false, true, true, Priority::core());
-        }
-
         $view->vars['attr']['fork-block-editor-config'] = json_encode(
             $options['editorBlocks']->getConfig(),
             JSON_HEX_APOS

--- a/src/Common/BlockEditor/Blocks/AbstractBlock.php
+++ b/src/Common/BlockEditor/Blocks/AbstractBlock.php
@@ -36,9 +36,6 @@ abstract class AbstractBlock
      */
     abstract public function getValidation(): array;
 
-    /** The url to the JS file with the config needed to make this block work in the editor */
-    abstract public function getJavaScriptUrl(): ?string;
-
     abstract public function parse(array $data): string;
 
     final protected function parseWithTwig(string $template, array $data): string

--- a/src/Common/BlockEditor/Blocks/HeaderBlock.php
+++ b/src/Common/BlockEditor/Blocks/HeaderBlock.php
@@ -31,9 +31,4 @@ final class HeaderBlock extends AbstractBlock
     {
         return $this->parseWithTwig('Core/Layout/Templates/EditorBlocks/HeaderBlock.html.twig', $data);
     }
-
-    public function getJavaScriptUrl(): ?string
-    {
-        return '/js/vendors/editor.js';
-    }
 }

--- a/src/Common/BlockEditor/Blocks/ListBlock.php
+++ b/src/Common/BlockEditor/Blocks/ListBlock.php
@@ -34,9 +34,4 @@ final class ListBlock extends AbstractBlock
     {
         return $this->parseWithTwig('Core/Layout/Templates/EditorBlocks/ListBlock.html.twig', $data);
     }
-
-    public function getJavaScriptUrl(): ?string
-    {
-        return '/js/vendors/editor.js';
-    }
 }

--- a/src/Common/BlockEditor/Blocks/MediaLibraryImageBlock.php
+++ b/src/Common/BlockEditor/Blocks/MediaLibraryImageBlock.php
@@ -39,9 +39,4 @@ final class MediaLibraryImageBlock extends AbstractBlock
 
         return $this->parseWithTwig('Core/Layout/Templates/EditorBlocks/MediaLibraryImageBlock.html.twig', $data);
     }
-
-    public function getJavaScriptUrl(): ?string
-    {
-        return '/js/vendors/editor.js';
-    }
 }

--- a/src/Common/BlockEditor/Blocks/ParagraphBlock.php
+++ b/src/Common/BlockEditor/Blocks/ParagraphBlock.php
@@ -30,9 +30,4 @@ final class ParagraphBlock extends AbstractBlock
     {
         return $this->parseWithTwig('Core/Layout/Templates/EditorBlocks/ParagraphBlock.html.twig', $data);
     }
-
-    public function getJavaScriptUrl(): ?string
-    {
-        return '/js/vendors/editor.js';
-    }
 }

--- a/src/Common/BlockEditor/EditorBlocks.php
+++ b/src/Common/BlockEditor/EditorBlocks.php
@@ -58,11 +58,6 @@ final class EditorBlocks
         return true;
     }
 
-    public function getJavaScriptUrls(): array
-    {
-        return $this->javaScriptUrls;
-    }
-
     public static function createJsonFromHtml(string $html): ?string
     {
         $emptyCharacter = "\t\n\r\0\x0B ";

--- a/src/Common/BlockEditor/EditorBlocks.php
+++ b/src/Common/BlockEditor/EditorBlocks.php
@@ -33,10 +33,6 @@ final class EditorBlocks
         foreach ($editorBlocks as $editorBlock) {
             $this->config[$editorBlock->getName()] = $editorBlock->getConfig();
             $this->validation[$editorBlock->getName()] = $editorBlock->getValidation();
-            $javaScriptUrl = $editorBlock->getJavaScriptUrl();
-            if ($javaScriptUrl !== null) {
-                $this->javaScriptUrls[$javaScriptUrl] = $javaScriptUrl;
-            }
         }
 
         return $this;


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Drop feature request

## Pull request description

We do not use JS files that are stored in a vendor file. We know load all the JS plugins by importing them in de ES6 components.
So I removed the AddJS functions from the PHP.
