### PR TITLE
Fix uploading type getting stuck on 'movie'

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
+++ b/src/Backend/Modules/MediaLibrary/Js/MediaLibraryHelper.js
@@ -1416,7 +1416,7 @@ jsBackend.mediaLibraryHelper.upload = {
     // movies not allowed
     if (!moviesAllowed) {
       // select first item (which is all, so we can upload regular media)
-      $uploadingType.find(':first-child').attr('checked', 'checked')
+      $uploadingType.eq(0).attr('checked', 'checked')
     } else {
       if (groupType === 'movie') {
         // select first item (which is all, so we can upload regular media)


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

When a module contains two media groups, one for images and another one for movies, the media dialog would get stuck on the movie type after having opened the movie dialog. 

This prevented images from being added to the other media group after the movie dialog was opened once, since the fields for adding a movie were incorrectly being shown.
