### PR TITLE
Fixed GenarteUrl to allow Backend Locale

### DIFF
--- a/src/Backend/Core/Ajax/GenerateUrl.php
+++ b/src/Backend/Core/Ajax/GenerateUrl.php
@@ -3,6 +3,7 @@
 namespace Backend\Core\Ajax;
 
 use Backend\Core\Engine\Base\AjaxAction as BackendBaseAJAXAction;
+use Backend\Core\Language\Locale;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,7 +23,9 @@ class GenerateUrl extends BackendBaseAJAXAction
         $parameters = $this->getRequest()->request->get('parameters', '');
 
         // cleanup values
-        $parameters = @unserialize($parameters, ['allowed_classes' => false]);
+        $parameters = @unserialize($parameters, ['allowed_classes' => [
+            Locale::class,
+        ]]);
 
         // fetch generated meta url
         $url = urldecode($this->get('fork.repository.meta')->generateUrl($url, $className, $methodName, $parameters));


### PR DESCRIPTION
## Type

- Critical bugfix

## Resolves the following issues

No issue attached

## Pull request description

When you would use MetaType to add SEO data to an entity you would probably use a `getUrl` method. While generating the url a Backend Locale class would be send. Unserialize would mark all classes as incomplete, and this would result in a 500 error.

This pull request allows the `Backend\Core\Language\Locale` and would mark all other classes as incomplete. 500 error has been gone and all url's are generated as expected.

