### PR TITLE
Fix mapping old content blocks when copying pages

### DIFF
--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -238,7 +238,7 @@ class Model
                 $block['edited_on'] = BackendModel::getUTCDate();
 
                 // Overwrite the extra_id of the old content block with the id of the new one
-                if (in_array($block['extra_id'], $contentBlockOldIds, true)) {
+                if (in_array((int) $block['extra_id'], $contentBlockOldIds, true)) {
                     $block['extra_id'] = $contentBlockIds[$block['extra_id']];
                 }
 


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When copying pages with content blocks on, through the hidden copy pages action, the mapping of old to new content block/module extra id didn't work properly. The block extra id was a string and the content block extra id was an int. With the strict parameter of in_array, this wasn't mapped correctly after the copy.
