### PR TITLE
prevent htmlspecialchars being executed twice on user_template extrad…

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Edit.php
+++ b/src/Backend/Modules/Pages/Actions/Edit.php
@@ -483,12 +483,7 @@ class Edit extends BackendBaseActionEdit
                 'block_extra_type_' . $block['index'],
                 $block['extra_type']
             );
-            $this->form->add(
-                $this->getHiddenJsonField(
-                    'block_extra_data_' . $block['index'],
-                    $block['extra_data']
-                )
-            );
+            $this->form->addHidden('block_extra_data_' . $block['index'],  $block['extra_data']);
             $block['formElements']['hidExtraData'] = $this->form->getField('block_extra_data_' . $block['index']);
             $block['formElements']['hidPosition'] = $this->form->addHidden(
                 'block_position_' . $block['index'],
@@ -1012,15 +1007,5 @@ class Edit extends BackendBaseActionEdit
             ['module' => $this->getModule()]
         );
         $this->template->assign('deleteForm', $deleteForm->createView());
-    }
-
-    private function getHiddenJsonField(string $name, ?string $json): SpoonFormHidden
-    {
-        return new class($name, $json) extends SpoonFormHidden {
-            public function getValue($allowHTML = null)
-            {
-                return parent::getValue(true);
-            }
-        };
     }
 }

--- a/src/Backend/Modules/Pages/Js/Pages.js
+++ b/src/Backend/Modules/Pages/Js/Pages.js
@@ -238,6 +238,7 @@ jsBackend.pages.extras = {
     } else if (extraType === 'usertemplate') {
       // user template
       if (typeof extraData === 'string' && extraData !== '') {
+        extraData = ($('<textarea />').html(extraData).text())
         extraData = JSON.parse(extraData)
       }
 


### PR DESCRIPTION
…ata + prevent json parse from crashing

## Type

- Non critical bugfix

## Resolves the following issues


## Pull request description

Prevent htmlspecialchars being executed twice on extra data for user_templates and prevent JSON.parse crashing when reading extradata
