### PR TITLE
Fix broken usertemplate rendering in backend

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -722,7 +722,7 @@ class Add extends BackendBaseActionAdd
 
     private function getHiddenJsonField(string $name, ?string $json): SpoonFormHidden
     {
-        return new class($name, htmlspecialchars($json)) extends SpoonFormHidden {
+        return new class($name, $json) extends SpoonFormHidden {
             public function getValue($allowHTML = null)
             {
                 return parent::getValue(true);

--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -1016,7 +1016,7 @@ class Edit extends BackendBaseActionEdit
 
     private function getHiddenJsonField(string $name, ?string $json): SpoonFormHidden
     {
-        return new class($name, htmlspecialchars($json)) extends SpoonFormHidden {
+        return new class($name, $json) extends SpoonFormHidden {
             public function getValue($allowHTML = null)
             {
                 return parent::getValue(true);


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

The usertemplates JSON from `extra_data` gets two times a `htmlspecialchars` applied in the  hidden field in the backend, and this causes a broken hidden field and a fatal javascript error in the backend. 

The root cause is that Spoon Library also started applying `htmlspecialchars` since https://github.com/forkcms/library/pull/80

This is how the hidden field of user templates  should look like:
```html
<input type="hidden" value="{&quot;title&quot;:&quot;Homepagina banner&quot;,&quot;description&quot;:&quot;Test&quot;,&quot;file&quot;:&quot;/src/Frontend/Themes/Custom/Core/Layout/Templates/UserTemplates/homepage-banner.html&quot;}" id="blockExtraData1" name="block_extra_data_1" />
```

However this is how they render in Fork CMS 5.9.3, because Spoon started to add the `htmlspecialchars` on hidden fields in the latest version, but Fork CMS was also adding `htmlspecialchars` in the Pages module on the hidden field:

```html
<input type="hidden" value="{&amp;quot;title&amp;quot;:&amp;quot;Homepagina banner&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Test&amp;quot;,&amp;quot;file&amp;quot;:&amp;quot;/src/Frontend/Themes/Custom/Core/Layout/Templates/UserTemplates/homepage-banner.html&amp;quot;}" id="blockExtraData1" name="block_extra_data_1" />
```

![Screenshot 2021-04-10 at 21 32 34@2x](https://user-images.githubusercontent.com/1352979/114286031-c0116900-9a5b-11eb-98e6-2a1b29b60c30.png)



Removing the `htmlspecialchars` fixes it in this case, since Spoon adds it before rendering