### PR TITLE
Add CLI command to install a module

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -186,14 +186,14 @@ abstract class Kernel extends BaseKernel
 
     public function isInstallingModule(): bool
     {
-        $isInstallingModuleRequest = preg_match('/\/private(\/\w\w)?\/extensions\/install_module\?/', $this->request->getRequestUri())
+        $isInstallingModuleHttp = preg_match('/\/private(\/\w\w)?\/extensions\/install_module\?/', $this->request->getRequestUri())
            && $this->request->query->has('module')
            && in_array($this->request->query->get('module'), $this->getAllPossibleModuleNames(), true);
-        $isInstallingModuleCommand = PHP_SAPI === "cli"
+        $isInstallingModuleCli = PHP_SAPI === "cli"
             && isset($_SERVER['INSTALLING_MODULE'])
             && in_array($_SERVER['INSTALLING_MODULE'], $this->getAllPossibleModuleNames(), true);
 
-        return $isInstallingModuleRequest || $isInstallingModuleCommand;
+        return $isInstallingModuleHttp || $isInstallingModuleCli;
     }
 
     private function getAllPossibleModuleNames(): array

--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -160,7 +160,7 @@ abstract class Kernel extends BaseKernel
 
         $moduleNames = [];
         if ($this->isInstallingModule()) {
-            $moduleNames[] = $this->request->query->get('module');
+            $moduleNames[] = $this->request->query->get('module') ?? $_SERVER['INSTALLING_MODULE'];
         }
 
         try {
@@ -186,9 +186,14 @@ abstract class Kernel extends BaseKernel
 
     public function isInstallingModule(): bool
     {
-        return preg_match('/\/private(\/\w\w)?\/extensions\/install_module\?/', $this->request->getRequestUri())
-               && $this->request->query->has('module')
-               && in_array($this->request->query->get('module'), $this->getAllPossibleModuleNames());
+        $isInstallingModuleRequest = preg_match('/\/private(\/\w\w)?\/extensions\/install_module\?/', $this->request->getRequestUri())
+           && $this->request->query->has('module')
+           && in_array($this->request->query->get('module'), $this->getAllPossibleModuleNames(), true);
+        $isInstallingModuleCommand = PHP_SAPI === "cli"
+            && isset($_SERVER['INSTALLING_MODULE'])
+            && in_array($_SERVER['INSTALLING_MODULE'], $this->getAllPossibleModuleNames(), true);
+
+        return $isInstallingModuleRequest || $isInstallingModuleCommand;
     }
 
     private function getAllPossibleModuleNames(): array

--- a/src/ForkCMS/Bundle/InstallerBundle/Console/InstallModuleCommand.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Console/InstallModuleCommand.php
@@ -109,7 +109,6 @@ class InstallModuleCommand extends Command
         });
 
         return $helper->ask($input, $output, $question);
-
     }
 
     private function getAlreadyInstalledModules(): array

--- a/src/ForkCMS/Bundle/InstallerBundle/Console/InstallModuleCommand.php
+++ b/src/ForkCMS/Bundle/InstallerBundle/Console/InstallModuleCommand.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace ForkCMS\Bundle\InstallerBundle\Console;
+
+use Backend\Core\Engine\Model as BackendModel;
+use Backend\Modules\Extensions\Engine\Model;
+use Backend\Modules\Extensions\Engine\Model as BackendExtensionsModel;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Exception;
+use PDO;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * This command allows you to install a module via the CLI
+ */
+class InstallModuleCommand extends Command
+{
+    /** @var SymfonyStyle */
+    private $formatter;
+
+    /** @var Connection */
+    private $dbConnection;
+
+    public function __construct(EntityManager $em)
+    {
+        parent::__construct();
+        $this->dbConnection = $em->getConnection();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('forkcms:install:module')
+            ->setDescription('Command to install a module in Fork CMS')
+            ->addArgument('module', InputArgument::OPTIONAL, 'Name of the module to install');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $this->formatter = new SymfonyStyle($input, $output);
+        $module = $this->getModuleToInstall($input, $output);
+
+        if (BackendExtensionsModel::existsModule($module)) {
+            // Make sure this module can be installed
+            $output->writeln("<comment>Validating if module can be installed...</comment>");
+            $this->validateIfModuleCanBeInstalled($module);
+
+            // Do the actual module install
+            $output->writeln("<comment>Installing module $module...</comment>");
+            BackendExtensionsModel::installModule($module);
+
+            // Remove our container cache after this installation
+            $output->writeln("<comment>Triggering cache clear...</comment>");
+            $symfonyCacheClearCommand = $this->getApplication()->find('cache:clear');
+            $symfonyCacheClearCommand->run(new ArrayInput(['--no-warmup' => true]), $output);
+
+            $output->writeln("<info>Module $module is installed succesfully 🎉!");
+        }
+    }
+
+    /**
+     * Get the module name from the input arguments, or by creating an interactive selection menu.
+     */
+    private function getModuleToInstall(InputInterface $input, OutputInterface $output): string
+    {
+        $moduleName = $input->getArgument('module');
+        $options = $this->getModulesToInstall();
+        if ($moduleName !== null && array_key_exists($moduleName, $options)) {
+            return $moduleName;
+        }
+
+        // Ask question
+        $output->writeln('<question>Select the module to install:</question>');
+
+        // Calculate max width to align the descriptions
+        $width = $this->getColumnWidth($options);
+
+        // Write the modules with name & description
+        foreach ($options as $option) {
+            $name = $option['name'];
+            $description = $option['description'];
+            $spacingWidth = $width - strlen($name);
+
+            $output->write(
+                sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $description),
+                $options
+            );
+        }
+
+        // Write the module selection question w/ autocomplete
+        $helper = $this->getHelper('question');
+        $question = new Question('<question>Your selection:</question> ');
+        $question->setAutocompleterValues(array_keys($options));
+        $question->setMaxAttempts(3);
+        $question->setValidator(function ($answer) use ($options) {
+            if (!array_key_exists($answer, $options)) {
+                throw new RunTimeException("Incorrect option: {$answer}");
+            }
+            return $answer;
+        });
+
+        return $helper->ask($input, $output, $question);
+
+    }
+
+    private function getAlreadyInstalledModules(): array
+    {
+        return $this->dbConnection
+            ->executeQuery('SELECT name FROM modules')
+            ->fetchAll(PDO::FETCH_COLUMN);
+    }
+
+    private function getModulesToInstall(): array
+    {
+        $modules = [];
+
+        $finder = new Finder();
+        $directories = $finder->directories()->in(__DIR__ . '/../../../../Backend/Modules')->depth(0);
+        $installedModules = $this->getAlreadyInstalledModules();
+
+        foreach ($directories->getIterator() as $directory) {
+            $name = $directory->getFilename();
+
+            // Skip module if already installed
+            if (in_array($name, $installedModules, true)) {
+                continue;
+            }
+
+            // Build array with module information
+            $moduleInformation = Model::getModuleInformation($name);
+            $description = preg_replace(['/\s{2,}/', '/[\t\n]/'], '', strip_tags($moduleInformation['data']['description']) ?? "");
+            $modules[$name] = [
+                'name' => $name,
+                'description' => strlen($description) > 100 ? substr($description, 0, 100)."..." : $description,
+            ];
+        }
+
+        ksort($modules);
+        return $modules;
+    }
+
+    /**
+     * Calculate the optimal column width for our interactive selection menu.
+     */
+    private function getColumnWidth(array $modules): int
+    {
+        $width = 0;
+        foreach ($modules as $module) {
+            $width = strlen($module['name']) > $width ? strlen($module['name']) : $width;
+        }
+
+        return $width + 2;
+    }
+
+
+    private function validateIfModuleCanBeInstalled(string $module): void
+    {
+        // Check if module is already installed
+        if (BackendModel::isModuleInstalled($module)) {
+            throw new Exception("Module is already installed");
+        }
+
+        // Check if installer class is present
+        if (!is_file(BACKEND_MODULES_PATH . '/' . $module . '/Installer/Installer.php')) {
+            throw new Exception("Module does not have an installer class");
+        }
+    }
+}

--- a/src/ForkCMS/Bundle/InstallerBundle/Resources/config/services.xml
+++ b/src/ForkCMS/Bundle/InstallerBundle/Resources/config/services.xml
@@ -19,5 +19,10 @@
             <argument type="service" id="forkcms.requirements.checker"/>
             <tag name="console.command" />
         </service>
+
+        <service id="forkcms.console.installer.install_module" class="ForkCMS\Bundle\InstallerBundle\Console\InstallModuleCommand">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <tag name="console.command" />
+        </service>
     </services>
 </container>

--- a/src/ForkCMS/Bundle/InstallerBundle/Resources/config/services.xml
+++ b/src/ForkCMS/Bundle/InstallerBundle/Resources/config/services.xml
@@ -22,6 +22,7 @@
 
         <service id="forkcms.console.installer.install_module" class="ForkCMS\Bundle\InstallerBundle\Console\InstallModuleCommand">
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="service" id="kernel"/>
             <tag name="console.command" />
         </service>
     </services>


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

When I setup CI/CD for a module, I kind of lack 
* Installing Fork CMS using CLI, so i have to load a `dump.sql` with the base schema of Fork CMS instead and generate the parameters.yml myself. 
* Running the installers of the modules I want to test in my CI/CD. It's kind of cumbersome to dump the module's tables to a `dump.sql` file and keep the sql dump up to date... because we work with Doctrine entities now anyway. Ideally, I can setup a database, import `dump.sql` (basic fork cms schema) and then install the module and the theme that I need (locale, tables, images, ...)

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
This PR adds a command that allows the developer to install a module using his CLI. E.g.


```bash
# Show an interactive question with autocomplete
bin/console forkcms:install:module

# Install a module without interaction
bin/console forkcms:install:module Faq
```

![Screenshot 2021-02-27 at 22 34 58](https://user-images.githubusercontent.com/1352979/109401126-211e2b00-794d-11eb-97d7-5e3385f544c0.gif)
