### PR TITLE
Translation issue in template

### DIFF
--- a/src/Backend/Modules/Blog/Layout/Templates/ImportWordpress.html.twig
+++ b/src/Backend/Modules/Blog/Layout/Templates/ImportWordpress.html.twig
@@ -23,7 +23,7 @@
       </div>
       <div class="form-group">
         <label for="filter" class="control-label">{{ 'lbl.WordpressFilter'|trans|ucfirst }}</label>
-        <p class="help-block">{{ 'msg.HelpWordpressFilter'|ucfirst }}</p>
+        <p class="help-block">{{ 'msg.HelpWordpressFilter'|trans|ucfirst }}</p>
         {% form_field filter %} {% form_field_error filter %}
       </div>
     </div>


### PR DESCRIPTION
The message "HelpWordpressFilter" was missing the "trans" modifier.

## Type

- Non critical bugfix

## Pull request description

Added "trans" modifier for the message "HelpWordpressFilter".