### PR TITLE
SpoonLibrary expects the charset to be in lowercase, otherwise some xss protections fail

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -80,7 +80,7 @@ abstract class Kernel extends BaseKernel
         Spoon::setDebug($container->getParameter('kernel.debug'));
         Spoon::setDebugEmail($container->getParameter('fork.debug_email'));
         Spoon::setDebugMessage($container->getParameter('fork.debug_message'));
-        Spoon::setCharset($container->getParameter('kernel.charset'));
+        Spoon::setCharset(strtolower($container->getParameter('kernel.charset')));
 
         /**
          * @deprecated SPOON_* constants are deprecated in favour of Spoon::set*().


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Security

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->
Spoon library doesn't encode some things well when the charset isn't utf-8 but UTF-8. This causes some xss issues
