### PR TITLE
Make function recursiveHtmlspecialchars work with PHP8

### DIFF
--- a/src/Common/Core/Model.php
+++ b/src/Common/Core/Model.php
@@ -351,10 +351,7 @@ class Model extends BaseModel
     {
         array_walk_recursive(
             $data,
-            static function (&$key, &$value) {
-                if (is_string($key)) {
-                    $key = htmlspecialchars($key);
-                }
+            static function (&$value, $key) {
                 if (is_string($value)) {
                     $value = htmlspecialchars($value);
                 }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description
The code suggests that the key of an array will be corrected if there are htmlspecialchars, but it isn't.
This also works with PHP8.1
