### PR TITLE
WIP: 405 page add block modal

### DIFF
--- a/src/Backend/Modules/Pages/Js/Components/Extra.js
+++ b/src/Backend/Modules/Pages/Js/Components/Extra.js
@@ -74,7 +74,6 @@ export class Extra {
         const element = document.querySelector('#' + editorId)
 
         element.value = originalContent
-        console.log(element.value)
 
         const text = this.getBlockPreview($.makeArray($modal.find('.ce-block [contenteditable]')))
         if (text !== '') {

--- a/src/Backend/Modules/Pages/Js/Components/Extra.js
+++ b/src/Backend/Modules/Pages/Js/Components/Extra.js
@@ -2,6 +2,7 @@ export class Extra {
   constructor () {
     this.blockTypeSwitcher()
     this.saveBlock()
+    this.cancelBlock()
     this.newBlock()
 
     // bind events
@@ -51,6 +52,37 @@ export class Extra {
       } else {
         $pageBlockPreview.addClass('d-none')
       }
+
+      $modal.modal('hide')
+    })
+  }
+
+  cancelBlock () {
+    $('[data-role="page-content-tab"]').on('click', '[data-role="page-block-cancel"]', (e) => {
+      const $modal = $(e.currentTarget).closest('.modal')
+      const originalContentField = $modal.find('[data-role="rich-text-original-content"]')
+      const $pageBlockWrapper = $modal.closest('[data-role="page-block-wrapper"]')
+      const $pageBlockPreview = $pageBlockWrapper.find('[data-role="page-block-preview"]')
+
+      // Read the original content from the hidden field
+      const originalContent = originalContentField.val()
+
+      // Save the original content again
+      const editors = document.querySelectorAll('textarea.inputBlockEditor')
+      editors.forEach((editor) => {
+        const editorId = editor.id + '-block-editor'
+        const element = document.querySelector('#' + editorId)
+
+        element.value = originalContent
+        console.log(element.value)
+
+        const text = this.getBlockPreview($.makeArray($modal.find('.ce-block [contenteditable]')))
+        if (text !== '') {
+          $pageBlockPreview.html(text)
+        } else {
+          $pageBlockPreview.html(window.backend.locale.lbl('NoContentToShow'))
+        }
+      });
 
       $modal.modal('hide')
     })

--- a/src/Backend/Modules/Pages/Resources/views/FormLayout.html.twig
+++ b/src/Backend/Modules/Pages/Resources/views/FormLayout.html.twig
@@ -330,10 +330,12 @@
             <div data-role="page-block-content-type-wrapper" data-type="widget">{{ form_row(form.widgetExtraId) }}</div>
             <div data-role="page-block-content-type-wrapper" data-type="block">{{ form_row(form.blockExtraId) }}</div>
             <div data-role="page-block-content-type-wrapper" data-type="rich_text">{{ form_row(form.html) }}</div>
+            <input type="hidden" data-role="rich-text-original-content" value="{{ form.html.vars.value }}" />
             {{ form_rest(form) }}
           </div>
           <div class="modal-footer d-flex">
             <div class="me-auto">{{ macro.alert('warning', 'msg.ContentSaveWarning'|trans|ucfirst) }}</div>
+            {{ macro.buttonIcon('', 'cancel', 'lbl.Cancel'|trans|ucfirst, 'btn-secondary', {'type': 'button', 'data-role':'page-block-cancel'}) }}
             {{ macro.buttonIcon('', 'save', 'lbl.Save'|trans|ucfirst, 'btn-default', {'type': 'button', 'data-role':'page-block-save'}) }}
           </div>
         </div>


### PR DESCRIPTION
## Type

- Enhancement

## Resolves the following issues

/

## Pull request description

This PR is an attempt to solve https://github.com/forkcms/forkcms/issues/3235, but isn't done. I've moved the original JSON content into a hidden field and made an attempt to move it back into the editor textarea's value property when a cancel button is clicked (as discussed in the last comment of the linked issue) but this doesn't seem to work. I figured I have to either reload the EditorJS instance to parse the old content I've put back, or somehow revert the AJAX call that is made by? Maybe @carakas could take a look and see where we go from here?
