### PR TITLE
Fix deleting cookies

### DIFF
--- a/src/Common/Core/Cookie.php
+++ b/src/Common/Core/Cookie.php
@@ -71,6 +71,9 @@ final class Cookie
         bool $secure = null,
         bool $httpOnly = true
     ): void {
+        // remove from the new cookies array
+        $this->newCookiesHeaderBag->removeCookie($name, $path, $this->normalizeDomain($domain));
+
         // clear in the browser
         $this->newCookiesHeaderBag->clearCookie(
             $name,
@@ -79,9 +82,6 @@ final class Cookie
             $this->normalizeSecure($secure),
             $httpOnly
         );
-
-        // remove from the new cookies array
-        $this->newCookiesHeaderBag->removeCookie($name, $path, $this->normalizeDomain($domain));
 
         // remove from the request
         unset($_COOKIE[$name]);


### PR DESCRIPTION
## Type
- Critical bugfix

## Pull request description

When deleting cookies, the current code adds a cookie with 1s expire time, but the next line removes this cookie again. Swapping those lines fixes this issue.

Note: there is also another issue that the deleting of cookie on RedirectResponse (Logout) is not persisted. But the Authentication has a backup check where it gets deleted in a "normal" fork action, which works.
