### PR TITLE
Fix xss trough media item title in datagrid

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -1586,7 +1586,7 @@ jsBackend.mediaLibraryHelper.templates = {
     }
 
     html += '<td class="url"><label for="media-' + mediaItem.id + '-checkbox">' + mediaItem.url + '</label></td>'
-    html += '<td class="title"><label for="media-' + mediaItem.id + '-checkbox">' + mediaItem.title + '</label></td>'
+    html += '<td class="title"><label for="media-' + mediaItem.id + '-checkbox">' + utils.string.htmlEncode(mediaItem.title) + '</label></td>'
     html += '</tr>'
 
     return html


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Security

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
It was possible to perform an xss attack by changing the title of a media item. When building the media item datagrid that javascript in the title of the item would be executed
