### PR TITLE
Improve consent dialog

### DIFF
--- a/src/ForkCMS/Privacy/ConsentDialog.php
+++ b/src/ForkCMS/Privacy/ConsentDialog.php
@@ -23,6 +23,11 @@ class ConsentDialog
         $this->cookie = $cookie;
     }
 
+    public function isDialogEnabled(): bool
+    {
+        return $this->settings->get('Core', 'show_consent_dialog', false);
+    }
+
     public function shouldDialogBeShown(): bool
     {
         // the cookiebar is hidden within the settings, so don't show it

--- a/src/Frontend/Core/Engine/Page.php
+++ b/src/Frontend/Core/Engine/Page.php
@@ -340,6 +340,7 @@ class Page extends KernelLoader
     {
         $consentDialog = $this->get(ConsentDialog::class);
 
+        $this->template->assignGlobal('privacyConsentEnabled', $consentDialog->isDialogEnabled());
         $this->template->assignGlobal('privacyConsentDialogHide', !$consentDialog->shouldDialogBeShown());
         $this->template->assignGlobal('privacyConsentDialogLevels', $consentDialog->getLevels());
     }

--- a/src/Frontend/Core/Js/frontend.js
+++ b/src/Frontend/Core/Js/frontend.js
@@ -163,10 +163,21 @@ jsFrontend.consentDialog = {
           }
         }
 
-          // store data in functional cookies for later usage
+        // store data in functional cookies for later usage
         utils.cookies.setCookie('privacy_consent_level_' + name + '_agreed', isChecked ? 1 : 0, 6 * 30)
         utils.cookies.setCookie('privacy_consent_hash', jsData.privacyConsent.levelsHash, 6 * 30)
+
+        // trigger events
+        var eventName = 'privacyConsentLevel' + niceName
+        if (isChecked) {
+          eventName += 'Agreed'
+        } else {
+          eventName += 'Disagreed'
+        }
+        $(document).trigger(eventName)
       }
+
+      $(document).trigger('privacyConsentChanged')
 
       $consentDialog.hide()
     })

--- a/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,68 +1,70 @@
-<div
-  id="privacyConsentDialog"
-  tabindex="-1"
-  role="dialog"
-  aria-labelledby="privacyConsentDialogTitle"
-  data-role="privacy_consent_dialog"
-  data-backdrop="false"
-  {% if privacyConsentDialogHide %}
-    style="display: none"
-  {% endif %}
->
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <form data-role="privacy_consent_dialog_form">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
-        </div>
-        <div class="modal-body">
-          <div>
-            {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
+{% if privacyConsentEnabled %}
+  <div
+    id="privacyConsentDialog"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="privacyConsentDialogTitle"
+    data-role="privacy_consent_dialog"
+    data-backdrop="false"
+    {% if privacyConsentDialogHide %}
+      style="display: none"
+    {% endif %}
+  >
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <form data-role="privacy_consent_dialog_form">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
           </div>
+          <div class="modal-body">
+            <div>
+              {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
+            </div>
 
-          <div class="checkbox">
-            <label id="privacyConsentLevelFunctionalCheckbox">
-              <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
-                     type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
-                     data-role="privacy-level"
-                     data-value="functional"
-              >
-              {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
-            </label>
-            <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
-              {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
-            </small>
-          </div>
-          {% for level in privacyConsentDialogLevels %}
             <div class="checkbox">
-              <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
-                <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
-                       id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
-                       aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
+              <label id="privacyConsentLevelFunctionalCheckbox">
+                <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
+                       type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
                        data-role="privacy-level"
-                       data-value="{{ level }}"
+                       data-value="functional"
                 >
-                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
+                {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
               </label>
-              <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
-                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
+              <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
+                {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
               </small>
             </div>
-          {% endfor %}
+            {% for level in privacyConsentDialogLevels %}
+              <div class="checkbox">
+                <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
+                  <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
+                         id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
+                         aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
+                         data-role="privacy-level"
+                         data-value="{{ level }}"
+                  >
+                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
+                </label>
+                <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
+                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
+                </small>
+              </div>
+            {% endfor %}
 
-          <div>
-            {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
+            <div>
+              {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
-            {{ 'msg.PrivacyConsentDialogSave'|trans }}
-          </button>
-        </div>
-      </form>
+          <div class="modal-footer">
+            <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
+              {{ 'msg.PrivacyConsentDialogSave'|trans }}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-</div>
+{% endif %}

--- a/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,67 +1,68 @@
-{% if not privacyConsentDialogHide %}
-  <div
-    id="privacyConsentDialog"
-    tabindex="-1"
-    role="dialog"
-    aria-labelledby="privacyConsentDialogTitle"
-    data-role="privacy_consent_dialog"
-    data-backdrop="false"
-  >
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <form data-role="privacy_consent_dialog_form">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
-              <span aria-hidden="true">&times;</span>
-            </button>
-            <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
+<div
+  id="privacyConsentDialog"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="privacyConsentDialogTitle"
+  data-role="privacy_consent_dialog"
+  data-backdrop="false"
+  {% if privacyConsentDialogHide %}
+    style="display: none"
+  {% endif %}
+>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form data-role="privacy_consent_dialog_form">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
+        </div>
+        <div class="modal-body">
+          <div>
+            {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
           </div>
-          <div class="modal-body">
-            <div>
-              {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
-            </div>
 
+          <div class="checkbox">
+            <label id="privacyConsentLevelFunctionalCheckbox">
+              <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
+                     type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
+                     data-role="privacy-level"
+                     data-value="functional"
+              >
+              {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
+            </label>
+            <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
+              {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
+            </small>
+          </div>
+          {% for level in privacyConsentDialogLevels %}
             <div class="checkbox">
-              <label id="privacyConsentLevelFunctionalCheckbox">
-                <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
-                       type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
+              <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
+                <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
+                       id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
+                       aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
                        data-role="privacy-level"
-                       data-value="functional"
+                       data-value="{{ level }}"
                 >
-                {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
+                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
               </label>
-              <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
-                {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
+              <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
+                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
               </small>
             </div>
-            {% for level in privacyConsentDialogLevels %}
-              <div class="checkbox">
-                <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
-                  <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
-                         id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
-                         aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
-                         data-role="privacy-level"
-                         data-value="{{ level }}"
-                  >
-                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
-                </label>
-                <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
-                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
-                </small>
-              </div>
-            {% endfor %}
+          {% endfor %}
 
-            <div>
-              {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
-            </div>
+          <div>
+            {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
           </div>
-          <div class="modal-footer">
-            <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
-              {{ 'msg.PrivacyConsentDialogSave'|trans }}
-            </button>
-          </div>
-        </form>
-      </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
+            {{ 'msg.PrivacyConsentDialogSave'|trans }}
+          </button>
+        </div>
+      </form>
     </div>
   </div>
-{% endif %}
+</div>

--- a/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,6 +1,13 @@
 {% if not privacyConsentDialogHide %}
-  <div id="privacyConsentDialog" tabindex="-1" role="dialog" aria-labelledby="privacyConsentDialogTitle" data-role="privacy_consent_dialog" data-backdrop="false">
-    <div class="modal-dialog"  role="document">
+  <div
+    id="privacyConsentDialog"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="privacyConsentDialogTitle"
+    data-role="privacy_consent_dialog"
+    data-backdrop="false"
+  >
+    <div class="modal-dialog" role="document">
       <div class="modal-content">
         <form data-role="privacy_consent_dialog_form">
           <div class="modal-header">

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,67 +1,69 @@
-<div
-  id="privacyConsentDialog"
-  tabindex="-1"
-  role="dialog"
-  aria-labelledby="privacyConsentDialogTitle"
-  data-role="privacy_consent_dialog"
-  data-backdrop="false"
-  {% if privacyConsentDialogHide %}
-    style="display: none"
-  {% endif %}
->
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <form data-role="privacy_consent_dialog_form">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
-            <span aria-hidden="true">&times;</span>
-          </button>
-          <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
-        </div>
-        <div class="modal-body">
-          <div>
-            {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
+{% if privacyConsentEnabled %}
+  <div
+    id="privacyConsentDialog"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="privacyConsentDialogTitle"
+    data-role="privacy_consent_dialog"
+    data-backdrop="false"
+    {% if privacyConsentDialogHide %}
+      style="display: none"
+    {% endif %}
+  >
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <form data-role="privacy_consent_dialog_form">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
+              <span aria-hidden="true">&times;</span>
+            </button>
+            <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
           </div>
+          <div class="modal-body">
+            <div>
+              {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
+            </div>
 
-          <div class="checkbox">
-            <label id="privacyConsentLevelFunctionalCheckbox">
-              <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
-                     type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
-                     data-role="privacy-level"
-                     data-value="functional"
-              >
-              {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
-            </label>
-            <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
-              {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
-            </small>
-          </div>
-          {% for level in privacyConsentDialogLevels %}
             <div class="checkbox">
-              <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
-                <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
-                       id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
-                       aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
+              <label id="privacyConsentLevelFunctionalCheckbox">
+                <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
+                       type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
                        data-role="privacy-level"
-                       data-value="{{ level }}"
+                       data-value="functional"
                 >
-                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
+                {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
               </label>
-              <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
-                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
+              <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
+                {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
               </small>
             </div>
-          {% endfor %}
-          <div>
-            {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
+            {% for level in privacyConsentDialogLevels %}
+              <div class="checkbox">
+                <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
+                  <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
+                         id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
+                         aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
+                         data-role="privacy-level"
+                         data-value="{{ level }}"
+                  >
+                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
+                </label>
+                <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
+                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
+                </small>
+              </div>
+            {% endfor %}
+            <div>
+              {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
-            {{ 'msg.PrivacyConsentDialogSave'|trans }}
-          </button>
-        </div>
-      </form>
+          <div class="modal-footer">
+            <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
+              {{ 'msg.PrivacyConsentDialogSave'|trans }}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
-</div>
+{% endif %}

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,66 +1,67 @@
-{% if not privacyConsentDialogHide %}
-  <div
-    id="privacyConsentDialog"
-    tabindex="-1"
-    role="dialog"
-    aria-labelledby="privacyConsentDialogTitle"
-    data-role="privacy_consent_dialog"
-    data-backdrop="false"
-  >
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <form data-role="privacy_consent_dialog_form">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
-              <span aria-hidden="true">&times;</span>
-            </button>
-            <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
+<div
+  id="privacyConsentDialog"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="privacyConsentDialogTitle"
+  data-role="privacy_consent_dialog"
+  data-backdrop="false"
+  {% if privacyConsentDialogHide %}
+    style="display: none"
+  {% endif %}
+>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form data-role="privacy_consent_dialog_form">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'lbl.Close'|trans }}">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h5 id="privacyConsentDialogTitle">{{ 'msg.PrivacyConsentDialogTitle'|trans|raw }}</h5>
+        </div>
+        <div class="modal-body">
+          <div>
+            {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
           </div>
-          <div class="modal-body">
-            <div>
-              {{ 'msg.PrivacyConsentDialogBefore'|trans|raw }}
-            </div>
 
+          <div class="checkbox">
+            <label id="privacyConsentLevelFunctionalCheckbox">
+              <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
+                     type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
+                     data-role="privacy-level"
+                     data-value="functional"
+              >
+              {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
+            </label>
+            <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
+              {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
+            </small>
+          </div>
+          {% for level in privacyConsentDialogLevels %}
             <div class="checkbox">
-              <label id="privacyConsentLevelFunctionalCheckbox">
-                <input name="privacyConsentLevelFunctionalCheckbox" id="privacyConsentLevelFunctionalCheckbox"
-                       type="checkbox" checked disabled aria-describedby="privacyConsentLevelFunctionalHelpBlock"
+              <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
+                <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
+                       id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
+                       aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
                        data-role="privacy-level"
-                       data-value="functional"
+                       data-value="{{ level }}"
                 >
-                {{ 'msg.PrivacyConsentLevelFunctionalTitle'|trans|raw }}
+                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
               </label>
-              <small id="privacyConsentLevelFunctionalHelpBlock" class="help-block">
-                {{ 'msg.PrivacyConsentLevelFunctionalText'|trans|raw }}
+              <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
+                {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
               </small>
             </div>
-            {% for level in privacyConsentDialogLevels %}
-              <div class="checkbox">
-                <label id="privacyConsentLevel{{ level|ucfirst }}Checkbox">
-                  <input name="privacyConsentLevel{{ level|ucfirst }}Checkbox"
-                         id="privacyConsentLevel{{ level|ucfirst }}Checkbox" type="checkbox"
-                         aria-describedby="privacyConsentLevel{{ level|ucfirst }}HelpBlock"
-                         data-role="privacy-level"
-                         data-value="{{ level }}"
-                  >
-                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Title')|trans|raw }}
-                </label>
-                <small id="privacyConsentLevel{{ level|ucfirst }}HelpBlock" class="help-block">
-                  {{ ('msg.PrivacyConsentLevel' ~ level|ucfirst ~ 'Text')|trans|raw }}
-                </small>
-              </div>
-            {% endfor %}
-            <div>
-              {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
-            </div>
+          {% endfor %}
+          <div>
+            {{ 'msg.PrivacyConsentDialogAfter'|trans|raw }}
           </div>
-          <div class="modal-footer">
-            <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
-              {{ 'msg.PrivacyConsentDialogSave'|trans }}
-            </button>
-          </div>
-        </form>
-      </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" data-role="privacy_consent_dialog_save_button" class="btn btn-sm btn-success">
+            {{ 'msg.PrivacyConsentDialogSave'|trans }}
+          </button>
+        </div>
+      </form>
     </div>
   </div>
-{% endif %}
+</div>

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/PrivacyConsentDialog.html.twig
@@ -1,6 +1,13 @@
 {% if not privacyConsentDialogHide %}
-  <div id="privacyConsentDialog" tabindex="-1" role="dialog" aria-labelledby="privacyConsentDialogTitle" data-role="privacy_consent_dialog" data-backdrop="false">
-    <div class="modal-dialog"  role="document">
+  <div
+    id="privacyConsentDialog"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="privacyConsentDialogTitle"
+    data-role="privacy_consent_dialog"
+    data-backdrop="false"
+  >
+    <div class="modal-dialog" role="document">
       <div class="modal-content">
         <form data-role="privacy_consent_dialog_form">
           <div class="modal-header">


### PR DESCRIPTION
## Type

- Enhancement
- Feature

## Pull request description

### Trigger events
    
A JS event is triggered in the document when the Consent dialog is submitted.
    
* `privacyConsentChanged`: is always triggered when the dialog is submitted.
* `privacyConsentLevelXXXAgreed`: is triggered when consent is given for that level.
* `privacyConsentLevelXXXDisagreed`: is triggered when consent is not given for that level.
    
<small>`XXX` is replaced by the ucfirst version of the level.</small>

### Better rendering of the dialog.

Don't render HTML if the dialog is disabled through the settings. But render the HTML if it is enabled so you can open the dialog with JS.
   
_Remark:_ If you include your own version of the HTML of the dialog you will need to implement the changes in your own theme.