### PR TITLE
Reauthenticate when a user password is changed

### DIFF
--- a/src/Backend/Core/Engine/Authentication.php
+++ b/src/Backend/Core/Engine/Authentication.php
@@ -436,4 +436,9 @@ class Authentication
         self::$allowedModules = [];
         self::$user = null;
     }
+
+    public static function clearUserSessionsForId(int $userId): void
+    {
+        BackendModel::get('database')->delete('users_sessions', 'user_id = ?', $userId);
+    }
 }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Security

## Pull request description

At the moment we don't require a user with an active session whose password has changed to authenticate, this can allow hackers that are already logged in to stay logged in even after the password has changed for as long as their session is valid