### PR TITLE
Only run tests once on PR

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: run-tests
 on:
     push:
         branches:
-            - main
+            - master
     pull_request: ~
     workflow_dispatch: ~
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,11 @@
 name: run-tests
 
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - main
+    pull_request: ~
+    workflow_dispatch: ~
 
 jobs:
     phpunit:


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->
- Enhancement

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

When a PR is submitted, or changes are pushed to a branch, you see that tests are running twice: one for `push` and one for `pull_request`, for a whopping total of 37 tests on a single PR. See a random screenshot from current PR's:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/1352979/135764369-dd0e0401-6bdb-4c8f-b375-6b4010d64e9d.png">


I checked how API Platform is doing their CI, https://github.com/api-platform/api-platform/blob/main/.github/workflows/ci.yml#L3-L8 and that seems to be a better way. It's running only one time (for `pull request`) and also still allows push to master (if we ever do that)

You'll see on this PR that there's only one series of tests (pull request event)