### PR TITLE
Fix XSS vulnerability in media upload

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemAddMovie.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemAddMovie.php
@@ -52,7 +52,7 @@ class MediaItemAddMovie extends BackendBaseAJAXAction
 
     protected function getMovieId(): string
     {
-        $movieId = trim($this->getRequest()->request->get('id'));
+        $movieId = htmlspecialchars(trim($this->getRequest()->request->get('id')), ENT_QUOTES | ENT_HTML5);
 
         // Movie id not null
         if (empty($movieId)) {
@@ -69,7 +69,7 @@ class MediaItemAddMovie extends BackendBaseAJAXAction
 
     protected function getMovieTitle(): string
     {
-        $movieTitle = trim($this->getRequest()->request->get('title'));
+        $movieTitle = htmlspecialchars(trim($this->getRequest()->request->get('title')), ENT_QUOTES | ENT_HTML5);
 
         // Title not valid
         if (empty($movieTitle)) {


### PR DESCRIPTION
(Pull request to wrong repository, github is weird)

### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://huntr.dev/bounties/8-other-forkcms/

### ⚙️ Description *

Fixes vulnerability that allows for HTML to be stored and executed in admin panel.

### 💻 Technical Description *

Fixes XSS vulnerability that allows HTML & XSS to be stored and executed in admin session. Converting HTML characters using `htmlspecialchars` will resolve the XSS issue while still allowing admins to use HTML display characters as part of their media title and (if necessary) media ID.

### 🐛 Proof of Concept (PoC) *

Payload: `<img src onerror=alert()>`

1. With an authenticated user, access: http://localhost/private/en/media_library/media_item_index.
2. Select the option Online movies (Youtube, Vimeo, ...) and click on Next.
3. Select any source and put the payload into Movie id or Movie title.
4. Click on Add movie.

Empty alert box will appear to user.

### 🔥 Proof of Fix (PoF) *

Payload: `<img src onerror=alert()>`

1. With an authenticated user, access: http://localhost/private/en/media_library/media_item_index.
2. Select the option Online movies (Youtube, Vimeo, ...) and click on Next.
3. Select any source and put the payload into Movie id or Movie title.
4. Click on Add movie.

No alert box will display to user and media will be shown.

### 👍 User Acceptance Testing (UAT)

No UAT performed