### PR TITLE
Pin xdebug v2 for PHP 7.1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY var/docker/php/php.ini ${PHP_INI_DIR}/php.ini
 
 # Install and configure XDebug
-RUN pecl install xdebug && \
+RUN pecl install xdebug-2.9.8 && \
     docker-php-ext-enable xdebug && \
     rm -rf /tmp/pear
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
![image](https://user-images.githubusercontent.com/1352979/100660387-400f2000-3352-11eb-9357-1528e4457417.png)


Recently xdebug 3 was release, which dropped support for PHP 7.1. We still support this version so we need to pin the version (https://pecl.php.net/package/xdebug)