### PR TITLE
Fix xss in mediaitem type movie id on edit

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemDataGrid.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemDataGrid.php
@@ -208,6 +208,7 @@ class MediaItemDataGrid extends DataGridDatabase
 
         // our JS needs to know an id, so we can highlight it
         $this->setRowAttributes(['id' => 'row-[id]']);
+        $this->setColumnFunction('htmlspecialchars', ['[url]'], 'url', false);
         $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
     }
 }

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemSelectionDataGrid.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemSelectionDataGrid.php
@@ -152,6 +152,7 @@ class MediaItemSelectionDataGrid extends DataGridDatabase
             true
         );
         $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
+        $this->setColumnFunction('htmlspecialchars', ['[url]'], 'url', false);
     }
 
     private function addDataAttributes(): void

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemType.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItemType.php
@@ -5,6 +5,7 @@ namespace Backend\Modules\MediaLibrary\Domain\MediaItem;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class MediaItemType extends AbstractType
 {
@@ -14,16 +15,20 @@ class MediaItemType extends AbstractType
 
         if ($builder->getData()->getMediaItemEntity()->getType()->isMovie()) {
             $label = 'lbl.MediaMovieTitle';
-            $this->addField($builder, 'url', 'lbl.MediaMovieId');
+            $builder->add(
+                'url',
+                TextType::class,
+                [
+                    'label' => 'lbl.MediaMovieId',
+                    'constraints' => [
+                        new Regex(['pattern' => '/^[a-zA-Z]+[a-zA-Z0-9._]+$/', 'message' => 'err.InvalidValue']),
+                    ],
+                ]
+            );
         }
 
-        $this->addField($builder, 'title', $label);
-    }
-
-    private function addField(FormBuilderInterface $builder, string $name, string $label): void
-    {
         $builder->add(
-            $name,
+            'title',
             TextType::class,
             [
                 'label' => $label,


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Security

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

In fork 5.10.0 we fixed this for adding new media items but somehow the edit wasn't fixed. Mea culpa.
