### PR TITLE
Copy forms and their widgets when making a language copy

### DIFF
--- a/src/Backend/Modules/FormBuilder/Command/CopyFormWidgetsToOtherLocale.php
+++ b/src/Backend/Modules/FormBuilder/Command/CopyFormWidgetsToOtherLocale.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Command;
+
+use Backend\Core\Language\Locale;
+
+final class CopyFormWidgetsToOtherLocale
+{
+    /** @var Locale */
+    public $toLocale;
+
+    /** @var Locale */
+    public $fromLocale;
+
+    /** @var array this is used to be able to convert the old ids to the new ones if used in other places */
+    public $extraIdMap;
+
+    public function __construct(Locale $toLocale, Locale $fromLocale = null)
+    {
+        if ($fromLocale === null) {
+            $fromLocale = Locale::workingLocale();
+        }
+
+        $this->toLocale = $toLocale;
+        $this->fromLocale = $fromLocale;
+        $this->extraIdMap = [];
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Command/CopyFormWidgetsToOtherLocaleHandler.php
+++ b/src/Backend/Modules/FormBuilder/Command/CopyFormWidgetsToOtherLocaleHandler.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Backend\Modules\FormBuilder\Command;
+
+use Backend\Core\Engine\Model as BackendModel;
+use Common\ModuleExtraType;
+use SpoonDatabase;
+
+final class CopyFormWidgetsToOtherLocaleHandler
+{
+    /** @var SpoonDatabase */
+    private $database;
+
+    public function __construct(SpoonDatabase $database)
+    {
+        $this->database = $database;
+    }
+
+    public function handle(CopyFormWidgetsToOtherLocale $command): void
+    {
+        $currentWidgets = (array) $this->database->getRecords(
+            'SELECT * FROM modules_extras WHERE module = ? AND type = ? AND action = ?',
+            [
+                'FormBuilder',
+                ModuleExtraType::widget(),
+                'Form'
+            ]
+        );
+
+        foreach ($currentWidgets as $currentWidget) {
+            $data = unserialize($currentWidget['data'], ['allowed_classes' => false]);
+
+            if (!is_array($data)
+                || !isset($data['language'])
+                || $data['language'] !== $command->fromLocale->getLocale()
+            ) {
+                // This is not a widget we want to duplicate
+                continue;
+            }
+
+            // Duplicate the existing form
+            $currentFormId = $data['id'];
+            $data['id'] = $this->duplicateForm($currentFormId, $command->toLocale->getLocale());
+
+            // Replace the language of our widget
+            $data['language'] = $command->toLocale->getLocale();
+            $data['edit_url'] = BackendModel::createUrlForAction('Edit', 'FormBuilder', $command->toLocale->getLocale()) . '&id=' . $data['id'];
+            $currentWidget['data'] = serialize($data);
+
+            // Save the old ID
+            $oldId = $currentWidget['id'];
+
+            // Unset the ID so we get a new one
+            unset($currentWidget['id']);
+
+            // Insert the new widget and save the id
+            $newId = $this->database->insert('modules_extras', $currentWidget);
+
+            // Map the new ID
+            $command->extraIdMap[$oldId] = $newId;
+        }
+    }
+
+    private function duplicateForm(int $formId, string $newLanguage): int
+    {
+        $currentForm = (array) $this->database->getRecord(
+            'SELECT * FROM forms WHERE id = ?',
+            [
+                $formId,
+            ]
+        );
+
+        unset($currentForm['id']);
+
+        $currentForm['language'] = $newLanguage;
+
+        $newId = $this->database->insert('forms', $currentForm);
+
+        $currentFormFields = (array) $this->database->getRecords(
+            'SELECT * FROM forms_fields WHERE form_id = ?',
+            [
+                $formId,
+            ]
+        );
+
+        foreach ($currentFormFields as $field) {
+            // Save the old field ID
+            $oldFieldId = $field['id'];
+
+            // Switch to the new form
+            $field['form_id'] = $newId;
+
+            // Unset the ID so we get a new one
+            unset($field['id']);
+
+            // Insert the new field
+            $newFieldId = $this->database->insert('forms_fields', $field);
+
+            $currentFieldValidations = (array) $this->database->getRecords(
+                'SELECT * FROM forms_fields_validation WHERE field_id = ?',
+                [
+                    $oldFieldId,
+                ]
+            );
+
+            foreach ($currentFieldValidations as $fieldValidations) {
+                $fieldValidations['field_id'] = $newFieldId;
+
+                // Unset the ID so we get a new one
+                unset($fieldValidations['id']);
+
+                // Insert the new field validation
+                $this->database->insert('forms_fields_validation', $fieldValidations);
+            }
+        }
+
+        return $newId;
+    }
+}

--- a/src/Backend/Modules/FormBuilder/Resources/config/commands.yml
+++ b/src/Backend/Modules/FormBuilder/Resources/config/commands.yml
@@ -1,0 +1,8 @@
+services:
+    form.handler.copy_widgets_to_other_locale:
+        class: Backend\Modules\FormBuilder\Command\CopyFormWidgetsToOtherLocaleHandler
+        public: true
+        arguments:
+            - "@database"
+        tags:
+            - { name: command_handler, handles: Backend\Modules\FormBuilder\Command\CopyFormWidgetsToOtherLocale }

--- a/src/Backend/Modules/FormBuilder/Resources/config/services.yml
+++ b/src/Backend/Modules/FormBuilder/Resources/config/services.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: commands.yml }
+
 services:
     formbuilder.submitted.mailer:
         class: Frontend\Modules\FormBuilder\EventListener\FormBuilderSubmittedMailSubscriber

--- a/src/Backend/Modules/Pages/Engine/Model.php
+++ b/src/Backend/Modules/Pages/Engine/Model.php
@@ -3,6 +3,7 @@
 namespace Backend\Modules\Pages\Engine;
 
 use Backend\Modules\ContentBlocks\Domain\ContentBlock\Command\CopyContentBlocksToOtherLocale;
+use Backend\Modules\FormBuilder\Command\CopyFormWidgetsToOtherLocale;
 use Backend\Modules\Location\Command\CopyLocationWidgetsToOtherLocale;
 use Common\Doctrine\Entity\Meta;
 use ForkCMS\Utility\Thumbnails;
@@ -117,6 +118,18 @@ class Model
 
             // define old block ids
             $locationWidgetOldIds = array_keys($locationWidgetIds);
+        }
+
+        $formWidgetOldIds = [];
+        $formWidgetIds = [];
+        if (BackendModel::isModuleInstalled('FormBuilder')) {
+            // copy form widgets and get copied widget ids
+            $copyFormWidgets = new CopyFormWidgetsToOtherLocale($toLocale, $fromLocale);
+            $commandBus->handle($copyFormWidgets);
+            $formWidgetIds = $copyFormWidgets->extraIdMap;
+
+            // define old block ids
+            $formWidgetOldIds = array_keys($formWidgetIds);
         }
 
         // get all old pages
@@ -257,8 +270,13 @@ class Model
                 }
 
                 // Overwrite the extra_id of the old location widget with the id of the new one
-                if ((count($locationWidgetOldIds) > 0) && in_array($block['extra_id'], $locationWidgetOldIds, true)) {
+                if ((count($locationWidgetOldIds) > 0) && in_array((int) $block['extra_id'], $locationWidgetOldIds, true)) {
                     $block['extra_id'] = $locationWidgetIds[$block['extra_id']];
+                }
+
+                // Overwrite the extra_id of the old form widget with the id of the new one
+                if ((count($formWidgetOldIds) > 0) && in_array((int) $block['extra_id'], $formWidgetOldIds, true)) {
+                    $block['extra_id'] = $formWidgetIds[(int) $block['extra_id']];
                 }
 
                 // add block


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

/

## Pull request description

When making a copy of a language using the hidden Pages copy action, forms would not be duplicated for the new language, and the content blocks on the new pages would still refer to the old form (in the source language). This results in a lot of weird behaviour if you started editing these forms and moving the widgets.

This PR properly duplicates each form (and its fields + validations) found on an active page, updates the language of that form to the new locale and then adds a new content block with the new ID.