### PR TITLE
invoke symfony console clear:cache commands

### DIFF
--- a/src/Core/Domain/Kernel/Command/ClearContainerHandler.php
+++ b/src/Core/Domain/Kernel/Command/ClearContainerHandler.php
@@ -2,18 +2,35 @@
 
 namespace ForkCMS\Core\Domain\Kernel\Command;
 
-use ForkCMS\Core\Domain\Kernel\Kernel;
 use ForkCMS\Core\Domain\MessageHandler\CommandHandlerInterface;
+use ForkCMS\Core\Domain\Kernel\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 final class ClearContainerHandler implements CommandHandlerInterface
 {
-    public function __construct(private Kernel $kernel)
-    {
+    public function __construct(
+        private Kernel $kernel,
+        private KernelInterface $symfonyKernel
+    ) {
     }
 
     public function __invoke(ClearContainerCache $clearContainerCache): void
     {
+        $application = new Application($this->symfonyKernel);
+        $application->setAutoExit(false);
+
+        $command = $application->find('cache:clear');
+        $command->run(new ArrayInput([]), new NullOutput());
+
+        $command = $application->find('cache:pool:clear');
+        $command->run(new ArrayInput([
+            'pools' => ['cache.global_clearer']
+        ]), new NullOutput());
+
         $fileSystem = new Filesystem();
         $containerCachePath = $this->kernel->getCacheDir() . '/' . $this->kernel->getContainerClass() . '.php';
 


### PR DESCRIPTION
## Type

- Non critical bugfix

## Resolves the following issues

When installing a new Module it doesn't show up in the Navigation sidebar right away unless you clear the cache in the console.

## Pull request description

Added cache:clear and cache:pool:clear commands to the ClearContainerHandler (for some reason cache:clear in the console is enough, but not programmatically). If this belongs somewhere else please let me know.