### PR TITLE
Formbuilder fixes

### DIFF
--- a/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
+++ b/src/Backend/Modules/FormBuilder/Ajax/SaveField.php
@@ -45,7 +45,7 @@ class SaveField extends BackendBaseAJAXAction
         $values = trim($this->getRequest()->request->get('values', ''));
 
         // this is somewhat a nasty hack, but it makes special chars work.
-        $values = \SpoonFilter::htmlspecialcharsDecode($values);
+        $values = html_entity_decode($values);
 
         $defaultValues = trim($this->getRequest()->request->get('default_values', ''));
         $placeholder = trim($this->getRequest()->request->get('placeholder', ''));
@@ -231,10 +231,10 @@ class SaveField extends BackendBaseAJAXAction
         // htmlspecialchars except for paragraphs
         if ($type !== 'paragraph') {
             if ($values !== '') {
-                $values = \SpoonFilter::htmlspecialchars($values);
+                $values = htmlentities($values);
             }
             if ($defaultValues !== '') {
-                $defaultValues = \SpoonFilter::htmlspecialchars($defaultValues);
+                $defaultValues = htmlentities($defaultValues);
             }
         }
 

--- a/src/Backend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Backend/Modules/FormBuilder/Engine/Model.php
@@ -285,17 +285,21 @@ class Model
      *
      * @param string $string The serialized string that should be formatted
      *
-     * @return string
+     * @return string|null
      */
-    public static function formatRecipients(string $string): string
+    public static function formatRecipients(string $string): ?string
     {
-        return implode(
-            ', ',
-            (array) array_map(
-                'htmlspecialchars',
-                @unserialize($string, ['allowed_classes' => false])
-            )
-        );
+        if ($string) {
+            return implode(
+                ', ',
+                (array)array_map(
+                    'htmlspecialchars',
+                    @unserialize($string, ['allowed_classes' => false])
+                )
+            );
+        }
+
+        return null;
     }
 
     /**

--- a/src/Frontend/Modules/FormBuilder/Engine/Model.php
+++ b/src/Frontend/Modules/FormBuilder/Engine/Model.php
@@ -65,6 +65,18 @@ class Model
                 $field['settings'] = unserialize($field['settings'], ['allowed_classes' => false]);
             }
 
+            if (isset($field['settings']['values'])) {
+                if (is_array($field['settings']['values'])) {
+                    $field['settings']['values'] = array_map('html_entity_decode', $field['settings']['values']);
+                } else {
+                    $field['settings']['values'] = html_entity_decode($field['settings']['values']);
+                }
+            }
+
+            if (isset($field['settings']['default_values'])) {
+                $field['settings']['default_values'] = html_entity_decode($field['settings']['default_values']);
+            }
+
             // init validations
             $field['validations'] = [];
         }


### PR DESCRIPTION
## Type

<!-- Remove the types that don't apply -->
<!-- If you discover any security-related issues, please email core@fork-cms.com instead of using the issue tracker. -->

- Non critical bugfix

## Resolves the following issues

<!-- List the hashes of the issues that this pull request resolves if there are issues for it. -->
<!-- Use the following format: fixes #[issue_number] -->

#3193 

## Pull request description

<!-- Provide a summary of the pull request you are submitting. -->

When saving a field that contains field option(s) with special characters (for example a checkbox with the value: "J'accepte conformément à la clause de non-responsabilité") an AJAX error was thrown.
Encoding all characters of the values in the SaveField action fixes this issue.

But it still made the form fail validation as described in the linked issue, so I decoded the values before rendering the form to fix validation.

_Not sure if this is the best way to fix this issue?
I only applied this to values & default values for now to fix functional errors, other form fields (placeholders, error messages, ...) also require a fix since for example adding the same value as placeholder shows a string with encoded characters._

Secondly I added a check to the formatRecipients function which was trying to run when no recipients are provided (when having selected the database method).
