### PR TITLE
Fix redirecting in parseWidget

### DIFF
--- a/src/Frontend/Core/Engine/TemplateModifiers.php
+++ b/src/Frontend/Core/Engine/TemplateModifiers.php
@@ -392,7 +392,7 @@ class TemplateModifiers extends BaseTwigModifiers
 
             return (string) $content;
         } catch (RedirectException $redirectException) {
-            throw new \Twig_Error('redirect fix from template modifier', null, null, $redirectException);
+            throw new \Twig_Error('redirect fix from template modifier', -1, null, $redirectException);
         } catch (Exception $e) {
             // if we are debugging, we want to see the exception
             if (FrontendModel::getContainer()->getParameter('kernel.debug')) {


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

/

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

This fixes the following error that occurs when submitting a form that's added via `parseWidget`:
**Type error: Argument 2 passed to Twig\Error\Error::__construct() must be of the type int, null given**

Set `lineno` to the default value `-1` (to enable its automatic guessing)
