### PR TITLE
Correct wrong method used in the front-end FAQ category widget

### DIFF
--- a/src/Frontend/Modules/Faq/Engine/Model.php
+++ b/src/Frontend/Modules/Faq/Engine/Model.php
@@ -91,7 +91,7 @@ class Model implements FrontendTagsInterface
 
     public static function getCategoryById(int $id): array
     {
-        return FrontendModel::get('faq.repository.category')->findOne(
+        return FrontendModel::get('faq.repository.category')->findOneBy(
             [
                 'id' => $id,
                 'locale' => Locale::frontendLanguage()


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

/

## Pull request description

Wrong method name was used when looking for a single FAQ category when the widget is used. Small fix :)
