### PR TITLE
Refactor add css js methods

### DIFF
--- a/src/Backend/Core/Engine/Form.php
+++ b/src/Backend/Core/Engine/Form.php
@@ -80,8 +80,8 @@ class Form extends \Common\Core\Form
             $this->header->addJS(
                 '/src/Frontend/Cache/Navigation/editor_link_list_' . BackendLanguage::getWorkingLanguage() . '.js',
                 null,
-                false,
                 true,
+                false,
                 true
             );
         }

--- a/src/Backend/Core/Engine/Header.php
+++ b/src/Backend/Core/Engine/Header.php
@@ -144,9 +144,9 @@ final class Header extends KernelLoader
      *
      * @param string $file The file to load.
      * @param string $module The module wherein the file is located.
-     * @param bool $minify Should the javascript be minified?
      * @param bool $overwritePath Should we overwrite the full path?
      *                            An external url will always be handled with $overwritePath as true.
+     * @param bool $minify Should the javascript be minified?
      * @param bool $addTimestamp May we add a timestamp for caching purposes?
      * @param Priority $priority the files are added based on the priority
      *                           defaults to standard for full links or core or module for core or module css
@@ -154,8 +154,8 @@ final class Header extends KernelLoader
     public function addJS(
         string $file,
         string $module = null,
-        bool $minify = true,
         bool $overwritePath = false,
+        bool $minify = true,
         bool $addTimestamp = true,
         Priority $priority = null
     ): void {

--- a/src/Backend/Form/Type/EditorType.php
+++ b/src/Backend/Form/Type/EditorType.php
@@ -198,7 +198,7 @@ class EditorType extends TextareaType
         $javaScriptUrls['/js/vendors/editor.js'] = '/js/vendors/editor.js';
 
         foreach ($javaScriptUrls as $url) {
-            $header->addJS($url, null, false, true, true, Priority::core());
+            $header->addJS($url, null,true,false,true, Priority::core());
         }
 
         $view->vars['attr']['fork-block-editor-config'] = json_encode(
@@ -219,8 +219,8 @@ class EditorType extends TextareaType
             $header->addJS(
                 '/src/Frontend/Cache/Navigation/editor_link_list_' . $currentLanguage . '.js?m=' . $timestamp,
                 null,
-                false,
                 true,
+                false,
                 true
             );
         }

--- a/src/Backend/Form/Type/EditorType.php
+++ b/src/Backend/Form/Type/EditorType.php
@@ -198,7 +198,7 @@ class EditorType extends TextareaType
         $javaScriptUrls['/js/vendors/editor.js'] = '/js/vendors/editor.js';
 
         foreach ($javaScriptUrls as $url) {
-            $header->addJS($url, null,true,false,true, Priority::core());
+            $header->addJS($url, null, true, false, true, Priority::core());
         }
 
         $view->vars['attr']['fork-block-editor-config'] = json_encode(


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

Fixes #3305

## Pull request description

This PR refactors the addJS method of Engine/Header so that the parameter order matches addCSS. I only found a small amount of usage for this method, although it is still a breaking change for people that have used this method in their own modules.
