### PR TITLE
Duplicate user template images when copying page

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -14,8 +14,10 @@ use Backend\Modules\Pages\Engine\Model as BackendPagesModel;
 use Backend\Modules\Search\Engine\Model as BackendSearchModel;
 use Backend\Modules\Tags\Engine\Model as BackendTagsModel;
 use Backend\Modules\Profiles\Engine\Model as BackendProfilesModel;
+use Common\Core\Model;
 use ForkCMS\Utility\Thumbnails;
 use SpoonFormHidden;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -607,7 +609,7 @@ class Add extends BackendBaseActionAdd
                         (array) $this->form->getField('allow')->getValue(),
                         true
                     );
-                    
+
                     // link class
                     $data['link_class'] = $this->form->getField('link_class')->getValue();
                 }
@@ -741,7 +743,49 @@ class Add extends BackendBaseActionAdd
         $this->template->assign('showCopyWarning', true);
 
         $originalPage = BackendPagesModel::get($id);
-        $this->blocksContent = BackendPagesModel::getBlocks($id, $originalPage['revision_id']);
+
+        // Handle usertemplate images on copying a page, as otherwise the same path will be used.
+        // On changing/deleting a copied usertemplate image, the old image is deleted, breaking the usertemplate
+        // with the same image on the original page
+        $this->blocksContent = array_map(
+            function (array $block) {
+                // Only for usertemplates
+                if ($block['extra_type'] !== 'usertemplate') {
+                    return $block;
+                }
+
+                // Only usertemplates with image
+                if (strpos($block['html'], 'data-ft-type="image"') === false) {
+                    return $block;
+                }
+
+                // Find images in usertemplate
+                $blockElements = new Crawler($block['html']);
+                $images = $blockElements->filter('[data-ft-type="image"]');
+                $filesystem = new Filesystem();
+                $path = FRONTEND_FILES_PATH . '/Pages/UserTemplate';
+                $url = FRONTEND_FILES_URL . '/Pages/UserTemplate';
+                foreach ($images as $image) {
+                    $imagePath = $image->getAttribute('src');
+                    $basename = pathinfo($imagePath, PATHINFO_FILENAME);
+                    $extension = pathinfo($imagePath, PATHINFO_EXTENSION);
+                    $originalFilename = $basename . '.' . $extension;
+                    $filename = $originalFilename;
+
+                    // Generate a non-existing filename
+                    while ($filesystem->exists($path . '/' . $filename)) {
+                        $basename = Model::addNumber($basename);
+                        $filename = $basename . '.' . $extension;
+                    }
+
+                    $block['html'] = str_replace($imagePath, $url . '/' . $filename, $block['html']);
+                    $filesystem->copy($path . '/' . $originalFilename, $path . '/' . $filename);
+                }
+
+                return $block;
+            },
+            BackendPagesModel::getBlocks($id, $originalPage['revision_id'])
+        );
 
         return $originalPage;
     }


### PR DESCRIPTION
## Type
- Non critical bugfix

## Resolves the following issues
When copying pages with user templates which has images, the images will be linked with the same file. Which when you change the image in one of the user template, the other will be broken as the original image gets deleted.

## Pull request description
Duplicate the images of the user templates when copying a page.
