### PR TITLE
Skip empty images while copying a page

### DIFF
--- a/src/Backend/Modules/Pages/Actions/Add.php
+++ b/src/Backend/Modules/Pages/Actions/Add.php
@@ -766,6 +766,12 @@ class Add extends BackendBaseActionAdd
                 $url = FRONTEND_FILES_URL . '/Pages/UserTemplate';
                 foreach ($images as $image) {
                     $imagePath = $image->getAttribute('src');
+
+                    // skip empty images
+                    if ($imagePath === '') {
+                        continue;
+                    }
+
                     $basename = pathinfo($imagePath, PATHINFO_FILENAME);
                     $extension = pathinfo($imagePath, PATHINFO_EXTENSION);
                     $originalFilename = $basename . '.' . $extension;


### PR DESCRIPTION
## Type

- Non critical bugfix

## Pull request description

Images with an empty src attribute need to be skipped as there is no image. Before this fix an exception was triggered as it was trying to copy the full directory.
