### PR TITLE
Security Fix for Open Redirect - huntr.dev

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4121,16 +4121,16 @@
         },
         {
             "name": "spoon/library",
-            "version": "3.2.5",
+            "version": "3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/forkcms/library.git",
-                "reference": "593c2061d83a8df4ac2b3600bed773de8ed0849a"
+                "reference": "8ea81341a17de89df80d8a4ba9beeaa035369d8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/forkcms/library/zipball/593c2061d83a8df4ac2b3600bed773de8ed0849a",
-                "reference": "593c2061d83a8df4ac2b3600bed773de8ed0849a",
+                "url": "https://api.github.com/repos/forkcms/library/zipball/8ea81341a17de89df80d8a4ba9beeaa035369d8e",
+                "reference": "8ea81341a17de89df80d8a4ba9beeaa035369d8e",
                 "shasum": ""
             },
             "require": {
@@ -4152,7 +4152,11 @@
             ],
             "description": "A PHP5 library that is fast, easy to learn and fun!",
             "homepage": "http://www.spoon-library.com",
-            "time": "2019-12-05T10:12:33+00:00"
+            "support": {
+                "issues": "https://github.com/forkcms/library/issues",
+                "source": "https://github.com/forkcms/library/tree/3.2.8"
+            },
+            "time": "2021-02-18T08:10:25+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Backend/Modules/Authentication/Actions/Index.php
+++ b/src/Backend/Modules/Authentication/Actions/Index.php
@@ -326,11 +326,10 @@ class Index extends BackendBaseActionIndex
 
     private function sanitizeQueryString(string $queryString, string $default): string
     {
-        // only allow internal urls starting with "\"
-        if (!preg_match('/^\//', $queryString)) {
+        if (!preg_match('/^\/[^\/]/', $queryString)) {
             return $default;
         }
 
-        return $queryString;
+        return filter_var($queryString, FILTER_SANITIZE_URL);
     }
 }

--- a/src/Backend/Modules/Authentication/Actions/Index.php
+++ b/src/Backend/Modules/Authentication/Actions/Index.php
@@ -326,7 +326,7 @@ class Index extends BackendBaseActionIndex
 
     private function sanitizeQueryString(string $queryString, string $default): string
     {
-        if (!preg_match('/^\/[^\/]/', $queryString)) {
+        if (!preg_match('/^\//', $queryString) or preg_match('/^\/[^a-zA-Z0-9.-_~]/', $queryString)) {
             return $default;
         }
 

--- a/src/Frontend/Modules/Profiles/Actions/Login.php
+++ b/src/Frontend/Modules/Profiles/Actions/Login.php
@@ -120,7 +120,7 @@ class Login extends FrontendBaseBlock
 
     private function sanitizeQueryString(string $queryString): string
     {
-        if (!preg_match('/^\/[^\/]/', $queryString)) {
+        if (!preg_match('/^\//', $queryString) or preg_match('/^\/[^a-zA-Z0-9.-_~]/', $queryString)) {
             return SITE_MULTILANGUAGE ? SITE_URL . '/' . LANGUAGE : SITE_URL;
         }
 


### PR DESCRIPTION
@EffectRenan (https://huntr.dev/users/EffectRenan) has fixed a potential Open Redirect vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/forkcms/pull/8

If you are happy with this disclosure, we would love to get a CVE assigned to the vulnerability. Feel free to credit @EffectRenan, the discloser found in the bounty URL (below) and @huntr-helper.

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/3-other-forkcms/

### ⚙️ Description *

The `forkcms` is vulnerable to `Open Redirect` through invalid characters in the URL path. It allows attackers to fool victims to access fake URLs.

### 💻 Technical Description *

The fix checks the string starts with `/` and the second character is a valid character like `a-zA-z09.-_~`.

### 🐛 Proof of Concept (PoC) *

With an authenticated user, access (localhost): http://localhost/private/en/authentication?querystring=/%01/effectrenan.com

### 🔥 Proof of Fix (PoF) *

Samples:
  http://localhost/private/en/authentication?querystring=/%00/effectrenan.com
  http://localhost/private/en/authentication?querystring=/%01/effectrenan.com
  http://localhost/private/en/authentication?querystring=//effectrenan.com

### 👍 User Acceptance Testing (UAT)

Samples:
  http://localhost/private/en/authentication?querystring=/test
  http://localhost/private/en/authentication?querystring=/.test
  http://localhost/private/en/authentication?querystring=/~test
  http://localhost/private/en/authentication?querystring=/0test
  http://localhost/private/en/authentication?querystring=/-test
  http://localhost/private/en/authentication?querystring=/_test