### PR TITLE
Security Fix for Stored XSS - huntr.dev

### DIFF
--- a/src/Backend/Modules/Search/Actions/Statistics.php
+++ b/src/Backend/Modules/Search/Actions/Statistics.php
@@ -50,8 +50,8 @@ class Statistics extends Action
     {
         $data = unserialize($data, ['allowed_classes' => false]);
 
-        if (isset($data['server']['HTTP_REFERER'])) {                          
-            $referrer = $data['server']['HTTP_REFERER'];        
+        if (isset($data['server']['HTTP_REFERER'])) {
+            $referrer = $data['server']['HTTP_REFERER'];
             if (preg_match('/^(http|https):\/\//', $referrer)) {
                 $referrer = htmlspecialchars($referrer);
                 return '<a href="' . $referrer . '">' . $referrer . '</a>';


### PR DESCRIPTION
@EffectRenan (https://huntr.dev/users/EffectRenan) has fixed a potential Stored XSS vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/forkcms/pull/13

If you are happy with this disclosure, we would love to get a CVE assigned to the vulnerability. Feel free to credit @EffectRenan, the discloser found in the bounty URL (below) and @huntr-helper.

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/9-other-forkcms/

### ⚙️ Description *

The `forkcms` is vulnerable to XSS through search request. It is possible to set the HTTP referer header to `javascript:`.

### 💻 Technical Description *

The referer is not being sanitized correctly. It doesn't check if the referer is a valid URL.

### 🐛 Proof of Concept (PoC) *

Execute the following command (localhost):

```shell
curl -H 'Referer: javascript:alert()' 'http://localhost/search?form=search&q_widget=poc&submit=search'
```

With an authenticated user, access `http://localhost/private/en/search/statistics`.

Click on `javascript:alert()`.

PoC image: https://i.imgur.com/EIMofDE.png

### 🔥 Proof of Fix (PoF) *

With an authenticated user, access `http://localhost/private/en/search/statistics`.

Now you cannot see searches made from `javascript:`.

### 👍 User Acceptance Testing (UAT)

Test 1:
```shell
curl -H 'Referer: http://effectrenan.com' 'http://localhost/search?form=search&q_widget=poc&submit=search'
```

Test 2:
```shell
curl -H 'Referer: https://effectrenan.com' 'http://localhost/search?form=search&q_widget=poc&submit=search'
```