### PR TITLE
Update the placeholder image URLs

### DIFF
--- a/docs/03. user guide/03. pages.md
+++ b/docs/03. user guide/03. pages.md
@@ -102,12 +102,12 @@ currently supported:
 `[path_to_theme]/Core/Layout/Templates/UserTemplates/test.html`
 
     <a data-ft-label="link" data-ft-type="link" href="#">This is the placeholder for the link</a>
-    <a href="#" data-ft-label="image link" data-ft-type="link-without-content"><img class="media-object" src="https://placehold.it/200x200" alt="placeholder" data-ft-label="Image" data-ft-type="image" data-ft-block-optional="true"></a>
+    <a href="#" data-ft-label="image link" data-ft-type="link-without-content"><img class="media-object" src="https://via.placeholder.com/200x200" alt="placeholder" data-ft-label="Image" data-ft-type="image" data-ft-block-optional="true"></a>
     <h2 data-ft-label="Title voor dit blokje" data-ft-type="text">Dit is een titel</h2>
     <p data-ft-label="beschrijving" data-ft-type="textarea">Dit is de beschrijving</p>
     <div data-ft-label="editor" data-ft-type="editor">Dit is de editor</div>
-    <img src="https://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
-    <div class="image-holder" data-src="https://placehold.it/200x200" data-ft-label="Background image" data-ft-type="image-background" data-ft-block-optional="true" style="background-image: url('https://placehold.it/200x200');"></div>
+    <img src="https://via.placeholder.com/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
+    <div class="image-holder" data-src="https://via.placeholder.com/200x200" data-ft-label="Background image" data-ft-type="image-background" data-ft-block-optional="true" style="background-image: url('https://via.placeholder.com/200x200');"></div>
     <div id="placeholder" data-ft-label="id" data-ft-type="anchor"></div>
 
     

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/quote.html
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/quote.html
@@ -1,7 +1,7 @@
 <blockquote>
   <div class="row">
     <div class="col-sm-2">
-      <img src="https://placehold.it/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
+      <img src="https://via.placeholder.com/128x128" alt="Placeholder" class="img-responsive img-circle" data-ft-label="Avatar" data-ft-type="image" />
     </div>
     <div class="col-sm-10">
       <p data-ft-type="textarea" data-ft-label="Quote text">The only way to do great work is to love what you do</p>

--- a/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/test.html
+++ b/src/Frontend/Themes/Fork/Core/Layout/Templates/UserTemplates/test.html
@@ -1,6 +1,6 @@
 <a data-ft-label="link" data-ft-type="link" href="#">This is the placeholder for the link</a>
 <h2 data-ft-label="title for this block" data-ft-type="text">This is a title</h2>
-<a href="#" data-ft-label="image link" data-ft-type="link-without-content"><img class="media-object" src="https://placehold.it/200x200" alt="placeholder" data-ft-label="Image" data-ft-type="image" data-ft-block-optional="true"></a>
+<a href="#" data-ft-label="image link" data-ft-type="link-without-content"><img class="media-object" src="https://via.placeholder.com/200x200" alt="placeholder" data-ft-label="Image" data-ft-type="image" data-ft-block-optional="true"></a>
 <p data-ft-label="description" data-ft-type="textarea">This is a description</p>
 <div data-ft-label="editor" data-ft-type="editor">This is an editor</div>
-<div class="image-holder" data-src="https://placehold.it/200x200" data-ft-label="Background image" data-ft-type="image-background" style="background-image: url('https://placehold.it/200x200');"></div>
+<div class="image-holder" data-src="https://via.placeholder.com/200x200" data-ft-label="Background image" data-ft-type="image-background" style="background-image: url('https://via.placeholder.com/200x200');"></div>


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description

Updated the URLs for placeholder images in user templates.
The https certificate for placehold.it has expired resulting in the images failing to load: `Failed to load resource: net::ERR_CERT_DATE_INVALID`.
The new URL is via.placeholder.com.