### PR TITLE
Update css-to-inline-styles implementation

### DIFF
--- a/src/Common/Mailer/Message.php
+++ b/src/Common/Mailer/Message.php
@@ -172,10 +172,10 @@ class Message extends \Swift_Message
     private function cssToInlineStyles(string $html): string
     {
         $cssToInlineStyles = new CssToInlineStyles();
-        $cssToInlineStyles->setHTML($html);
-        $cssToInlineStyles->setUseInlineStylesBlock(true);
 
-        return (string) $cssToInlineStyles->convert();
+        return (string) $cssToInlineStyles->convert(
+            $html
+        );
     }
 
     /**


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

By updating to symfony 4.4, the [css-to-inline-styles](https://github.com/tijsverkoyen/CssToInlineStyles/tree/master) package was updated to ^2.0 which requires a different implementation to convert the HTML.
This will fix the emails that are currently failing to be sent.
