### PR TITLE
Fix ajax live search results - removed Theme::getPath function

### DIFF
--- a/src/Frontend/Modules/Search/Ajax/Livesuggest.php
+++ b/src/Frontend/Modules/Search/Ajax/Livesuggest.php
@@ -65,7 +65,7 @@ class Livesuggest extends FrontendBaseAJAXAction
         $this->output(
             Response::HTTP_OK,
             $this->template->render(
-                Theme::getPath(FRONTEND_MODULES_PATH . '/Search/Layout/Templates/Results.html.twig'),
+                '/Search/Layout/Templates/Results.html.twig',
                 $this->template->getAssignedVariables()
             )
         );


### PR DESCRIPTION
## Type

- Critical bugfix #3575 

## Resolves the following issues

Removed the Theme::getPath function. 
This function does not seem to be necessary anymore, by directly calling the path of the template the ajax results work again.

## Pull request description

Removed the Theme::getPath function. 
