### PR TITLE
Fix broken thumbnail on blog edit

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/Edit.html.twig
@@ -81,7 +81,7 @@
                       <div class="row">
                         {% if item.image %}
                         <div class="col-lg-3">
-                          <img src="{{ FRONTEND_FILES_URL }}/Blog/images/200x200/{{ item.image }}" class="img-thumbnail" width="200" height="200" alt="{{ 'lbl.Image'|trans|ucfirst }}" />
+                          <img src="{{ FRONTEND_FILES_URL }}/Blog/images/128x128/{{ item.image }}" class="img-thumbnail" width="200" height="200" alt="{{ 'lbl.Image'|trans|ucfirst }}" />
                         </div>
                         <div class="col-lg-9">
                           {% endif %}


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
Seems like the change in #2757 caused a broken Blog image thumbnail for quite some time. There's no 200x200 folder. We only create a 128x128 image for blog images. Unless we should change this to 200x200?

* https://github.com/forkcms/forkcms/blob/master/src/Backend/Modules/Blog/Actions/Add.php#L153
* https://github.com/forkcms/forkcms/blob/master/src/Backend/Modules/Blog/Actions/Edit.php#L359

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/1352979/113360476-2d314a00-934a-11eb-80cd-19cdc5300479.png">
