### PR TITLE
overwrite filterAction of ImagineController to skip filter for svg im…

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -77,6 +77,8 @@ liip_imagine:
                 locator: filesystem_insecure
     cache: default
     data_loader: default
+    controller:
+        filter_action:  ForkCMS\ImagineController:filterAction
 
     # your filter sets are defined here
     filter_sets:
@@ -272,3 +274,7 @@ services:
         arguments:
             - "@fork.settings"
             - "@fork.cookie"
+
+    ForkCMS\ImagineController:
+        public: true
+        autowire: true

--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
@@ -190,7 +190,7 @@ class MediaItem implements JsonSerializable
 
         $mediaItem->setForFile($file);
 
-        if ($mediaItem->getMime() !== 'image/svg+xml') {
+        if (!in_array($mediaItem->getMime(), ['image/svg', 'image/svg+xml'])) {
             $mediaItem->setResolutionFromPath($path);
         } else {
             $mediaItem->setResolutionForSvg($path);

--- a/src/Backend/Modules/MediaLibrary/Resources/config/services.yml
+++ b/src/Backend/Modules/MediaLibrary/Resources/config/services.yml
@@ -1,6 +1,6 @@
 parameters:
     media_library.image_extensions: [gif, jpeg, jpg, png, tiff, svg]
-    media_library.image_mime_types: [image/gif, image/jpeg, image/pjpeg, image/png, image/tiff, image/x-tiff, image/svg+xml]
+    media_library.image_mime_types: [image/gif, image/jpeg, image/pjpeg, image/png, image/tiff, image/x-tiff, image/svg, image/svg+xml]
 
     media_library.file_extensions: [doc, docx, pdf]
     media_library.file_mime_types: [application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/pdf]

--- a/src/ForkCMS/ImagineController.php
+++ b/src/ForkCMS/ImagineController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ForkCMS;
+
+use Imagine\Exception\RuntimeException;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
+use Liip\ImagineBundle\Exception\Imagine\Filter\NonExistingFilterException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ImagineController extends \Liip\ImagineBundle\Controller\ImagineController
+{
+    /**
+     * This action applies a given filter to a given image, optionally saves the image and outputs it to the browser at the same time.
+     *
+     * @param Request $request
+     * @param string  $path
+     * @param string  $filter
+     *
+     * @throws \RuntimeException
+     * @throws BadRequestHttpException
+     *
+     * @return RedirectResponse
+     */
+    public function filterAction(Request $request, $path, $filter)
+    {
+        // decoding special characters and whitespaces from path obtained from url
+        $path = urldecode($path);
+        $resolver = $request->get('resolver');
+
+        try {
+            if (!$this->cacheManager->isStored($path, $filter, $resolver)) {
+                try {
+                    $binary = $this->dataManager->find($filter, $path);
+                } catch (NotLoadableException $e) {
+                    if ($defaultImageUrl = $this->dataManager->getDefaultImageUrl($filter)) {
+                        return new RedirectResponse($defaultImageUrl);
+                    }
+
+                    throw new NotFoundHttpException('Source image could not be found', $e);
+                }
+
+                if ($binary->getFormat() === 'svg') {
+                    $this->cacheManager->store(
+                        $binary,
+                        $path,
+                        $filter,
+                        $resolver
+                    );
+                } else {
+                    $this->cacheManager->store(
+                        $this->filterManager->applyFilter($binary, $filter),
+                        $path,
+                        $filter,
+                        $resolver
+                    );
+                }
+            }
+
+            return new RedirectResponse($this->cacheManager->resolve($path, $filter, $resolver), $this->redirectResponseCode);
+        } catch (NonExistingFilterException $e) {
+            $message = sprintf('Could not locate filter "%s" for path "%s". Message was "%s"', $filter, $path, $e->getMessage());
+
+            if (null !== $this->logger) {
+                $this->logger->debug($message);
+            }
+
+            throw new NotFoundHttpException($message, $e);
+        } catch (RuntimeException $e) {
+            throw new \RuntimeException(sprintf('Unable to create image for path "%s" and filter "%s". Message was "%s"', $path, $filter, $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/src/ForkCMS/ImagineController.php
+++ b/src/ForkCMS/ImagineController.php
@@ -42,7 +42,7 @@ class ImagineController extends \Liip\ImagineBundle\Controller\ImagineController
                     throw new NotFoundHttpException('Source image could not be found', $e);
                 }
 
-                if ($binary->getFormat() === 'svg') {
+                if (in_array($binary->getMimeType(), ['image/svg', 'image/svg+xml'])) {
                     $this->cacheManager->store(
                         $binary,
                         $path,


### PR DESCRIPTION
…ages

## Type

- Non critical bugfix

## Resolves the following issues

Don't apply a filter on svg images so they can be displayed
