### PR TITLE
Make the old session clean-up method timezone aware

### DIFF
--- a/src/Backend/Core/Engine/Authentication.php
+++ b/src/Backend/Core/Engine/Authentication.php
@@ -58,8 +58,8 @@ class Authentication
      */
     public static function cleanupOldSessions(): void
     {
-        // remove all sessions that are invalid (older then 30 min)
-        BackendModel::get('database')->delete('users_sessions', 'date <= DATE_SUB(NOW(), INTERVAL 30 MINUTE)');
+        $deleteIfOlderThan = (new DateTime('- 30 minutes', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+        BackendModel::get('database')->delete('users_sessions', 'date <= ?', [$deleteIfOlderThan]);
     }
 
     /**


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

/

## Pull request description

This fixes a bug where the database timezone would be different from
UTC, and the date inserted into the database would be incorrectly removed
by the NOW() check.
