### PR TITLE
Update robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,5 +2,5 @@ User-agent: *
 Disallow: /api
 Disallow: /backend/ajax
 Disallow: /backend/cronjob
-Disallow: /install
+Disallow: /install/
 Disallow: /frontend/ajax


### PR DESCRIPTION
## Type
- Non critical bugfix

## Pull request description
When you have an url that starts with "install" then it will be blocked. The urls for the installer are with a slash anyway (like "/install/2")
