### PR TITLE
Fix movie id validation

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Ajax/MediaItemAddMovie.php
+++ b/src/Backend/Modules/MediaLibrary/Ajax/MediaItemAddMovie.php
@@ -65,7 +65,7 @@ class MediaItemAddMovie extends BackendBaseAJAXAction
         }
 
         // Make sure the movie id is valid
-        if (!preg_match('/^[a-zA-Z]+[a-zA-Z0-9._]+$/', (string) $movieId)) {
+        if (!preg_match('/^[a-zA-Z0-9._-]+$/', (string) $movieId)) {
             throw new AjaxExitException(Language::err('InvalidValue'));
         }
 


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

The movie id validation was preventing actual video ids from being uploaded.
Made it less strict to allow these examples that were previously failing:

- YouTube 
   - id starting with an underscore
      - https://www.youtube.com/watch?v=_5196kRXWF0
   - id containing '-'
      - https://www.youtube.com/watch?v=1nyyLhoj-bc
- Vimeo
   - Vimeo id is just an integer (so didn't work with the requirement of starting with a-Z)
      - https://vimeo.com/451626607

