### PR TITLE
Fix deprecation notice MediaGroupMediaItemNotFound

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroup/MediaGroup.php
@@ -3,7 +3,7 @@
 namespace Backend\Modules\MediaLibrary\Domain\MediaGroup;
 
 use Backend\Modules\MediaLibrary\Domain\MediaGroupMediaItem\MediaGroupMediaItem;
-use Backend\Modules\MediaLibrary\Domain\MediaItem\Exception\MediaGroupMediaItemNotFound;
+use Backend\Modules\MediaLibrary\Domain\MediaGroupMediaItem\Exception\MediaGroupMediaItemNotFound;
 use Backend\Modules\MediaLibrary\Domain\MediaItem\MediaItem;
 use Countable;
 use Doctrine\Common\Collections\Collection;

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaGroupMediaItem/Exception/MediaGroupMediaItemNotFound.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaGroupMediaItem/Exception/MediaGroupMediaItemNotFound.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Backend\Modules\MediaLibrary\Domain\MediaItem\Exception;
+namespace Backend\Modules\MediaLibrary\Domain\MediaGroupMediaItem\Exception;
 
 class MediaGroupMediaItemNotFound extends \Exception
 {


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

```
Deprecation Notice: Class Backend\Modules\MediaLibrary\Domain\MediaItem\Exception\MediaGroupMediaItemNotFound located in ./src/Backend/Modules/MediaLibrary/Domain/MediaGroupMediaItem/Exception/MediaGroupMediaItemNotFound.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/Cellar/composer/1.7.2/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```
